### PR TITLE
Introduce class Preconditions and restructure some parameter checks in G...

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -15,6 +15,9 @@
 
 package org.gearvrf;
 
+import static org.gearvrf.utility.Preconditions.checkStringNotNullOrEmpty;
+import static org.gearvrf.utility.Preconditions.checkFloatNotNaNOrInfinity;
+
 /** Holds the GVRCameras. */
 public class GVRCameraRig extends GVRComponent {
     /** Ways to use the rotation sensor data. */
@@ -156,6 +159,8 @@ public class GVRCameraRig extends GVRComponent {
      *            The {@code float} value to map.
      */
     public void setFloat(String key, float value) {
+        checkStringNotNullOrEmpty("key", key);
+        checkFloatNotNaNOrInfinity("value", value);
         NativeCameraRig.setFloat(getPtr(), key, value);
     }
 
@@ -180,6 +185,7 @@ public class GVRCameraRig extends GVRComponent {
      *            'Y' component of vector.
      */
     public void setVec2(String key, float x, float y) {
+        checkStringNotNullOrEmpty("key", key);
         NativeCameraRig.setVec2(getPtr(), key, x, y);
     }
 
@@ -206,6 +212,7 @@ public class GVRCameraRig extends GVRComponent {
      *            'Z' component of vector.
      */
     public void setVec3(String key, float x, float y, float z) {
+        checkStringNotNullOrEmpty("key", key);
         NativeCameraRig.setVec3(getPtr(), key, x, y, z);
     }
 
@@ -234,6 +241,7 @@ public class GVRCameraRig extends GVRComponent {
      *            'W' component of vector.
      */
     public void setVec4(String key, float x, float y, float z, float w) {
+        checkStringNotNullOrEmpty("key", key);
         NativeCameraRig.setVec4(getPtr(), key, x, y, z, w);
     }
 
@@ -348,6 +356,7 @@ public class GVRCameraRig extends GVRComponent {
     public float[] getLookAt() {
         return NativeCameraRig.getLookAt(getPtr());
     }
+
 }
 
 class NativeCameraRig {

--- a/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Future;
 
 import org.gearvrf.utility.Colors;
 import org.gearvrf.utility.Threads;
+import static org.gearvrf.utility.Preconditions.*;
 
 import android.graphics.Color;
 
@@ -267,6 +268,8 @@ public class GVRMaterial extends GVRHybridObject implements
     }
 
     public void setTexture(String key, GVRTexture texture) {
+        checkStringNotNullOrEmpty("key", key);
+        checkNotNull("texture", texture);
         NativeMaterial.setTexture(getPtr(), key, texture.getPtr());
     }
 
@@ -289,6 +292,8 @@ public class GVRMaterial extends GVRHybridObject implements
     }
 
     public void setFloat(String key, float value) {
+        checkStringNotNullOrEmpty("key", key);
+        checkFloatNotNaNOrInfinity("value", value);
         NativeMaterial.setFloat(getPtr(), key, value);
     }
 
@@ -297,6 +302,7 @@ public class GVRMaterial extends GVRHybridObject implements
     }
 
     public void setVec2(String key, float x, float y) {
+        checkStringNotNullOrEmpty("key", key);
         NativeMaterial.setVec2(getPtr(), key, x, y);
     }
 
@@ -305,6 +311,7 @@ public class GVRMaterial extends GVRHybridObject implements
     }
 
     public void setVec3(String key, float x, float y, float z) {
+        checkStringNotNullOrEmpty("key", key);
         NativeMaterial.setVec3(getPtr(), key, x, y, z);
     }
 
@@ -313,6 +320,7 @@ public class GVRMaterial extends GVRHybridObject implements
     }
 
     public void setVec4(String key, float x, float y, float z, float w) {
+        checkStringNotNullOrEmpty("key", key);
         NativeMaterial.setVec4(getPtr(), key, x, y, z, w);
     }
 
@@ -325,9 +333,11 @@ public class GVRMaterial extends GVRHybridObject implements
     public void setMat4(String key, float x1, float y1, float z1, float w1,
             float x2, float y2, float z2, float w2, float x3, float y3,
             float z3, float w3, float x4, float y4, float z4, float w4) {
+        checkStringNotNullOrEmpty("key", key);
         NativeMaterial.setMat4(getPtr(), key, x1, y1, z1, w1, x2, y2, z2, w2,
                 x3, y3, z3, w3, x4, y4, z4, w4);
     }
+
 }
 
 class NativeMaterial {

--- a/GVRf/Framework/src/org/gearvrf/GVRMesh.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMesh.java
@@ -17,6 +17,9 @@ package org.gearvrf;
 
 import org.gearvrf.utility.Exceptions;
 
+import android.util.Log;
+import static org.gearvrf.utility.Preconditions.*;
+
 /**
  * This is one of the key GVRF classes: It holds GL meshes.
  * 
@@ -66,8 +69,7 @@ public class GVRMesh extends GVRHybridObject {
      *            Array containing the packed vertex data.
      */
     public void setVertices(float[] vertices) {
-        isNonNull(vertices);
-        isValidData(vertices.length, 3);
+        checkValidFloatArray("vertices", vertices, 3);
         NativeMesh.setVertices(getPtr(), vertices);
     }
 
@@ -93,8 +95,7 @@ public class GVRMesh extends GVRHybridObject {
      *            Array containing the packed normal data.
      */
     public void setNormals(float[] normals) {
-        isNonNull(normals);
-        isValidData(normals.length, 3);
+        checkValidFloatArray("normals", normals, 3);
         NativeMesh.setNormals(getPtr(), normals);
     }
 
@@ -120,8 +121,7 @@ public class GVRMesh extends GVRHybridObject {
      *            Array containing the packed texture coordinate data.
      */
     public void setTexCoords(float[] texCoords) {
-        isNonNull(texCoords);
-        isValidData(texCoords.length, 2);
+        checkValidFloatArray("texCoords", texCoords, 2);
         NativeMesh.setTexCoords(getPtr(), texCoords);
     }
 
@@ -153,8 +153,8 @@ public class GVRMesh extends GVRHybridObject {
      *            Array containing the packed triangle index data.
      */
     public void setTriangles(char[] triangles) {
-        isNonNull(triangles);
-        isValidData(triangles.length, 3);
+        checkNotNull("triangles", triangles);
+        checkDivisibleDataLength("triangles", triangles.length, 3);
         NativeMesh.setTriangles(getPtr(), triangles);
     }
 
@@ -180,9 +180,7 @@ public class GVRMesh extends GVRHybridObject {
      *            Data to bind to the shader attribute.
      */
     public void setFloatVector(String key, float[] floatVector) {
-        isNonNull(floatVector);
-        isValidData(floatVector.length, 1);
-        verticesCheck(floatVector.length, 1);
+        checkValidFloatVector("key", key, "floatVector", floatVector, 1);
         NativeMesh.setFloatVector(getPtr(), key, floatVector);
     }
 
@@ -209,9 +207,7 @@ public class GVRMesh extends GVRHybridObject {
      *            attribute.
      */
     public void setVec2Vector(String key, float[] vec2Vector) {
-        isNonNull(vec2Vector);
-        isValidData(vec2Vector.length, 2);
-        verticesCheck(vec2Vector.length, 2);
+        checkValidFloatVector("key", key, "vec2Vector", vec2Vector, 2);
         NativeMesh.setVec2Vector(getPtr(), key, vec2Vector);
     }
 
@@ -238,9 +234,7 @@ public class GVRMesh extends GVRHybridObject {
      *            shader attribute.
      */
     public void setVec3Vector(String key, float[] vec3Vector) {
-        isNonNull(vec3Vector);
-        isValidData(vec3Vector.length, 3);
-        verticesCheck(vec3Vector.length, 3);
+        checkValidFloatVector("key", key, "vec3Vector", vec3Vector, 3);
         NativeMesh.setVec3Vector(getPtr(), key, vec3Vector);
     }
 
@@ -267,9 +261,7 @@ public class GVRMesh extends GVRHybridObject {
      *            attribute.
      */
     public void setVec4Vector(String key, float[] vec4Vector) {
-        isNonNull(vec4Vector);
-        isValidData(vec4Vector.length, 4);
-        verticesCheck(vec4Vector.length, 4);
+        checkValidFloatVector("key", key, "vec4Vector", vec4Vector, 4);
         NativeMesh.setVec4Vector(getPtr(), key, vec4Vector);
     }
 
@@ -291,31 +283,31 @@ public class GVRMesh extends GVRHybridObject {
         return new GVRMesh(getGVRContext(), NativeMesh.getBoundingBox(getPtr()));
     }
 
-    private static void isNonNull(Object data) {
-        if (data == null) {
-            throw new IllegalArgumentException(
-                    "The input array should not be null.");
-        }
+    private void checkValidFloatVector(String keyName, String key,
+            String vectorName, float[] vector, int expectedComponents) {
+        checkStringNotNullOrEmpty(keyName, key);
+        checkNotNull(vectorName, vector);
+        checkDivisibleDataLength(vectorName, vector.length, expectedComponents);
+        checkVectorLengthWithVertices(vectorName, vector.length,
+                expectedComponents);
     }
 
-    private static void isValidData(int dataLength, int expectedComponents) {
-        if (dataLength == 0 || dataLength % expectedComponents != 0) {
-            throw Exceptions
-                    .IllegalArgument(
-                            "The input array should be an array of %d-component elements whose length is non-zero and divisible by %d. But current data length is %d.",
-                            expectedComponents, expectedComponents, dataLength);
-        }
+    private void checkValidFloatArray(String parameterName, float[] data,
+            int expectedComponents) {
+        checkNotNull(parameterName, data);
+        checkDivisibleDataLength(parameterName, data.length, expectedComponents);
     }
 
-    private void verticesCheck(int dataLength, int expectedComponents) {
+    private void checkVectorLengthWithVertices(String parameterName,
+            int dataLength, int expectedComponents) {
         int verticesNumber = getVertices().length / 3;
         int numberOfElements = dataLength / expectedComponents;
         if (dataLength / expectedComponents != verticesNumber) {
             throw Exceptions
                     .IllegalArgument(
-                            "The input array should be an array of %d-component elements and the number of elements should match the number of vertices. The current number of elements is %d, but the current number of vertices is %d.",
-                            expectedComponents, numberOfElements,
-                            verticesNumber);
+                            "The input array %s should be an array of %d-component elements and the number of elements should match the number of vertices. The current number of elements is %d, but the current number of vertices is %d.",
+                            parameterName, expectedComponents,
+                            numberOfElements, verticesNumber);
         }
     }
 }

--- a/GVRf/Framework/src/org/gearvrf/utility/Preconditions.java
+++ b/GVRf/Framework/src/org/gearvrf/utility/Preconditions.java
@@ -1,0 +1,137 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf.utility;
+
+import android.text.TextUtils;
+
+public abstract class Preconditions {
+
+    /**
+     * The goal of this class is to improve the readability and to provide some
+     * common checking method to improve the robustness of GVRF. But in some
+     * cases, this may be a significant performance cost. Try to use and further
+     * extend this class carefully with concern on performance issue.
+     * 
+     * Actually, one purpose of this class may help us avoid from using
+     * GVRJniException which is not a proper way to throw/simulate an exception
+     * with JNI crash.
+     */
+
+    /**
+     * Check that the parameter is not {@code null}.
+     * 
+     * @param parameterName
+     *            The name of the user-supplied parameter that we are validating
+     *            so that the user can easily find the error in their code.
+     * @param object
+     *            the parameter object can be any Java reference type, including
+     *            arrays.
+     * @throws IllegalArgumentException
+     *             if the object is null pointer.
+     */
+    public static void checkNotNull(String parameterName, Object object) {
+        if (object == null) {
+            throw Exceptions.IllegalArgument("Input %s can't be null.",
+                    parameterName);
+        }
+    }
+
+    /**
+     * This function is to ensure that any input string value is not null or
+     * empty
+     * 
+     * @param value
+     *            String value to be checked.
+     * @param parameterName
+     *            The name of the user-supplied parameter that we are validating
+     *            so that the user can easily find the error in their code.
+     * @throws IllegalArgumentException
+     *             If the key is null or empty.
+     */
+    public static void checkStringNotNullOrEmpty(String parameterName,
+            String value) {
+        if (TextUtils.isEmpty(value)) {
+            throw Exceptions.IllegalArgument("Current input string %s is %s.",
+                    parameterName, value == null ? "null" : "empty");
+        }
+    }
+
+    /**
+     * This function is to ensure that the length of input array is legal
+     * according to the expected components' number.
+     * 
+     * @param parameterName
+     *            The name of the user-supplied parameter that we are validating
+     *            so that the user can easily find the error in their code.
+     * @param dataLength
+     *            Length of array data.
+     * @param expectedComponents
+     *            Expected number of components.
+     * @throws IllegalArgumentException
+     *             If the dataLength is zero or not divisible by the expected
+     *             number.
+     */
+    public static void checkDivisibleDataLength(String parameterName,
+            int dataLength, int expectedComponents) {
+        if (dataLength == 0 || dataLength % expectedComponents != 0) {
+            throw Exceptions
+                    .IllegalArgument(
+                            "The input array of %s should be an array of %d-component elements whose length is non-zero and divisible by %d. But current data length is %d.",
+                            parameterName, expectedComponents,
+                            expectedComponents, dataLength);
+        }
+    }
+
+    /**
+     * In common shader cases, NaN makes little sense. Correspondingly, GVRF is
+     * going to use Float.NaN as illegal flag in many cases. Therefore, we need
+     * a function to check if there is any setX that is using NaN as input.
+     * 
+     * @param parameterName
+     *            The name of the user-supplied parameter that we are validating
+     *            so that the user can easily find the error in their code.
+     * @param data
+     *            A series of input float data.
+     * @throws IllegalArgumentException
+     *             if the data includes NaN.
+     */
+    public static void checkFloatNotNaNOrInfinity(String parameterName,
+            float... data) {
+        for (float element : data) {
+            checkFloatNotNaNOrInfinity(parameterName, element);
+        }
+    }
+
+    /**
+     * This is checkNotNaN for only single float.
+     * 
+     * @param parameterName
+     *            The name of the user-supplied parameter that we are validating
+     *            so that the user can easily find the error in their code.
+     * @param data
+     *            A single float data.
+     * @throws IllegalArgumentException
+     *             if the data includes NaN.
+     */
+    public static void checkFloatNotNaNOrInfinity(String parameterName,
+            float data) {
+        if (Float.isNaN(data) || Float.isInfinite(data)) {
+            throw Exceptions.IllegalArgument(
+                    "%s should never be NaN or Infinite.", parameterName);
+        }
+    }
+
+}


### PR DESCRIPTION
...VRMesh, GVRMaterial, and GVRCameraRig

One of our goal is to provide Java side exception as possible as we can while in the illegal states.
Previously I impelment a GVRJniException class which can simulate Java stack trace and throw a JNI crash finally.I am thinking if we should avoid using this class as possible as we can. So for the readability and further robustness in GVRF, I want to introduce the class Preconditions and provide some convenient pre-condition check at Java level so that we can avoid using GVRJniException when crash happens in JNI side.

But I think the use of Preconditions may need to be very careful since unnecessary checks will eventually turn out to be a significant overhead. For example, in GVRMaterial and GVRCameraRig I finally decided to only add NaN check in setFloat is because only in the case of single float parameter may need NaN as a special flag to inform Java that an illegal state happens. Corresponsively, in the case of float vector/array, we can simply return null pointer back from JNI to Java as an illegal state identifier. I mean, we probably can't check all illegal states using Preconditions. But in necessary cases, I think we'd better make use of it and in the future extend it in a proper way.


GearVRf-DCO-1.0-Signed-off-by: Chao Chen
c.chen@samsung.com