### PR TITLE
Remove three warnings.

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRActivity.java
@@ -19,7 +19,6 @@ import org.gearvrf.utility.Log;
 
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
-import android.opengl.GLSurfaceView;
 import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.Window;

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/GVRCompressedTextureLoader.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/GVRCompressedTextureLoader.java
@@ -21,8 +21,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.gearvrf.GVRAndroidResource;
-
 import android.opengl.GLES20;
 
 /**

--- a/GVRf/Framework/src/org/gearvrf/debug/GVRConsole.java
+++ b/GVRf/Framework/src/org/gearvrf/debug/GVRConsole.java
@@ -18,18 +18,8 @@ package org.gearvrf.debug;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.gearvrf.GVRBitmapTexture;
-import org.gearvrf.GVRCamera;
-import org.gearvrf.GVRCameraRig;
-import org.gearvrf.GVRContext;
-import org.gearvrf.GVRCustomPostEffectShaderId;
-import org.gearvrf.GVRPostEffect;
-import org.gearvrf.GVRPostEffectMap;
-import org.gearvrf.GVRPostEffectShaderId;
-import org.gearvrf.GVRPostEffectShaderManager;
-import org.gearvrf.debug.GVRConsole.EyeMode;
+import org.gearvrf.*;
 
-import org.gearvrf.R;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
 import android.graphics.Canvas;


### PR DESCRIPTION
GVRf/Framework/src branch is once again free of warnings.

This checkin was based on the GitHub distribution, not
cherry-picked from our internal Gerrit server.