### PR TITLE
Fix the rotation animation on the thumbnails and object.

### DIFF
--- a/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/ViewerScript.java
+++ b/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/ViewerScript.java
@@ -597,14 +597,14 @@ public class ViewerScript extends GVRScript {
         // THUMBNAIL_ROT += -1.0f;
         // if( THUMBNAIL_ROT > 360.0f ) THUMBNAIL_ROT = THUMBNAIL_ROT - 360.0f;
         // }
-        THUMBNAIL_ROT += -1.0f;
+        THUMBNAIL_ROT = -1.0f;
         for (int i = 0; i < THUMBNAIL_NUM; i++)
             ThumbnailRotation[i].getTransform().rotateByAxis(THUMBNAIL_ROT,
                     0.0f, 1.0f, 0.0f);
 
         // ---------------------------------------object motion
 
-        OBJECT_ROT += -1.0f;
+        OBJECT_ROT = -1.0f;
         for (int i = 0; i < THUMBNAIL_NUM; i++)
             Objects[i].getTransform()
                     .rotateByAxis(OBJECT_ROT, 0.0f, 1.0f, 0.0f);


### PR DESCRIPTION
Original had +=1 which was incrementing the angle on each frame.  Ended
    up being crazy.  Just needs to be =1 for the animation to look proper.
    Oh, and slowed down the thumbnail animation so one can see the thumbnail
    long enough before clicking on it.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn 
flynnt@acm.org