### PR TITLE
Correct solid normals.

### DIFF
--- a/GVRf/Framework/jni/shaders/material/cubemap_reflection_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/cubemap_reflection_shader.cpp
@@ -62,35 +62,36 @@
 // (http://stackoverflow.com/questions/11685608/convention-of-faces-in-opengl-cubemapping)
 
 namespace gvr {
-static const char VERTEX_SHADER[] = //
-        "attribute vec4 a_position;\n"
-                "attribute vec3 a_normal;\n"
-                "uniform mat4 u_mv;\n"
-                "uniform mat4 u_mv_it;\n"
-                "uniform mat4 u_mvp;\n"
-                "uniform mat4 u_view_i;\n"
-                "varying vec3 v_tex_coord;\n"
-                "void main() {\n"
-                "  vec4 v_viewspace_position_vec4 = u_mv * a_position;\n"
-                "  vec3 v_viewspace_position = v_viewspace_position_vec4.xyz / v_viewspace_position_vec4.w;\n"
-                "  vec3 v_viewspace_normal = (u_mv_it * vec4(a_normal, 1.0)).xyz;\n"
-                "  vec3 v_reflected_position = reflect(v_viewspace_position, normalize(v_viewspace_normal));\n"
-                "  v_tex_coord = (u_view_i * vec4(v_reflected_position, 1.0)).xyz;\n"
-                "  v_tex_coord.z = -v_tex_coord.z;\n"
-                "  gl_Position = u_mvp * a_position;\n"
-                "}\n";
+static const char VERTEX_SHADER[] = "attribute vec4 a_position;\n"
+		"attribute vec3 a_normal;\n"
+		"uniform mat4 u_mv;\n"
+		"uniform mat4 u_mv_it;\n"
+		"uniform mat4 u_mvp;\n"
+		"varying vec3 v_viewspace_position;\n"
+		"varying vec3 v_viewspace_normal;\n"
+		"void main() {\n"
+		"  vec4 v_viewspace_position_vec4 = u_mv * a_position;\n"
+		"  v_viewspace_position = v_viewspace_position_vec4.xyz / v_viewspace_position_vec4.w;\n"
+		"  v_viewspace_normal = (u_mv_it * vec4(a_normal, 1.0)).xyz;\n"
+		"  gl_Position = u_mvp * a_position;\n"
+		"}\n";
 
-static const char FRAGMENT_SHADER[] = //
-        "precision highp float;\n"
-                "uniform samplerCube u_texture;\n"
-                "uniform vec3 u_color;\n"
-                "uniform float u_opacity;\n"
-                "varying vec3 v_tex_coord;\n"
-                "void main()\n"
-                "{\n"
-                "  vec4 color = textureCube(u_texture, v_tex_coord.xyz);\n"
-                "  gl_FragColor = vec4(color.r * u_color.r * u_opacity, color.g * u_color.g * u_opacity, color.b * u_color.b * u_opacity, color.a * u_opacity);\n"
-                "}\n";
+static const char FRAGMENT_SHADER[] =
+		"precision highp float;\n"
+				"uniform samplerCube u_texture;\n"
+				"uniform vec3 u_color;\n"
+				"uniform float u_opacity;\n"
+				"uniform mat4 u_view_i;\n"
+				"varying vec3 v_viewspace_position;\n"
+				"varying vec3 v_viewspace_normal;\n"
+				"void main()\n"
+				"{\n"
+				"  vec3 v_reflected_position = reflect(v_viewspace_position, normalize(v_viewspace_normal));\n"
+				"  vec3 v_tex_coord = (u_view_i * vec4(v_reflected_position, 1.0)).xyz;\n"
+				"  v_tex_coord.z = -v_tex_coord.z;\n"
+				"  vec4 color = textureCube(u_texture, v_tex_coord.xyz);\n"
+				"  gl_FragColor = vec4(color.r * u_color.r * u_opacity, color.g * u_color.g * u_opacity, color.b * u_color.b * u_opacity, color.a * u_opacity);\n"
+				"}\n";
 
 CubemapReflectionShader::CubemapReflectionShader() :
         program_(0), a_position_(0), a_normal_(0), u_mv_(0), u_mv_it_(0), u_mvp_(

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRConeSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRConeSceneObject.java
@@ -23,8 +23,8 @@ import org.gearvrf.GVRMesh;
 public class GVRConeSceneObject extends GVRSceneObject {
 
     private static final String TAG = "GVRConeSceneObject";
-    private static final int NUM_STACKS = 2;
-    private static final int NUM_SLICES = 36;
+    private static final int STACK_NUMBER = 10;
+    private static final int SLICE_NUMBER = 36;
     private static final float BASE_RADIUS = 0.5f;
     private static final float TOP_RADIUS = 0.0f;
     private static final float HEIGHT = 1.0f;
@@ -39,8 +39,8 @@ public class GVRConeSceneObject extends GVRSceneObject {
         super(gvrContext);
 
         GVRCylinderSceneObject cylinder = new GVRCylinderSceneObject(
-                gvrContext, BASE_RADIUS, TOP_RADIUS, HEIGHT, NUM_STACKS,
-                NUM_SLICES);
+                gvrContext, BASE_RADIUS, TOP_RADIUS, HEIGHT, STACK_NUMBER,
+                SLICE_NUMBER);
 
         GVRMesh mesh = cylinder.getRenderData().getMesh();
         GVRRenderData renderData = new GVRRenderData(gvrContext);

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
@@ -160,10 +160,10 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
             double theta1 = ((slice + 1) / sliceNumber) * 2.0 * Math.PI;
 
             float y = height;
-            float x0 = radius * (float) Math.cos(theta0);
-            float z0 = radius * (float) Math.sin(theta0);
-            float x1 = radius * (float) Math.cos(theta1);
-            float z1 = radius * (float) Math.sin(theta1);
+            float x0 = (float) (radius * Math.cos(theta0));
+            float z0 = (float) (radius * Math.sin(theta0));
+            float x1 = (float) (radius * Math.cos(theta1));
+            float z1 = (float) (radius * Math.sin(theta1));
 
             float s0 = 1.0f - ((float) (slice) / sliceNumber);
             float s1 = 1.0f - ((float) (slice + 1) / sliceNumber);
@@ -238,22 +238,22 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
                 float slicePercentage1 = ((float) (slice + 1) / sliceNumber);
                 double theta0 = slicePercentage0 * 2.0 * Math.PI;
                 double theta1 = slicePercentage1 * 2.0 * Math.PI;
-                float cosTheta0 = (float) Math.cos(theta0);
-                float sinTheta0 = (float) Math.sin(theta0);
-                float cosTheta1 = (float) Math.cos(theta1);
-                float sinTheta1 = (float) Math.sin(theta1);
+                double cosTheta0 = Math.cos(theta0);
+                double sinTheta0 = Math.sin(theta0);
+                double cosTheta1 = Math.cos(theta1);
+                double sinTheta1 = Math.sin(theta1);
 
                 float radius = (bottomRadius - (difference * stackPercentage0));
-                float x0 = radius * cosTheta0;
-                float z0 = -radius * sinTheta0;
-                float x1 = radius * cosTheta1;
-                float z1 = -radius * sinTheta1;
+                float x0 = (float) (radius * cosTheta0);
+                float z0 = (float) (-radius * sinTheta0);
+                float x1 = (float) (radius * cosTheta1);
+                float z1 = (float) (-radius * sinTheta1);
 
                 radius = (bottomRadius - (difference * stackPercentage1));
-                float x2 = radius * cosTheta0;
-                float z2 = -radius * sinTheta0;
-                float x3 = radius * cosTheta1;
-                float z3 = -radius * sinTheta1;
+                float x2 = (float) (radius * cosTheta0);
+                float z2 = (float) (-radius * sinTheta0);
+                float x3 = (float) (radius * cosTheta1);
+                float z3 = (float) (-radius * sinTheta1);
 
                 float s0 = slicePercentage0;
                 float s1 = slicePercentage1;

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
@@ -24,8 +24,8 @@ import org.gearvrf.GVRMesh;
 public class GVRCylinderSceneObject extends GVRSceneObject {
 
     private static final String TAG = "GVRCylinderSceneObject";
-    private static final int NUM_STACKS = 10;
-    private static final int NUM_SLICES = 36;
+    private static final int STACK_NUMBER = 10;
+    private static final int SLICE_NUMBER = 36;
     private static final float BASE_RADIUS = 0.5f;
     private static final float TOP_RADIUS = 0.5f;
     private static final float HEIGHT = 1.0f;
@@ -49,8 +49,8 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
     public GVRCylinderSceneObject(GVRContext gvrContext) {
         super(gvrContext);
 
-        generateCylinder(BASE_RADIUS, TOP_RADIUS, HEIGHT, NUM_STACKS,
-                NUM_SLICES);
+        generateCylinder(BASE_RADIUS, TOP_RADIUS, HEIGHT, STACK_NUMBER,
+                SLICE_NUMBER);
 
         GVRMesh mesh = new GVRMesh(gvrContext);
         mesh.setVertices(vertices);
@@ -74,20 +74,20 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
      *            radius for the top of the cylinder
      * @param height
      *            height of the cylinder
-     * @param numStacks
+     * @param stackNumber
      *            number of quads high to make the cylinder.
-     * @param numSlices
+     * @param sliceNumber
      *            number of quads around to make the cylinder.
      */
     public GVRCylinderSceneObject(GVRContext gvrContext, float bottomRadius,
-            float topRadius, float height, int numStacks, int numSlices) {
+            float topRadius, float height, int stackNumber, int sliceNumber) {
         super(gvrContext);
         // assert height, numStacks, numSlices > 0
-        if (height <= 0 || numStacks <= 0 || numSlices <= 0) {
+        if (height <= 0 || stackNumber <= 0 || sliceNumber <= 0) {
             throw new IllegalArgumentException(
                     "height, numStacks, and numSlices must be > 0.  Values passed were: height="
-                            + height + ", numStacks=" + numStacks
-                            + ", numSlices=" + numSlices);
+                            + height + ", numStacks=" + stackNumber
+                            + ", numSlices=" + sliceNumber);
         }
 
         // assert numCaps > 0
@@ -97,7 +97,8 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
                             + bottomRadius + ", topRadius=" + topRadius);
         }
 
-        generateCylinder(bottomRadius, topRadius, height, numStacks, numSlices);
+        generateCylinder(bottomRadius, topRadius, height, stackNumber,
+                sliceNumber);
 
         GVRMesh mesh = new GVRMesh(gvrContext);
         mesh.setVertices(vertices);
@@ -111,54 +112,52 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
     }
 
     private void generateCylinder(float bottomRadius, float topRadius,
-            float height, int numStacks, int numSlices) {
+            float height, int stackNumber, int sliceNumber) {
 
-        int numCaps = 2;
+        int capNumber = 2;
         if (bottomRadius == 0) {
-            numCaps--;
+            capNumber--;
         }
 
         if (topRadius == 0) {
-            numCaps--;
+            capNumber--;
         }
 
-        int capNumVertices = 3 * numSlices;
-        int bodyNumVertices = 4 * numSlices * numStacks;
-        int numVertices = (numCaps * capNumVertices) + bodyNumVertices;
-        int numTriangles = (numCaps * capNumVertices)
-                + (6 * numSlices * numStacks);
+        int capVertexNumber = 3 * sliceNumber;
+        int bodyVertexNumber = 4 * sliceNumber * stackNumber;
+        int vertexNumber = (capNumber * capVertexNumber) + bodyVertexNumber;
+        int triangleNumber = (capNumber * capVertexNumber)
+                + (6 * sliceNumber * stackNumber);
         float halfHeight = height / 2.0f;
 
-        vertices = new float[3 * numVertices];
-        normals = new float[3 * numVertices];
-        texCoords = new float[2 * numVertices];
-        indices = new char[numTriangles];
+        vertices = new float[3 * vertexNumber];
+        normals = new float[3 * vertexNumber];
+        texCoords = new float[2 * triangleNumber];
+        indices = new char[triangleNumber];
 
         // top cap
         // 3 * numSlices
         if (topRadius > 0) {
-            createCap(topRadius, halfHeight, numSlices, 1.0f);
+            createCap(topRadius, halfHeight, sliceNumber, 1.0f);
         }
 
         // cylinder body
         // 4 * numSlices * numStacks
-        createBody(bottomRadius, topRadius, height, numStacks, numSlices);
+        createBody(bottomRadius, topRadius, height, stackNumber, sliceNumber);
 
         // bottom cap
         // 3 * numSlices
         if (bottomRadius > 0) {
-            createCap(bottomRadius, -halfHeight, numSlices, -1.0f);
+            createCap(bottomRadius, -halfHeight, sliceNumber, -1.0f);
         }
 
     }
 
-    private void createCap(float radius, float height, int numSlices,
-            float normalDir) {
-        for (int slice = 0; slice < numSlices; slice++) {
-            float theta0 = ((float) (slice) / numSlices) * 2.0f
-                    * (float) Math.PI;
-            float theta1 = ((float) (slice + 1) / numSlices) * 2.0f
-                    * (float) Math.PI;
+    private void createCap(float radius, float height, int sliceNumber,
+            float normalDirection) {
+        for (int slice = 0; slice < sliceNumber; slice++) {
+            double theta0 = ((slice) / sliceNumber) * 2.0 * Math.PI;
+            double theta1 = ((slice + 1) / sliceNumber) * 2.0 * Math.PI;
 
             float y = height;
             float x0 = radius * (float) Math.cos(theta0);
@@ -166,8 +165,8 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
             float x1 = radius * (float) Math.cos(theta1);
             float z1 = radius * (float) Math.sin(theta1);
 
-            float s0 = 1.0f - ((float) (slice) / numSlices);
-            float s1 = 1.0f - ((float) (slice + 1) / numSlices);
+            float s0 = 1.0f - ((float) (slice) / sliceNumber);
+            float s1 = 1.0f - ((float) (slice + 1) / sliceNumber);
             float s2 = (s0 + s1) / 2.0f;
 
             vertices[vertexCount + 0] = x0;
@@ -181,13 +180,13 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
             vertices[vertexCount + 8] = 0.0f;
 
             normals[vertexCount + 0] = 0.0f;
-            normals[vertexCount + 1] = normalDir;
+            normals[vertexCount + 1] = normalDirection;
             normals[vertexCount + 2] = 0.0f;
             normals[vertexCount + 3] = 0.0f;
-            normals[vertexCount + 4] = normalDir;
+            normals[vertexCount + 4] = normalDirection;
             normals[vertexCount + 5] = 0.0f;
             normals[vertexCount + 6] = 0.0f;
-            normals[vertexCount + 7] = normalDir;
+            normals[vertexCount + 7] = normalDirection;
             normals[vertexCount + 8] = 0.0f;
 
             texCoords[texCoordCount + 0] = s0;
@@ -199,7 +198,7 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
             texCoords[texCoordCount + 4] = s2;
             texCoords[texCoordCount + 5] = 1.0f;
 
-            if (normalDir > 0) {
+            if (normalDirection > 0) {
                 indices[indexCount + 0] = (char) (triangleCount + 1);
                 indices[indexCount + 1] = (char) (triangleCount + 0);
                 indices[indexCount + 2] = (char) (triangleCount + 2);
@@ -217,27 +216,28 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
     }
 
     private void createBody(float bottomRadius, float topRadius, float height,
-            int numStacks, int numSlices) {
+            int stackNumber, int sliceNumber) {
         float difference = bottomRadius - topRadius;
         float halfHeight = height / 2.0f;
 
-        for (int stack = 0; stack < numStacks; stack++) {
+        for (int stack = 0; stack < stackNumber; stack++) {
 
             int initVertexCount = vertexCount;
 
-            float stackPercentage0 = ((float) (stack) / numStacks);
-            float stackPercentage1 = ((float) (stack + 1) / numStacks);
+            float stackPercentage0 = ((float) (stack) / stackNumber);
+            float stackPercentage1 = ((float) (stack + 1) / stackNumber);
 
             float t0 = 1.0f - stackPercentage0;
             float t1 = 1.0f - stackPercentage1;
             float y0 = -halfHeight + (stackPercentage0 * height);
             float y1 = -halfHeight + (stackPercentage1 * height);
 
-            for (int slice = 0; slice < numSlices; slice++) {
-                float slicePercentage0 = ((float) (slice) / numSlices);
-                float slicePercentage1 = ((float) (slice + 1) / numSlices);
-                float theta0 = slicePercentage0 * 2.0f * (float) Math.PI;
-                float theta1 = slicePercentage1 * 2.0f * (float) Math.PI;
+            float nx, ny, nz;
+            for (int slice = 0; slice < sliceNumber; slice++) {
+                float slicePercentage0 = ((float) (slice) / sliceNumber);
+                float slicePercentage1 = ((float) (slice + 1) / sliceNumber);
+                double theta0 = slicePercentage0 * 2.0 * Math.PI;
+                double theta1 = slicePercentage1 * 2.0 * Math.PI;
                 float cosTheta0 = (float) Math.cos(theta0);
                 float sinTheta0 = (float) Math.sin(theta0);
                 float cosTheta1 = (float) Math.cos(theta1);
@@ -275,14 +275,13 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
                 vertices[vertexCount + 11] = z3;
 
                 // calculate normal
-
                 Vector3D v1 = new Vector3D(x1 - x0, 0, z1 - z0);
                 Vector3D v2 = new Vector3D(x2 - x0, y1 - y0, z2 - z0);
                 Vector3D v3 = v1.crossProduct(v2).normalize();
 
-                float nx = (float) v3.getX();
-                float ny = (float) v3.getY();
-                float nz = (float) v3.getZ();
+                nx = (float) v3.getX();
+                ny = (float) v3.getY();
+                nz = (float) v3.getZ();
                 normals[vertexCount + 0] = nx;
                 normals[vertexCount + 1] = ny;
                 normals[vertexCount + 2] = nz;
@@ -323,47 +322,66 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
             }
 
             for (int i = initVertexCount; i < vertexCount - 12; i += 12) {
-                Vector3D v1 = new Vector3D(normals[i + 3], normals[i + 4], normals[i + 5]);
-                Vector3D v2 = new Vector3D(normals[i + 12], normals[i + 13], normals[i + 14]);
+                Vector3D v1 = new Vector3D(normals[i + 3], normals[i + 4],
+                        normals[i + 5]);
+                Vector3D v2 = new Vector3D(normals[i + 12], normals[i + 13],
+                        normals[i + 14]);
                 Vector3D v3 = v1.add(v2).normalize();
-                normals[i + 3] = (float)v3.getX();
-                normals[i + 4] = (float)v3.getY();
-                normals[i + 5] = (float)v3.getZ();
-                normals[i + 12] = (float)v3.getX();
-                normals[i + 13] = (float)v3.getY();
-                normals[i + 14] = (float)v3.getZ();
+                nx = (float) v3.getX();
+                ny = (float) v3.getY();
+                nz = (float) v3.getZ();
+                normals[i + 3] = nx;
+                normals[i + 4] = ny;
+                normals[i + 5] = nz;
+                normals[i + 12] = nx;
+                normals[i + 13] = ny;
+                normals[i + 14] = nz;
 
-                v1 = new Vector3D(normals[i + 9], normals[i + 10], normals[i + 11]);
-                v2 = new Vector3D(normals[i + 18], normals[i + 19], normals[i + 20]);
+                v1 = new Vector3D(normals[i + 9], normals[i + 10],
+                        normals[i + 11]);
+                v2 = new Vector3D(normals[i + 18], normals[i + 19],
+                        normals[i + 20]);
                 v3 = v1.add(v2).normalize();
-                normals[i + 9] = (float)v3.getX();
-                normals[i + 10] = (float)v3.getY();
-                normals[i + 11] = (float)v3.getZ();
-                normals[i + 18] = (float)v3.getX();
-                normals[i + 19] = (float)v3.getY();
-                normals[i + 20] = (float)v3.getZ();
+                nx = (float) v3.getX();
+                ny = (float) v3.getY();
+                nz = (float) v3.getZ();
+                normals[i + 9] = nx;
+                normals[i + 10] = ny;
+                normals[i + 11] = nz;
+                normals[i + 18] = nx;
+                normals[i + 19] = ny;
+                normals[i + 20] = nz;
             }
-            int ia = vertexCount - 12;
-            Vector3D v1 = new Vector3D(normals[ia + 3], normals[ia + 4], normals[ia + 5]);
-            int ib = initVertexCount;
-            Vector3D v2 = new Vector3D(normals[ib + 0], normals[ib + 1], normals[ib + 2]);
+            int i1 = vertexCount - 12;
+            Vector3D v1 = new Vector3D(normals[i1 + 3], normals[i1 + 4],
+                    normals[i1 + 5]);
+            int i2 = initVertexCount;
+            Vector3D v2 = new Vector3D(normals[i2 + 0], normals[i2 + 1],
+                    normals[i2 + 2]);
             Vector3D v3 = v1.add(v2).normalize();
-            normals[ia + 3] = (float)v3.getX();
-            normals[ia + 4] = (float)v3.getY();
-            normals[ia + 5] = (float)v3.getZ();
-            normals[ib + 0] = (float)v3.getX();
-            normals[ib + 1] = (float)v3.getY();
-            normals[ib + 2] = (float)v3.getZ();
+            nx = (float) v3.getX();
+            ny = (float) v3.getY();
+            nz = (float) v3.getZ();
+            normals[i1 + 3] = nx;
+            normals[i1 + 4] = ny;
+            normals[i1 + 5] = nz;
+            normals[i2 + 0] = nx;
+            normals[i2 + 1] = ny;
+            normals[i2 + 2] = nz;
 
-            v1 = new Vector3D(normals[ia + 9], normals[ia + 10], normals[ia + 11]);
-            v2 = new Vector3D(normals[ib + 6], normals[ib + 7], normals[ib + 8]);
+            v1 = new Vector3D(normals[i1 + 9], normals[i1 + 10],
+                    normals[i1 + 11]);
+            v2 = new Vector3D(normals[i2 + 6], normals[i2 + 7], normals[i2 + 8]);
             v3 = v1.add(v2).normalize();
-            normals[ia + 9] = (float)v3.getX();
-            normals[ia + 10] = (float)v3.getY();
-            normals[ia + 11] = (float)v3.getZ();
-            normals[ib + 6] = (float)v3.getX();
-            normals[ib + 7] = (float)v3.getY();
-            normals[ib + 8] = (float)v3.getZ();
+            nx = (float) v3.getX();
+            ny = (float) v3.getY();
+            nz = (float) v3.getZ();
+            normals[i1 + 9] = nx;
+            normals[i1 + 10] = ny;
+            normals[i1 + 11] = nz;
+            normals[i2 + 6] = nx;
+            normals[i2 + 7] = ny;
+            normals[i2 + 8] = nz;
         }
     }
 }

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
@@ -15,6 +15,7 @@
 
 package org.gearvrf.scene_objects;
 
+import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRRenderData;
 import org.gearvrf.GVRContext;
@@ -23,7 +24,7 @@ import org.gearvrf.GVRMesh;
 public class GVRCylinderSceneObject extends GVRSceneObject {
 
     private static final String TAG = "GVRCylinderSceneObject";
-    private static final int NUM_STACKS = 2;
+    private static final int NUM_STACKS = 10;
     private static final int NUM_SLICES = 36;
     private static final float BASE_RADIUS = 0.5f;
     private static final float TOP_RADIUS = 0.5f;
@@ -215,28 +216,32 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
         }
     }
 
-    private void createBody(float bottomRadius, float topRadius, float height, int numStacks, int numSlices) {
+    private void createBody(float bottomRadius, float topRadius, float height,
+            int numStacks, int numSlices) {
         float difference = bottomRadius - topRadius;
         float halfHeight = height / 2.0f;
 
-        for(int stack = 0; stack < numStacks; stack++) {
-            float stackPercentage0 = ((float)(stack)/numStacks);
-            float stackPercentage1 = ((float)(stack+1)/numStacks);
+        for (int stack = 0; stack < numStacks; stack++) {
+
+            int initVertexCount = vertexCount;
+
+            float stackPercentage0 = ((float) (stack) / numStacks);
+            float stackPercentage1 = ((float) (stack + 1) / numStacks);
 
             float t0 = 1.0f - stackPercentage0;
             float t1 = 1.0f - stackPercentage1;
             float y0 = -halfHeight + (stackPercentage0 * height);
             float y1 = -halfHeight + (stackPercentage1 * height);
 
-            for(int slice = 0; slice < numSlices; slice++) {
-                float slicePercentage0 = ((float)(slice)/numSlices);
-                float slicePercentage1 = ((float)(slice+1)/numSlices);
-                float theta0 = slicePercentage0*2.0f*(float)Math.PI;
-                float theta1 = slicePercentage1*2.0f*(float)Math.PI;
-                float cosTheta0 = (float)Math.cos(theta0);
-                float sinTheta0 = (float)Math.sin(theta0);
-                float cosTheta1 = (float)Math.cos(theta1);
-                float sinTheta1 = (float)Math.sin(theta1);
+            for (int slice = 0; slice < numSlices; slice++) {
+                float slicePercentage0 = ((float) (slice) / numSlices);
+                float slicePercentage1 = ((float) (slice + 1) / numSlices);
+                float theta0 = slicePercentage0 * 2.0f * (float) Math.PI;
+                float theta1 = slicePercentage1 * 2.0f * (float) Math.PI;
+                float cosTheta0 = (float) Math.cos(theta0);
+                float sinTheta0 = (float) Math.sin(theta0);
+                float cosTheta1 = (float) Math.cos(theta1);
+                float sinTheta1 = (float) Math.sin(theta1);
 
                 float radius = (bottomRadius - (difference * stackPercentage0));
                 float x0 = radius * cosTheta0;
@@ -252,67 +257,113 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
 
                 float s0 = slicePercentage0;
                 float s1 = slicePercentage1;
-                
-                vertices[vertexCount+0] = x0;
-                vertices[vertexCount+1] = y0;
-                vertices[vertexCount+2] = z0;
 
-                vertices[vertexCount+3] = x1;
-                vertices[vertexCount+4] = y0;
-                vertices[vertexCount+5] = z1;
+                vertices[vertexCount + 0] = x0;
+                vertices[vertexCount + 1] = y0;
+                vertices[vertexCount + 2] = z0;
 
-                vertices[vertexCount+6] = x2;
-                vertices[vertexCount+7] = y1;
-                vertices[vertexCount+8] = z2;
+                vertices[vertexCount + 3] = x1;
+                vertices[vertexCount + 4] = y0;
+                vertices[vertexCount + 5] = z1;
 
-                vertices[vertexCount+9]  = x3;
-                vertices[vertexCount+10] = y1;
-                vertices[vertexCount+11] = z3;
+                vertices[vertexCount + 6] = x2;
+                vertices[vertexCount + 7] = y1;
+                vertices[vertexCount + 8] = z2;
+
+                vertices[vertexCount + 9] = x3;
+                vertices[vertexCount + 10] = y1;
+                vertices[vertexCount + 11] = z3;
 
                 // calculate normal
-                float length = (float) Math.sqrt(difference*difference + height*height);
-                float ratio = height / length;
-                float nx = (float) (ratio * sinTheta0);
-                float ny = (float) (ratio * cosTheta0);
-                float nz = difference / length;
-                normals[vertexCount+0] = nx; 
-                normals[vertexCount+1] = ny; 
-                normals[vertexCount+2] = nz;
-                normals[vertexCount+3] = nx;
-                normals[vertexCount+4] = ny; 
-                normals[vertexCount+5] = nz;
-                normals[vertexCount+6] = nx;
-                normals[vertexCount+7] = ny; 
-                normals[vertexCount+8] = nz;
-                normals[vertexCount+9] = nx;
-                normals[vertexCount+10] = ny;
-                normals[vertexCount+11] = nz;
 
-                texCoords[texCoordCount+0] = s0;
-                texCoords[texCoordCount+1] = t0;
+                Vector3D v1 = new Vector3D(x1 - x0, 0, z1 - z0);
+                Vector3D v2 = new Vector3D(x2 - x0, y1 - y0, z2 - z0);
+                Vector3D v3 = v1.crossProduct(v2).normalize();
 
-                texCoords[texCoordCount+2] = s1;
-                texCoords[texCoordCount+3] = t0;
+                float nx = (float) v3.getX();
+                float ny = (float) v3.getY();
+                float nz = (float) v3.getZ();
+                normals[vertexCount + 0] = nx;
+                normals[vertexCount + 1] = ny;
+                normals[vertexCount + 2] = nz;
+                normals[vertexCount + 3] = nx;
+                normals[vertexCount + 4] = ny;
+                normals[vertexCount + 5] = nz;
+                normals[vertexCount + 6] = nx;
+                normals[vertexCount + 7] = ny;
+                normals[vertexCount + 8] = nz;
+                normals[vertexCount + 9] = nx;
+                normals[vertexCount + 10] = ny;
+                normals[vertexCount + 11] = nz;
 
-                texCoords[texCoordCount+4] = s0;
-                texCoords[texCoordCount+5] = t1;
+                texCoords[texCoordCount + 0] = s0;
+                texCoords[texCoordCount + 1] = t0;
 
-                texCoords[texCoordCount+6] = s1;
-                texCoords[texCoordCount+7] = t1;
+                texCoords[texCoordCount + 2] = s1;
+                texCoords[texCoordCount + 3] = t0;
 
-                indices[indexCount+0] = (char) (triangleCount+0); // 0 
-                indices[indexCount+1] = (char) (triangleCount+1); // 1
-                indices[indexCount+2] = (char) (triangleCount+2); // 2
+                texCoords[texCoordCount + 4] = s0;
+                texCoords[texCoordCount + 5] = t1;
 
-                indices[indexCount+3] = (char) (triangleCount+2); // 2
-                indices[indexCount+4] = (char) (triangleCount+1); // 1
-                indices[indexCount+5] = (char) (triangleCount+3); // 3
+                texCoords[texCoordCount + 6] = s1;
+                texCoords[texCoordCount + 7] = t1;
+
+                indices[indexCount + 0] = (char) (triangleCount + 0); // 0
+                indices[indexCount + 1] = (char) (triangleCount + 1); // 1
+                indices[indexCount + 2] = (char) (triangleCount + 2); // 2
+
+                indices[indexCount + 3] = (char) (triangleCount + 2); // 2
+                indices[indexCount + 4] = (char) (triangleCount + 1); // 1
+                indices[indexCount + 5] = (char) (triangleCount + 3); // 3
 
                 vertexCount += 12;
                 texCoordCount += 8;
                 indexCount += 6;
                 triangleCount += 4;
             }
+
+            for (int i = initVertexCount; i < vertexCount - 12; i += 12) {
+                Vector3D v1 = new Vector3D(normals[i + 3], normals[i + 4], normals[i + 5]);
+                Vector3D v2 = new Vector3D(normals[i + 12], normals[i + 13], normals[i + 14]);
+                Vector3D v3 = v1.add(v2).normalize();
+                normals[i + 3] = (float)v3.getX();
+                normals[i + 4] = (float)v3.getY();
+                normals[i + 5] = (float)v3.getZ();
+                normals[i + 12] = (float)v3.getX();
+                normals[i + 13] = (float)v3.getY();
+                normals[i + 14] = (float)v3.getZ();
+
+                v1 = new Vector3D(normals[i + 9], normals[i + 10], normals[i + 11]);
+                v2 = new Vector3D(normals[i + 18], normals[i + 19], normals[i + 20]);
+                v3 = v1.add(v2).normalize();
+                normals[i + 9] = (float)v3.getX();
+                normals[i + 10] = (float)v3.getY();
+                normals[i + 11] = (float)v3.getZ();
+                normals[i + 18] = (float)v3.getX();
+                normals[i + 19] = (float)v3.getY();
+                normals[i + 20] = (float)v3.getZ();
+            }
+            int ia = vertexCount - 12;
+            Vector3D v1 = new Vector3D(normals[ia + 3], normals[ia + 4], normals[ia + 5]);
+            int ib = initVertexCount;
+            Vector3D v2 = new Vector3D(normals[ib + 0], normals[ib + 1], normals[ib + 2]);
+            Vector3D v3 = v1.add(v2).normalize();
+            normals[ia + 3] = (float)v3.getX();
+            normals[ia + 4] = (float)v3.getY();
+            normals[ia + 5] = (float)v3.getZ();
+            normals[ib + 0] = (float)v3.getX();
+            normals[ib + 1] = (float)v3.getY();
+            normals[ib + 2] = (float)v3.getZ();
+
+            v1 = new Vector3D(normals[ia + 9], normals[ia + 10], normals[ia + 11]);
+            v2 = new Vector3D(normals[ib + 6], normals[ib + 7], normals[ib + 8]);
+            v3 = v1.add(v2).normalize();
+            normals[ia + 9] = (float)v3.getX();
+            normals[ia + 10] = (float)v3.getY();
+            normals[ia + 11] = (float)v3.getZ();
+            normals[ib + 6] = (float)v3.getX();
+            normals[ib + 7] = (float)v3.getY();
+            normals[ib + 8] = (float)v3.getZ();
         }
     }
 }

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRSphereSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRSphereSceneObject.java
@@ -23,8 +23,8 @@ import org.gearvrf.GVRMesh;
 public class GVRSphereSceneObject extends GVRSceneObject {
 
     private static final String TAG = "GVRSphereSceneObject";
-    private static final int NUM_STACKS = 18;
-    private static final int NUM_SLICES = 36;
+    private static final int STACK_NUMBER = 18;
+    private static final int SLICE_NUMBER = 36;
 
     private float[] vertices;
     private float[] normals;
@@ -46,7 +46,7 @@ public class GVRSphereSceneObject extends GVRSceneObject {
     public GVRSphereSceneObject(GVRContext gvrContext) {
         super(gvrContext);
 
-        generateSphere(NUM_STACKS, NUM_SLICES);
+        generateSphere(STACK_NUMBER, SLICE_NUMBER);
 
         GVRMesh mesh = new GVRMesh(gvrContext);
         mesh.setVertices(vertices);
@@ -59,55 +59,57 @@ public class GVRSphereSceneObject extends GVRSceneObject {
         renderData.setMesh(mesh);
     }
 
-    private void generateSphere(int numStacks, int numSlices) {
-        int capNumVertices = 3 * numSlices;
-        int bodyNumVertices = 4 * numSlices * numStacks;
-        int numVertices = (2 * capNumVertices) + bodyNumVertices;
-        int numTriangles = (2 * capNumVertices) + (6 * numSlices * numStacks);
+    private void generateSphere(int stackNumber, int sliceNumber) {
+        int capVertexNumber = 3 * sliceNumber;
+        int bodyVertexNumber = 4 * sliceNumber * stackNumber;
+        int vertexNumber = (2 * capVertexNumber) + bodyVertexNumber;
+        int triangleNumber = (2 * capVertexNumber)
+                + (6 * sliceNumber * stackNumber);
 
-        vertices = new float[3 * numVertices];
-        normals = new float[3 * numVertices];
-        texCoords = new float[2 * numVertices];
-        indices = new char[numTriangles];
+        vertices = new float[3 * vertexNumber];
+        normals = new float[3 * vertexNumber];
+        texCoords = new float[2 * vertexNumber];
+        indices = new char[triangleNumber];
 
         // bottom cap
-        createCap(0, numStacks, numSlices, false);
+        createCap(0, stackNumber, sliceNumber, false);
 
         // body
-        createBody(numStacks, numSlices);
+        createBody(stackNumber, sliceNumber);
 
         // top cap
-        createCap(numStacks, numStacks, numSlices, true);
+        createCap(stackNumber, stackNumber, sliceNumber, true);
     }
 
-    private void createCap(int stack, int numStacks, int numSlices, boolean top) {
+    private void createCap(int stack, int stackNumber, int sliceNumber,
+            boolean top) {
 
         float stackPercentage0;
         float stackPercentage1;
 
         if (top) {
-            stackPercentage0 = ((float) (stack - 1) / numStacks);
-            stackPercentage1 = ((float) (stack) / numStacks);
+            stackPercentage0 = ((float) (stack - 1) / stackNumber);
+            stackPercentage1 = ((float) (stack) / stackNumber);
 
         } else {
-            stackPercentage0 = ((float) (stack + 1) / numStacks);
-            stackPercentage1 = ((float) (stack) / numStacks);
+            stackPercentage0 = ((float) (stack + 1) / stackNumber);
+            stackPercentage1 = ((float) (stack) / stackNumber);
         }
 
         float t0 = 1.0f - stackPercentage0;
         float t1 = 1.0f - stackPercentage1;
-        float theta1 = stackPercentage0 * (float) Math.PI;
-        float theta2 = stackPercentage1 * (float) Math.PI;
+        double theta1 = stackPercentage0 * Math.PI;
+        double theta2 = stackPercentage1 * Math.PI;
         float cosTheta1 = (float) Math.cos(theta1);
         float sinTheta1 = (float) Math.sin(theta1);
         float cosTheta2 = (float) Math.cos(theta2);
         float sinTheta2 = (float) Math.sin(theta2);
 
-        for (int slice = 0; slice < numSlices; slice++) {
-            float slicePercentage0 = ((float) (slice) / numSlices);
-            float slicePercentage1 = ((float) (slice + 1) / numSlices);
-            float phi1 = slicePercentage0 * 2.0f * (float) Math.PI;
-            float phi2 = slicePercentage1 * 2.0f * (float) Math.PI;
+        for (int slice = 0; slice < sliceNumber; slice++) {
+            float slicePercentage0 = ((float) (slice) / sliceNumber);
+            float slicePercentage1 = ((float) (slice + 1) / sliceNumber);
+            double phi1 = slicePercentage0 * 2.0 * Math.PI;
+            double phi2 = slicePercentage1 * 2.0 * Math.PI;
             float s0 = slicePercentage0;
             float s1 = slicePercentage1;
             float s2 = (s0 + s1) / 2.0f;
@@ -177,25 +179,25 @@ public class GVRSphereSceneObject extends GVRSceneObject {
 
     }
 
-    private void createBody(int numStacks, int numSlices) {
-        for (int stack = 1; stack < numStacks - 1; stack++) {
-            float stackPercentage0 = ((float) (stack) / numStacks);
-            float stackPercentage1 = ((float) (stack + 1) / numStacks);
+    private void createBody(int stackNumber, int sliceNumber) {
+        for (int stack = 1; stack < stackNumber - 1; stack++) {
+            float stackPercentage0 = ((float) (stack) / stackNumber);
+            float stackPercentage1 = ((float) (stack + 1) / stackNumber);
 
             float t0 = 1.0f - stackPercentage0;
             float t1 = 1.0f - stackPercentage1;
-            float theta1 = stackPercentage0 * (float) Math.PI;
-            float theta2 = stackPercentage1 * (float) Math.PI;
+            double theta1 = stackPercentage0 * Math.PI;
+            double theta2 = stackPercentage1 * Math.PI;
             float cosTheta1 = (float) Math.cos(theta1);
             float sinTheta1 = (float) Math.sin(theta1);
             float cosTheta2 = (float) Math.cos(theta2);
             float sinTheta2 = (float) Math.sin(theta2);
 
-            for (int slice = 0; slice < numSlices; slice++) {
-                float slicePercentage0 = ((float) (slice) / numSlices);
-                float slicePercentage1 = ((float) (slice + 1) / numSlices);
-                float phi1 = slicePercentage0 * 2.0f * (float) Math.PI;
-                float phi2 = slicePercentage1 * 2.0f * (float) Math.PI;
+            for (int slice = 0; slice < sliceNumber; slice++) {
+                float slicePercentage0 = ((float) (slice) / sliceNumber);
+                float slicePercentage1 = ((float) (slice + 1) / sliceNumber);
+                double phi1 = slicePercentage0 * 2.0 * Math.PI;
+                double phi2 = slicePercentage1 * 2.0 * Math.PI;
                 float s0 = slicePercentage0;
                 float s1 = slicePercentage1;
                 float cosPhi1 = (float) Math.cos(phi1);

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRSphereSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRSphereSceneObject.java
@@ -100,10 +100,10 @@ public class GVRSphereSceneObject extends GVRSceneObject {
         float t1 = 1.0f - stackPercentage1;
         double theta1 = stackPercentage0 * Math.PI;
         double theta2 = stackPercentage1 * Math.PI;
-        float cosTheta1 = (float) Math.cos(theta1);
-        float sinTheta1 = (float) Math.sin(theta1);
-        float cosTheta2 = (float) Math.cos(theta2);
-        float sinTheta2 = (float) Math.sin(theta2);
+        double cosTheta1 = Math.cos(theta1);
+        double sinTheta1 = Math.sin(theta1);
+        double cosTheta2 = Math.cos(theta2);
+        double sinTheta2 = Math.sin(theta2);
 
         for (int slice = 0; slice < sliceNumber; slice++) {
             float slicePercentage0 = ((float) (slice) / sliceNumber);
@@ -113,22 +113,22 @@ public class GVRSphereSceneObject extends GVRSceneObject {
             float s0 = slicePercentage0;
             float s1 = slicePercentage1;
             float s2 = (s0 + s1) / 2.0f;
-            float cosPhi1 = (float) Math.cos(phi1);
-            float sinPhi1 = (float) Math.sin(phi1);
-            float cosPhi2 = (float) Math.cos(phi2);
-            float sinPhi2 = (float) Math.sin(phi2);
+            double cosPhi1 = Math.cos(phi1);
+            double sinPhi1 = Math.sin(phi1);
+            double cosPhi2 = Math.cos(phi2);
+            double sinPhi2 = Math.sin(phi2);
 
-            float x0 = sinTheta1 * cosPhi1;
-            float y0 = sinTheta1 * sinPhi1;
-            float z0 = cosTheta1;
+            float x0 = (float) (sinTheta1 * cosPhi1);
+            float y0 = (float) (sinTheta1 * sinPhi1);
+            float z0 = (float) cosTheta1;
 
-            float x1 = sinTheta1 * cosPhi2;
-            float y1 = sinTheta1 * sinPhi2;
-            float z1 = cosTheta1;
+            float x1 = (float) (sinTheta1 * cosPhi2);
+            float y1 = (float) (sinTheta1 * sinPhi2);
+            float z1 = (float) cosTheta1;
 
-            float x2 = sinTheta2 * cosPhi1;
-            float y2 = sinTheta2 * sinPhi1;
-            float z2 = cosTheta2;
+            float x2 = (float) (sinTheta2 * cosPhi1);
+            float y2 = (float) (sinTheta2 * sinPhi1);
+            float z2 = (float) cosTheta2;
 
             vertices[vertexCount + 0] = x0;
             vertices[vertexCount + 1] = y0;
@@ -188,10 +188,10 @@ public class GVRSphereSceneObject extends GVRSceneObject {
             float t1 = 1.0f - stackPercentage1;
             double theta1 = stackPercentage0 * Math.PI;
             double theta2 = stackPercentage1 * Math.PI;
-            float cosTheta1 = (float) Math.cos(theta1);
-            float sinTheta1 = (float) Math.sin(theta1);
-            float cosTheta2 = (float) Math.cos(theta2);
-            float sinTheta2 = (float) Math.sin(theta2);
+            double cosTheta1 = Math.cos(theta1);
+            double sinTheta1 = Math.sin(theta1);
+            double cosTheta2 = Math.cos(theta2);
+            double sinTheta2 = Math.sin(theta2);
 
             for (int slice = 0; slice < sliceNumber; slice++) {
                 float slicePercentage0 = ((float) (slice) / sliceNumber);
@@ -200,29 +200,29 @@ public class GVRSphereSceneObject extends GVRSceneObject {
                 double phi2 = slicePercentage1 * 2.0 * Math.PI;
                 float s0 = slicePercentage0;
                 float s1 = slicePercentage1;
-                float cosPhi1 = (float) Math.cos(phi1);
-                float sinPhi1 = (float) Math.sin(phi1);
-                float cosPhi2 = (float) Math.cos(phi2);
-                float sinPhi2 = (float) Math.sin(phi2);
+                double cosPhi1 = Math.cos(phi1);
+                double sinPhi1 = Math.sin(phi1);
+                double cosPhi2 = Math.cos(phi2);
+                double sinPhi2 = Math.sin(phi2);
 
                 // 2-----3
                 // |     |
                 // 0-----1
-                float x0 = sinTheta1 * cosPhi1;
-                float y0 = sinTheta1 * sinPhi1;
-                float z0 = cosTheta1;
+                float x0 = (float) (sinTheta1 * cosPhi1);
+                float y0 = (float) (sinTheta1 * sinPhi1);
+                float z0 = (float) cosTheta1;
 
-                float x1 = sinTheta1 * cosPhi2;
-                float y1 = sinTheta1 * sinPhi2;
-                float z1 = cosTheta1;
+                float x1 = (float) (sinTheta1 * cosPhi2);
+                float y1 = (float) (sinTheta1 * sinPhi2);
+                float z1 = (float) cosTheta1;
 
-                float x2 = sinTheta2 * cosPhi1;
-                float y2 = sinTheta2 * sinPhi1;
-                float z2 = cosTheta2;
+                float x2 = (float) (sinTheta2 * cosPhi1);
+                float y2 = (float) (sinTheta2 * sinPhi1);
+                float z2 = (float) cosTheta2;
 
-                float x3 = sinTheta2 * cosPhi2;
-                float y3 = sinTheta2 * sinPhi2;
-                float z3 = cosTheta2;
+                float x3 = (float) (sinTheta2 * cosPhi2);
+                float y3 = (float) (sinTheta2 * sinPhi2);
+                float z3 = (float) cosTheta2;
 
                 vertices[vertexCount + 0] = x0;
                 vertices[vertexCount + 1] = y0;

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRSphereSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRSphereSceneObject.java
@@ -160,12 +160,12 @@ public class GVRSphereSceneObject extends GVRSceneObject {
             texCoords[texCoordCount + 5] = t1;
 
             if (top) {
-                indices[indexCount + 0] = (char) (triangleCount + 0);
-                indices[indexCount + 1] = (char) (triangleCount + 1);
-                indices[indexCount + 2] = (char) (triangleCount + 2);
-            } else {
                 indices[indexCount + 0] = (char) (triangleCount + 1);
                 indices[indexCount + 1] = (char) (triangleCount + 0);
+                indices[indexCount + 2] = (char) (triangleCount + 2);
+            } else {
+                indices[indexCount + 0] = (char) (triangleCount + 0);
+                indices[indexCount + 1] = (char) (triangleCount + 1);
                 indices[indexCount + 2] = (char) (triangleCount + 2);
             }
 
@@ -204,7 +204,7 @@ public class GVRSphereSceneObject extends GVRSceneObject {
                 float sinPhi2 = (float) Math.sin(phi2);
 
                 // 2-----3
-                // | |
+                // |     |
                 // 0-----1
                 float x0 = sinTheta1 * cosPhi1;
                 float y0 = sinTheta1 * sinPhi1;
@@ -266,11 +266,11 @@ public class GVRSphereSceneObject extends GVRSceneObject {
                 // 0, 1, 2
                 // 2, 1, 3
                 indices[indexCount + 0] = (char) (triangleCount + 0);
-                indices[indexCount + 1] = (char) (triangleCount + 1);
-                indices[indexCount + 2] = (char) (triangleCount + 2);
+                indices[indexCount + 1] = (char) (triangleCount + 2);
+                indices[indexCount + 2] = (char) (triangleCount + 1);
                 indices[indexCount + 3] = (char) (triangleCount + 2);
-                indices[indexCount + 4] = (char) (triangleCount + 1);
-                indices[indexCount + 5] = (char) (triangleCount + 3);
+                indices[indexCount + 4] = (char) (triangleCount + 3);
+                indices[indexCount + 5] = (char) (triangleCount + 1);
 
                 vertexCount += 12;
                 texCoordCount += 8;


### PR DESCRIPTION
* Corrected normals for cylinder and sphere.
* Moved reflection calcutation from vertex shader to fragment shader,
so that the results look better for curved surfaces.
* Increased the threshold in pick-and-move demo a little, so that it
is easier to click.

GearVRf-DCO-1.0-Signed-off-by: Guodong Rong
rongguodong@hotmail.com