### PR TITLE
Add a way for custom post effects to access latest projection matrix.

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -127,14 +127,14 @@ void Renderer::renderCamera(std::shared_ptr<Scene> scene,
                 glViewport(viewportX, viewportY, viewportWidth, viewportHeight);
 
                 glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
-                renderPostEffectData(texture_render_texture, post_effects[i],
+                renderPostEffectData(camera, texture_render_texture, post_effects[i],
                         post_effect_shader_manager);
             }
 
             glBindFramebuffer(GL_FRAMEBUFFER, framebufferId);
             glViewport(viewportX, viewportY, viewportWidth, viewportHeight);
             glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
-            renderPostEffectData(texture_render_texture, post_effects.back(),
+            renderPostEffectData(camera, texture_render_texture, post_effects.back(),
                     post_effect_shader_manager);
         }
     } // flag checking
@@ -265,7 +265,7 @@ void Renderer::renderRenderData(std::shared_ptr<RenderData> render_data,
     }
 }
 
-void Renderer::renderPostEffectData(
+void Renderer::renderPostEffectData(std::shared_ptr<Camera> camera,
         std::shared_ptr<RenderTexture> render_texture,
         std::shared_ptr<PostEffectData> post_effect_data,
         std::shared_ptr<PostEffectShaderManager> post_effect_shader_manager) {
@@ -287,7 +287,8 @@ void Renderer::renderPostEffectData(
             break;
         default:
             post_effect_shader_manager->getCustomPostEffectShader(
-                    post_effect_data->shader_type())->render(render_texture,
+                    post_effect_data->shader_type())->render(camera,
+                    render_texture,
                     post_effect_data,
                     post_effect_shader_manager->quad_vertices(),
                     post_effect_shader_manager->quad_uvs(),

--- a/GVRf/Framework/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/jni/engine/renderer/renderer.h
@@ -88,7 +88,7 @@ private:
     static void renderRenderData(std::shared_ptr<RenderData> render_data,
             const glm::mat4& vp_matrix, int render_mask,
             std::shared_ptr<ShaderManager> shader_manager);
-    static void renderPostEffectData(
+    static void renderPostEffectData(std::shared_ptr<Camera> camera,
             std::shared_ptr<RenderTexture> render_texture,
             std::shared_ptr<PostEffectData> post_effect_data,
             std::shared_ptr<PostEffectShaderManager> post_effect_shader_manager);

--- a/GVRf/Framework/jni/shaders/posteffect/custom_post_effect_shader.cpp
+++ b/GVRf/Framework/jni/shaders/posteffect/custom_post_effect_shader.cpp
@@ -36,6 +36,8 @@ CustomPostEffectShader::CustomPostEffectShader(std::string vertex_shader,
     checkGlError("glGetAttribLocation");
     u_texture_ = glGetUniformLocation(program_->id(), "u_texture");
     checkGlError("glGetUniformLocation");
+    u_projection_matrix_ = glGetUniformLocation(program_->id(), "u_projection_matrix");
+    checkGlError("glGetUniformLocation");
 
     vaoID_ = 0;
 
@@ -92,7 +94,7 @@ void CustomPostEffectShader::addMat4Key(std::string variable_name,
     mat4_keys_[location] = key;
 }
 
-void CustomPostEffectShader::render(
+void CustomPostEffectShader::render(std::shared_ptr<Camera> camera,
         std::shared_ptr<RenderTexture> render_texture,
         std::shared_ptr<PostEffectData> post_effect_data,
         std::vector<glm::vec3>& vertices, std::vector<glm::vec2>& tex_coords,
@@ -135,6 +137,11 @@ void CustomPostEffectShader::render(
         glActiveTexture(getGLTexture(texture_index));
         glBindTexture(GL_TEXTURE_2D, render_texture->getId());
         glUniform1i(u_texture_, texture_index++);
+    }
+
+    if (u_projection_matrix_ != -1) {
+        glm::mat4 view = camera->getViewMatrix();
+        glUniformMatrix4fv(u_projection_matrix_, 1, GL_TRUE, glm::value_ptr(view));
     }
 
     for (auto it = texture_keys_.begin(); it != texture_keys_.end(); ++it) {
@@ -193,6 +200,11 @@ void CustomPostEffectShader::render(
         glActiveTexture(getGLTexture(texture_index));
         glBindTexture(GL_TEXTURE_2D, render_texture->getId());
         glUniform1i(u_texture_, texture_index++);
+    }
+
+    if (u_projection_matrix_ != -1) {
+        glm::mat4 view = camera->getViewMatrix();
+        glUniformMatrix4fv(u_projection_matrix_, 1, GL_TRUE, glm::value_ptr(view));
     }
 
     for (auto it = texture_keys_.begin(); it != texture_keys_.end(); ++it) {

--- a/GVRf/Framework/jni/shaders/posteffect/custom_post_effect_shader.h
+++ b/GVRf/Framework/jni/shaders/posteffect/custom_post_effect_shader.h
@@ -30,6 +30,7 @@
 #include "glm/glm.hpp"
 
 #include "objects/recyclable_object.h"
+#include "objects/components/camera.h"
 
 namespace gvr {
 class GLProgram;
@@ -48,7 +49,8 @@ public:
     void addVec3Key(std::string variable_name, std::string key);
     void addVec4Key(std::string variable_name, std::string key);
     void addMat4Key(std::string variable_name, std::string key);
-    void render(std::shared_ptr<RenderTexture> render_texture,
+    void render(std::shared_ptr<Camera> camera,
+            std::shared_ptr<RenderTexture> render_texture,
             std::shared_ptr<PostEffectData> post_effect_data,
             std::vector<glm::vec3>& vertices,
             std::vector<glm::vec2>& tex_coords,
@@ -70,6 +72,7 @@ private:
     GLuint a_position_;
     GLuint a_tex_coord_;
     GLuint u_texture_;
+    GLuint u_projection_matrix_;
     std::map<int, std::string> texture_keys_;
     std::map<int, std::string> float_keys_;
     std::map<int, std::string> vec2_keys_;


### PR DESCRIPTION
Add handling for the "u_projection_matrix" uniform, that will
automatically get the mapping of the predicted projection matrix when
used in a custom shader.

GearVRf-DCO-1.0-Signed-off-by: Benoit Fouet <benoit.fouet@kolor.com>