### PR TITLE
Add a new, high-level eye picking API.

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRPicker.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRPicker.java
@@ -13,8 +13,11 @@
  * limitations under the License.
  */
 
-
 package org.gearvrf;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Finds the scene objects you are pointing to.
@@ -47,6 +50,28 @@ public class GVRPicker {
      * user's head and pointing into the scene along the camera lookat vector,
      * pass in 0, 0, 0 for the origin and 0, 0, -1 for the direction.
      * 
+     * <p>
+     * <em>Note:</em> The {@linkplain GVREyePointeeHolder#getHit() hit location}
+     * is stored in the native eye pointee holder during the ray casting
+     * operation: <em>It is only valid until the next ray cast operation.</em>
+     * That is, either the {@linkplain #pickScene(GVRScene) short pickScene()},
+     * or the
+     * {@linkplain #pickScene(GVRScene, float, float, float, float, float, float)
+     * long pickScene()}, or
+     * {@linkplain #findObjects(GVRScene, float, float, float, float, float, float)
+     * findObjects()} calls will invalidate previous hit data. There are two
+     * ways to avoid getting invalid hit data:
+     * <ul>
+     * <li>Use the high-level
+     * {@linkplain #findObjects(GVRScene, float, float, float, float, float, float)
+     * findObjects()} method, which returns a list of {@link GVRPickedObject}:
+     * each picked object pairs a {@link GVRSceneObject} with the hit data.
+     * <li>Write your code so that you never call ray casting operation until
+     * you have retrieved the previous operations hit data. (This is easy, if
+     * you only ever do picking from the GL thread. It's significantly harder if
+     * you are using multiple threads.)
+     * </ul>
+     * 
      * @param scene
      *            The {@link GVRScene} with all the objects to be tested.
      * 
@@ -76,19 +101,44 @@ public class GVRPicker {
      */
     public static final GVREyePointeeHolder[] pickScene(GVRScene scene,
             float ox, float oy, float oz, float dx, float dy, float dz) {
-        long[] ptrs = NativePicker.pickScene(scene.getPtr(), ox, oy, oz, dx,
-                dy, dz);
-        GVREyePointeeHolder[] eyePointeeHolders = new GVREyePointeeHolder[ptrs.length];
-        for (int i = 0; i < ptrs.length; ++i) {
-            eyePointeeHolders[i] = GVREyePointeeHolder.factory(
-                    scene.getGVRContext(), ptrs[i]);
+        synchronized (scene) {
+            long[] ptrs = NativePicker.pickScene(scene.getPtr(), ox, oy, oz,
+                    dx, dy, dz);
+            GVREyePointeeHolder[] eyePointeeHolders = new GVREyePointeeHolder[ptrs.length];
+            GVRContext gvrContext = scene.getGVRContext();
+            for (int i = 0, length = ptrs.length; i < length; ++i) {
+                eyePointeeHolders[i] = GVREyePointeeHolder.factory(gvrContext,
+                        ptrs[i]);
+            }
+            return eyePointeeHolders;
         }
-        return eyePointeeHolders;
     }
 
     /**
      * Tests the {@link GVRSceneObject}s contained within scene against the
      * camera rig's lookat vector.
+     * 
+     * <p>
+     * <em>Note:</em> The {@linkplain GVREyePointeeHolder#getHit() hit location}
+     * is stored in the native eye pointee holder during the ray casting
+     * operation: <em>It is only valid until the next ray cast operation.</em>
+     * That is, either the {@linkplain #pickScene(GVRScene) short pickScene()},
+     * or the
+     * {@linkplain #pickScene(GVRScene, float, float, float, float, float, float)
+     * long pickScene()}, or
+     * {@linkplain #findObjects(GVRScene, float, float, float, float, float, float)
+     * findObjects()} calls will invalidate previous hit data. There are two
+     * ways to avoid getting invalid hit data:
+     * <ul>
+     * <li>Use the high-level
+     * {@linkplain #findObjects(GVRScene, float, float, float, float, float, float)
+     * findObjects()} method, which returns a list of {@link GVRPickedObject}:
+     * each picked object pairs a {@link GVRSceneObject} with the hit data.
+     * <li>Write your code so that you never call ray casting operation until
+     * you have retrieved the previous operations hit data. (This is easy, if
+     * you only ever do picking from the GL thread. It's significantly harder if
+     * you are using multiple threads.)
+     * </ul>
      * 
      * @param scene
      *            The {@link GVRScene} with all the objects to be tested.
@@ -119,6 +169,134 @@ public class GVRPicker {
             GVRCameraRig cameraRig) {
         return NativePicker.pickSceneObject(sceneObject.getPtr(),
                 cameraRig.getPtr());
+    }
+
+    /**
+     * Casts a ray into the scene graph, and returns the objects it intersects.
+     * 
+     * The ray is defined by its origin {@code [ox, oy, oz]} and its direction
+     * {@code [dx, dy, dz]}.
+     * 
+     * <p>
+     * The ray origin may be [0, 0, 0] and the direction components should be
+     * normalized from -1 to 1: Note that the y direction runs from -1 at the
+     * bottom to 1 at the top. To construct a picking ray originating at the
+     * user's head and pointing into the scene along the camera lookat vector,
+     * pass in 0, 0, 0 for the origin and 0, 0, -1 for the direction.
+     * 
+     * <p>
+     * This method is higher-level and easier to use than
+     * {@link #pickScene(GVRScene, float, float, float, float, float, float)
+     * pickScene():} Not only does it return the hit scene object (not its
+     * holder) and the hit location directly, it is thread safe in a way that
+     * the lower-level methods are not: The
+     * {@linkplain GVREyePointeeHolder#getHit() hit location} is stored in the
+     * native eye pointee holder during the ray casting operation and it is only
+     * valid until the next ray cast operation. This method guarantees that only
+     * one thread at a time is doing a ray cast into a particular scene graph,
+     * and it extracts the hit data during within its synchronized block. You
+     * can then examine the return list without worrying about another thread
+     * corrupting your hit data.
+     * 
+     * @param scene
+     *            The {@link GVRScene} with all the objects to be tested.
+     * 
+     * @param ox
+     *            The x coordinate of the ray origin.
+     * 
+     * @param oy
+     *            The y coordinate of the ray origin.
+     * 
+     * @param oz
+     *            The z coordinate of the ray origin.
+     * 
+     * @param dx
+     *            The x vector of the ray direction.
+     * 
+     * @param dy
+     *            The y vector of the ray direction.
+     * 
+     * @param dz
+     *            The z vector of the ray direction.
+     * @return A list of {@link GVRPickedObject}, sorted by distance from the
+     *         camera rig. Each {@link GVRPickedObject} contains the object
+     *         within the {@link GVREyePointeeHolder} along with the hit
+     *         location. (Note that the hit location is actually the point where
+     *         the cast ray intersected the holder's axis-aligned bounding box,
+     *         which may not be exactly where the ray would intersect the scene
+     *         object itself.)
+     * 
+     * @since 1.6.6
+     */
+    public static final List<GVRPickedObject> findObjects(GVRScene scene,
+            float ox, float oy, float oz, float dx, float dy, float dz) {
+        synchronized (scene) {
+            GVRContext gvrContext = scene.getGVRContext();
+
+            long[] pointers = NativePicker.pickScene(scene.getPtr(), ox, oy,
+                    oz, dx, dy, dz);
+            List<GVRPickedObject> result = new ArrayList<GVRPickedObject>(
+                    pointers.length);
+            for (long pointer : pointers) {
+                GVREyePointeeHolder holder = GVREyePointeeHolder.factory(
+                        gvrContext, pointer);
+                result.add(new GVRPickedObject(holder));
+            }
+            return result;
+        }
+    }
+
+    /**
+     * The result of a
+     * {@link GVRPicker#findObjects(GVRScene, float, float, float, float, float, float)
+     * findObjects()} call.
+     * 
+     * @since 1.6.6
+     */
+    public static class GVRPickedObject {
+        private final GVRSceneObject sceneObject;
+        private final float[] hitLocation;
+
+        private GVRPickedObject(GVREyePointeeHolder holder) {
+            sceneObject = holder.getOwnerObject();
+            hitLocation = holder.getHit();
+        }
+
+        /**
+         * The {@link GVRSceneObject} within the eye pointee holder's bounding
+         * box - the object that the ray intersected.
+         * 
+         * @return {@link GVREyePointeeHolder#getOwnerObject()}
+         */
+        public GVRSceneObject getHitObject() {
+            return sceneObject;
+        }
+
+        /**
+         * The hit location, as an [x, y, z] array.
+         * 
+         * @return A copy of the {@link GVREyePointeeHolder#getHit()} result:
+         *         changing the result will not change the
+         *         {@link GVRPickedObject picked object's} hit data.
+         */
+        public float[] getHitLocation() {
+            return Arrays.copyOf(hitLocation, hitLocation.length);
+        }
+
+        /** The x coordinate of the hit location */
+        public float getHitX() {
+            return hitLocation[0];
+        }
+
+        /** The x coordinate of the hit location */
+        public float getHitY() {
+            return hitLocation[1];
+        }
+
+        /** The x coordinate of the hit location */
+        public float getHitZ() {
+            return hitLocation[2];
+        }
     }
 }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRVersion.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRVersion.java
@@ -45,5 +45,12 @@ public class GVRVersion {
      */
     public static final String V_1_6_5 = "1.6.5";
 
-    public static final String CURRENT = V_1_6_5;
+    /**
+     * Add high-level
+     * {@link GVRPicker#findObjects(GVRScene, float, float, float, float, float, float)}
+     * method.
+     */
+    public static final String V_1_6_6 = "1.6.6";
+
+    public static final String CURRENT = V_1_6_6;
 }


### PR DESCRIPTION
Eye picking saves the hit location in the eye pointee holder:
the hit location is only valid until the next eye pick
operation. This means that the existing APIs are both complex
and NOT THREAD-SAFE.

The new GVRPicker.findObjects() API is easier to use AND
thread-safe.

GearVRf-DCO-1.0-Signed-off-by: Jon Shemitz
j.shemitz@samsung.com