### PR TITLE
Update activity_jni.cpp

### DIFF
--- a/GVRf/Framework/jni/oculus/activity_jni.cpp
+++ b/GVRf/Framework/jni/oculus/activity_jni.cpp
@@ -223,11 +223,11 @@ Matrix4f GVRActivity::Frame( const VrFrame vrFrame )
     glm::mat4 vp_matrix = camera->getCenterViewMatrix();
 
     ovrMatrix4f view2;
-    view2.M[0][0] = vp_matrix[0][0]; view2.M[1][0] = vp_matrix[1][0]; view2.M[2][0] = vp_matrix[2][0]; view2.M[3][0] = vp_matrix[3][0];
-    view2.M[0][1] = vp_matrix[0][1]; view2.M[1][1] = vp_matrix[1][1]; view2.M[2][1] = vp_matrix[2][1]; view2.M[3][1] = vp_matrix[3][1];
-    view2.M[0][2] = vp_matrix[0][2]; view2.M[1][2] = vp_matrix[1][2]; view2.M[2][2] = vp_matrix[2][2]; view2.M[3][2] = vp_matrix[3][2];
-    view2.M[0][3] = vp_matrix[0][3]; view2.M[1][3] = vp_matrix[1][3]; view2.M[2][3] = vp_matrix[2][3]; view2.M[3][3] = vp_matrix[3][3];
 
+    view2.M[0][0] = vp_matrix[0][0]; view2.M[1][0] = vp_matrix[0][1]; view2.M[2][0] = vp_matrix[0][2]; view2.M[3][0] = vp_matrix[0][3];
+    view2.M[0][1] = vp_matrix[1][0]; view2.M[1][1] = vp_matrix[1][1]; view2.M[2][1] = vp_matrix[1][2]; view2.M[3][1] = vp_matrix[1][3];
+    view2.M[0][2] = vp_matrix[2][0]; view2.M[1][2] = vp_matrix[2][1]; view2.M[2][2] = vp_matrix[2][2]; view2.M[3][2] = vp_matrix[2][3];
+    view2.M[0][3] = vp_matrix[3][0]; view2.M[1][3] = vp_matrix[3][1]; view2.M[2][3] = vp_matrix[3][2]; view2.M[3][3] = vp_matrix[3][3];
 
 	// Set the external velocity matrix so TimeWarp can smoothly rotate the
 	// view even if we are dropping frames.


### PR DESCRIPTION
Since OpenGL specifies matrices as a one-dimensional array listed in column-major order while C does in row-major order, the gl matrix should be converted accordingly.