### PR TITLE
Add a setDrawMode() method to GVRRenderData.

### DIFF
--- a/GVRf/Framework/jni/objects/components/render_data.h
+++ b/GVRf/Framework/jni/objects/components/render_data.h
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-
 /***************************************************************************
  * Containing data about how to render an object.
  ***************************************************************************/
@@ -24,6 +23,7 @@
 #include <memory>
 #include <vector>
 
+#include "gl/gl_program.h"
 #include "glm/glm.hpp"
 
 #include "objects/components/component.h"
@@ -47,7 +47,7 @@ public:
                     DEFAULT_RENDER_MASK), rendering_order_(
                     DEFAULT_RENDERING_ORDER), cull_test_(true), offset_(false), offset_factor_(
                     0.0f), offset_units_(0.0f), depth_test_(true), alpha_blend_(
-                    true) {
+                    true), draw_mode_(GL_TRIANGLES) {
     }
 
     ~RenderData() {
@@ -141,6 +141,14 @@ public:
         alpha_blend_ = alpha_blend;
     }
 
+    GLenum draw_mode() const {
+        return draw_mode_;
+    }
+
+    void set_draw_mode(GLenum draw_mode) {
+        draw_mode_ = draw_mode;
+    }
+
 private:
     RenderData(const RenderData& render_data);
     RenderData(RenderData&& render_data);
@@ -160,6 +168,7 @@ private:
     float offset_units_;
     bool depth_test_;
     bool alpha_blend_;
+    GLenum draw_mode_;
 };
 
 inline bool compareRenderData(std::shared_ptr<RenderData> i,

--- a/GVRf/Framework/jni/objects/components/render_data_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/render_data_jni.cpp
@@ -101,6 +101,14 @@ Java_org_gearvrf_NativeRenderData_getAlphaBlend(JNIEnv * env,
 JNIEXPORT void JNICALL
 Java_org_gearvrf_NativeRenderData_setAlphaBlend(JNIEnv * env,
         jobject obj, jlong jrender_data, jboolean alpha_blend);
+
+JNIEXPORT jint JNICALL
+Java_org_gearvrf_NativeRenderData_getDrawMode(
+        JNIEnv * env, jobject obj, jlong jrender_data);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeRenderData_setDrawMode(
+        JNIEnv * env, jobject obj, jlong jrender_data, jint draw_mode);
 }
 ;
 
@@ -278,4 +286,23 @@ Java_org_gearvrf_NativeRenderData_setAlphaBlend(JNIEnv * env,
             RenderData>*>(jrender_data);
     render_data->set_alpha_blend(static_cast<bool>(alpha_blend));
 }
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeRenderData_setDrawMode(
+        JNIEnv * env, jobject obj, jlong jrender_data, jint draw_mode) {
+    std::shared_ptr<RenderData> render_data = *reinterpret_cast<std::shared_ptr<
+            RenderData>*>(jrender_data);
+    render_data->set_draw_mode(draw_mode);
+}
+
+JNIEXPORT jint JNICALL
+Java_org_gearvrf_NativeRenderData_getDrawMode(
+        JNIEnv * env, jobject obj, jlong jrender_data) {
+    std::shared_ptr<RenderData> render_data = *reinterpret_cast<std::shared_ptr<
+            RenderData>*>(jrender_data);
+    return render_data->draw_mode();
+}
+
+
+
 }

--- a/GVRf/Framework/jni/shaders/material/unlit_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/unlit_shader.cpp
@@ -97,7 +97,7 @@ void UnlitShader::render(const glm::mat4& mvp_matrix,
     glUseProgram(program_->id());
 
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(mvp_matrix));
-    glActiveTexture (GL_TEXTURE0);
+    glActiveTexture(GL_TEXTURE0);
     glBindTexture(texture->getTarget(), texture->getId());
     glUniform1i(u_texture_, 0);
     glUniform3f(u_color_, color.r, color.g, color.b);

--- a/GVRf/Framework/jni/shaders/material/unlit_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/unlit_shader.cpp
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-
 /***************************************************************************
  * Renders a texture without light.
  ***************************************************************************/
@@ -98,14 +97,15 @@ void UnlitShader::render(const glm::mat4& mvp_matrix,
     glUseProgram(program_->id());
 
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(mvp_matrix));
-    glActiveTexture(GL_TEXTURE0);
+    glActiveTexture (GL_TEXTURE0);
     glBindTexture(texture->getTarget(), texture->getId());
     glUniform1i(u_texture_, 0);
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
 
     glBindVertexArray(mesh->getVAOId());
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT, 0);
+    glDrawElements(render_data->draw_mode(), mesh->triangles().size(),
+            GL_UNSIGNED_SHORT, 0);
     glBindVertexArray(0);
 #else
     glUseProgram(program_->id());
@@ -128,7 +128,7 @@ void UnlitShader::render(const glm::mat4& mvp_matrix,
 
     glUniform1f(u_opacity_, opacity);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->triangles().size(), GL_UNSIGNED_SHORT,
             mesh->triangles().data());
 #endif
 

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
@@ -337,10 +337,10 @@ public class GVRRenderData extends GVRComponent {
      * @param drawMode
      */
     public void setDrawMode(int drawMode) {
-        if (drawMode != GL_POINTS || drawMode != GL_LINES
-                || drawMode != GL_LINE_STRIP || drawMode != GL_LINE_LOOP
-                || drawMode != GL_TRIANGLES || drawMode != GL_TRIANGLE_STRIP
-                || drawMode != GL_TRIANGLE_FAN) {
+        if (drawMode != GL_POINTS && drawMode != GL_LINES
+                && drawMode != GL_LINE_STRIP && drawMode != GL_LINE_LOOP
+                && drawMode != GL_TRIANGLES && drawMode != GL_TRIANGLE_STRIP
+                && drawMode != GL_TRIANGLE_FAN) {
             throw new IllegalArgumentException(
                     "drawMode must be one of GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_LINE_LOOP, GL_TRIANGLES, GL_TRIANGLE_FAN, GL_TRIANGLE_STRIP.  Value passed was: "
                             + drawMode);

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
@@ -342,8 +342,7 @@ public class GVRRenderData extends GVRComponent {
                 && drawMode != GL_TRIANGLES && drawMode != GL_TRIANGLE_STRIP
                 && drawMode != GL_TRIANGLE_FAN) {
             throw new IllegalArgumentException(
-                    "drawMode must be one of GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_LINE_LOOP, GL_TRIANGLES, GL_TRIANGLE_FAN, GL_TRIANGLE_STRIP.  Value passed was: "
-                            + drawMode);
+                    "drawMode must be one of GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_LINE_LOOP, GL_TRIANGLES, GL_TRIANGLE_FAN, GL_TRIANGLE_STRIP.");
         }
         NativeRenderData.setDrawMode(getPtr(), drawMode);
     }

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
@@ -16,7 +16,7 @@
 package org.gearvrf;
 
 import java.util.concurrent.Future;
-
+import static android.opengl.GLES30.*;
 import org.gearvrf.utility.Threads;
 
 /**
@@ -323,6 +323,31 @@ public class GVRRenderData extends GVRComponent {
     public void setAlphaBlend(boolean alphaBlend) {
         NativeRenderData.setAlphaBlend(getPtr(), alphaBlend);
     }
+
+    /**
+     * @return The OpenGL draw mode (e.g. GL_TRIANGLES).
+     */
+    public int getDrawMode() {
+        return NativeRenderData.getDrawMode(getPtr());
+    }
+
+    /**
+     * Set the draw mode for this mesh. Default is GL_TRIANGLES.
+     * 
+     * @param drawMode
+     */
+    public void setDrawMode(int drawMode) {
+        if (drawMode != GL_POINTS || drawMode != GL_LINES
+                || drawMode != GL_LINE_STRIP || drawMode != GL_LINE_LOOP
+                || drawMode != GL_TRIANGLES || drawMode != GL_TRIANGLE_STRIP
+                || drawMode != GL_TRIANGLE_FAN) {
+            throw new IllegalArgumentException(
+                    "drawMode must be one of GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_LINE_LOOP, GL_TRIANGLES, GL_TRIANGLE_FAN, GL_TRIANGLE_STRIP.  Value passed was: "
+                            + drawMode);
+        }
+        NativeRenderData.setDrawMode(getPtr(), drawMode);
+    }
+
 }
 
 class NativeRenderData {
@@ -369,4 +394,9 @@ class NativeRenderData {
     public static native boolean getAlphaBlend(long renderData);
 
     public static native void setAlphaBlend(long renderData, boolean alphaBlend);
+
+    public static native int getDrawMode(long renderData);
+
+    public static native void setDrawMode(long renderData, int draw_mode);
+
 }


### PR DESCRIPTION
Add setDrawMode()/getDrawMode methods to GVRRenderData.  This will allow
users to draw GL_LINES and GL_POINTS in addition to the default of
GL_TRIANGLES.

GearVRf-DCO-1.0-Signed-off-by: Thomas Flynn
tom.flynn@samsung.com