### PR TITLE
Fix a 'mandelbug' in async loading.

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRAndroidResource.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRAndroidResource.java
@@ -86,12 +86,7 @@ public class GVRAndroidResource {
      *             File doesn't exist, or can't be read.
      */
     public GVRAndroidResource(File file) throws FileNotFoundException {
-        stream = new MarkingFileInputStream(file);
-        debugState = DebugStates.OPEN;
-
-        filePath = file.getAbsolutePath();
-        resourceId = 0; // No R.whatever field will ever be 0
-        assetPath = null;
+        this(file.getAbsolutePath());
     }
 
     /**
@@ -179,6 +174,12 @@ public class GVRAndroidResource {
         return stream;
     }
 
+    /*
+     * TODO Should we somehow expose the CLOSED state? Return null or throw an
+     * exception from getStream()? Or is it enough for the calling code to fail,
+     * reading a closed stream?
+     */
+
     /**
      * Close the open stream.
      * 
@@ -192,7 +193,6 @@ public class GVRAndroidResource {
             debugState = DebugStates.CLOSED;
             stream.close();
         } catch (IOException e) {
-            // Auto-generated catch block
             e.printStackTrace();
         }
     }

--- a/GVRf/Framework/src/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRContext.java
@@ -200,10 +200,24 @@ public abstract class GVRContext {
      *            {@link GVRAndroidResource} class has six constructors to
      *            handle a wide variety of Android resource types. Taking a
      *            {@code GVRAndroidResource} here eliminates six overloads.
-     * 
      * @throws IllegalArgumentException
-     *             If either parameter is {@code null}
-     * 
+     *             If either parameter is {@code null} or if you 'abuse' request
+     *             consolidation by passing the same {@link GVRAndroidResource}
+     *             descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      * @since 1.6.2
      */
     public void loadMesh(MeshCallback callback,
@@ -260,8 +274,23 @@ public abstract class GVRContext {
      * 
      * @throws IllegalArgumentException
      *             If either {@code callback} or {@code resource} is
-     *             {@code null}, or if {@code priority} is out of range.
-     * 
+     *             {@code null}, or if {@code priority} is out of range - or if
+     *             you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      * @since 1.6.2
      */
     public void loadMesh(MeshCallback callback, GVRAndroidResource resource,
@@ -289,6 +318,24 @@ public abstract class GVRContext {
      *         {@link GVRRenderData#setMesh(Future)}
      * 
      * @since 1.6.7
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public Future<GVRMesh> loadFutureMesh(GVRAndroidResource resource) {
         return loadFutureMesh(resource, DEFAULT_PRIORITY);
@@ -316,6 +363,24 @@ public abstract class GVRContext {
      *         {@link GVRRenderData#setMesh(Future)}
      * 
      * @since 1.6.7
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public Future<GVRMesh> loadFutureMesh(GVRAndroidResource resource,
             int priority) {
@@ -341,11 +406,12 @@ public abstract class GVRContext {
                 width * 0.5f, height * -0.5f, 0.0f };
         mesh.setVertices(vertices);
 
-        final float[] normals = { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
-                1.0f, 0.0f, 0.0f, 1.0f };
+        final float[] normals = { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
+                0.0f, 1.0f, 0.0f, 0.0f, 1.0f };
         mesh.setNormals(normals);
 
-        final float[] texCoords = { 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f, 1.0f };
+        final float[] texCoords = { 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f,
+                1.0f };
         mesh.setTexCoords(texCoords);
 
         char[] triangles = { 0, 1, 2, 1, 3, 2 };
@@ -611,6 +677,24 @@ public abstract class GVRContext {
      *            {@link GVRAndroidResource} class has six constructors to
      *            handle a wide variety of Android resource types. Taking a
      *            {@code GVRAndroidResource} here eliminates six overloads.
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public void loadBitmapTexture(BitmapTextureCallback callback,
             GVRAndroidResource resource) {
@@ -684,7 +768,23 @@ public abstract class GVRContext {
      * @throws IllegalArgumentException
      *             If {@code priority} {@literal <} {@link #LOWEST_PRIORITY} or
      *             {@literal >} {@link #HIGHEST_PRIORITY}, or either of the
-     *             other parameters is {@code null}
+     *             other parameters is {@code null} - or if you 'abuse' request
+     *             consolidation by passing the same {@link GVRAndroidResource}
+     *             descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public void loadBitmapTexture(BitmapTextureCallback callback,
             GVRAndroidResource resource, int priority)
@@ -718,6 +818,24 @@ public abstract class GVRContext {
      *            {@link GVRAndroidResource} class has six constructors to
      *            handle a wide variety of Android resource types. Taking a
      *            {@code GVRAndroidResource} here eliminates six overloads.
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public void loadCompressedTexture(CompressedTextureCallback callback,
             GVRAndroidResource resource) {
@@ -750,6 +868,24 @@ public abstract class GVRContext {
      *            {@link GVRCompressedTexture#BALANCED}, or
      *            {@link GVRCompressedTexture#QUALITY}, but other values are
      *            'clamped' to one of the recognized values.
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public void loadCompressedTexture(CompressedTextureCallback callback,
             GVRAndroidResource resource, int quality) {
@@ -820,6 +956,24 @@ public abstract class GVRContext {
      *            {@code GVRAndroidResource} here eliminates six overloads.
      * 
      * @since 1.6.7
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public void loadTexture(TextureCallback callback,
             GVRAndroidResource resource) {
@@ -895,6 +1049,24 @@ public abstract class GVRContext {
      *            request scheduler.
      * 
      * @since 1.6.7
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public void loadTexture(TextureCallback callback,
             GVRAndroidResource resource, int priority) {
@@ -975,6 +1147,24 @@ public abstract class GVRContext {
      *            quality parameter.
      * 
      * @since 1.6.7
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public void loadTexture(TextureCallback callback,
             GVRAndroidResource resource, int priority, int quality) {
@@ -1020,6 +1210,24 @@ public abstract class GVRContext {
      *         {@link GVRShaders#setMainTexture(Future)}
      * 
      * @since 1.6.7
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public Future<GVRTexture> loadFutureTexture(GVRAndroidResource resource) {
         return loadFutureTexture(resource, DEFAULT_PRIORITY);
@@ -1070,6 +1278,24 @@ public abstract class GVRContext {
      *         {@link GVRShaders#setMainTexture(Future)}
      * 
      * @since 1.6.7
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public Future<GVRTexture> loadFutureTexture(GVRAndroidResource resource,
             int priority) {
@@ -1129,6 +1355,24 @@ public abstract class GVRContext {
      *         {@link GVRShaders#setMainTexture(Future)}
      * 
      * @since 1.6.7
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public Future<GVRTexture> loadFutureTexture(GVRAndroidResource resource,
             int priority, int quality) {
@@ -1149,9 +1393,27 @@ public abstract class GVRContext {
      *            "posz.png", and "negz.png", which can be changed by calling
      *            {@link GVRCubemapTexture#setFaceNames(String[])}.
      * @return A {@link Future} that you can pass to methods like
-     *          {@link GVRShaders#setMainTexture(Future)}
+     *         {@link GVRShaders#setMainTexture(Future)}
      * 
      * @since 1.6.9
+     * 
+     * @throws IllegalArgumentException
+     *             If you 'abuse' request consolidation by passing the same
+     *             {@link GVRAndroidResource} descriptor to multiple load calls.
+     *             <p>
+     *             It's fairly common for multiple scene objects to use the same
+     *             texture or the same mesh. Thus, if you try to load, say,
+     *             {@code R.raw.whatever} while you already have a pending
+     *             request for {@code R.raw.whatever}, it will only be loaded
+     *             once; the same resource will be used to satisfy both (all)
+     *             requests. This "consolidation" uses
+     *             {@link GVRAndroidResource#equals(Object)}, <em>not</em>
+     *             {@code ==} (aka "reference equality"): The problem with using
+     *             the same resource descriptor is that if requests can't be
+     *             consolidated (because the later one(s) came in after the
+     *             earlier one(s) had already completed) the resource will be
+     *             reloaded ... but the original descriptor will have been
+     *             closed.
      */
     public Future<GVRTexture> loadFutureCubemapTexture(
             GVRAndroidResource resource) {

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncBitmapTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncBitmapTexture.java
@@ -600,10 +600,12 @@ abstract class AsyncBitmapTexture {
                 || requestedHeight == 0 //
                 || sampledWidth <= Math.abs(requestedWidth)
                 || sampledHeight <= Math.abs(requestedHeight)) {
-            Log.d(TAG,
-                    "Can't use slice decoder: sampledWidth = %.0f, requestedWidth = %d; sampledHeight = %.0f, requestedHeight = %d",
-                    sampledWidth, requestedWidth, sampledHeight,
-                    requestedHeight);
+            if (VERBOSE_DECODE) {
+                Log.d(TAG,
+                        "Can't use slice decoder: sampledWidth = %.0f, requestedWidth = %d; sampledHeight = %.0f, requestedHeight = %d",
+                        sampledWidth, requestedWidth, sampledHeight,
+                        requestedHeight);
+            }
             return shim.decode(options);
         }
 

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/Throttler.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/Throttler.java
@@ -294,7 +294,9 @@ abstract class Throttler {
                 Class<? extends GVRHybridObject> outClass,
                 CancelableCallback<? extends GVRHybridObject> callback,
                 GVRAndroidResource request, int priority) {
-            Log.d(TAG, "registerCallback(%s, %s)", request, callback);
+            if (VERBOSE_SCHEDULING) {
+                Log.d(TAG, "registerCallback(%s, %s)", request, callback);
+            }
             if (RUNTIME_ASSERTIONS) {
                 if (request == null) {
                     throw Exceptions
@@ -312,6 +314,11 @@ abstract class Throttler {
                 PendingRequest pending = pendingRequests.get(request);
 
                 if (pending != null) {
+                    if (request == pending.request) {
+                        throw new IllegalArgumentException(
+                                "Tried to load the same GVRAndroidResource more than once - each async load call should use a new GVRAndroidResource");
+                    }
+
                     // There is already a request for this resource: add
                     // callback, and reschedule
 

--- a/GVRf/Sample/solar-system/src/org/gearvrf/solarsystem/SolarViewManager.java
+++ b/GVRf/Sample/solar-system/src/org/gearvrf/solarsystem/SolarViewManager.java
@@ -39,9 +39,9 @@ public class SolarViewManager extends GVRScript {
     private GVRAnimationEngine mAnimationEngine;
 
     private GVRSceneObject asyncSceneObject(GVRContext context,
-            GVRAndroidResource meshResource, String textureName)
-            throws IOException {
-        return new GVRSceneObject(context, meshResource,
+            String textureName) throws IOException {
+        return new GVRSceneObject(context, //
+                new GVRAndroidResource(context, "sphere.obj"), //
                 new GVRAndroidResource(context, textureName));
     }
 
@@ -61,7 +61,7 @@ public class SolarViewManager extends GVRScript {
         });
 
         mainScene.setFrustumCulling(true);
-        
+
         mainScene.getMainCameraRig().getLeftCamera()
                 .setBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
         mainScene.getMainCameraRig().getRightCamera()
@@ -76,11 +76,8 @@ public class SolarViewManager extends GVRScript {
         GVRSceneObject sunRotationObject = new GVRSceneObject(gvrContext);
         solarSystemObject.addChildObject(sunRotationObject);
 
-        GVRAndroidResource meshResource = new GVRAndroidResource(gvrContext,
-                "sphere.obj");
-
         GVRSceneObject sunMeshObject = asyncSceneObject(gvrContext,
-                meshResource, "sunmap.astc");
+                "sunmap.astc");
         sunMeshObject.getTransform().setPosition(0.0f, 0.0f, 0.0f);
         sunMeshObject.getTransform().setScale(10.0f, 10.0f, 10.0f);
         sunRotationObject.addChildObject(sunMeshObject);
@@ -93,7 +90,7 @@ public class SolarViewManager extends GVRScript {
         mercuryRevolutionObject.addChildObject(mercuryRotationObject);
 
         GVRSceneObject mercuryMeshObject = asyncSceneObject(gvrContext,
-                meshResource, "mercurymap.jpg");
+                "mercurymap.jpg");
         mercuryMeshObject.getTransform().setScale(0.3f, 0.3f, 0.3f);
         mercuryRotationObject.addChildObject(mercuryMeshObject);
 
@@ -105,7 +102,7 @@ public class SolarViewManager extends GVRScript {
         venusRevolutionObject.addChildObject(venusRotationObject);
 
         GVRSceneObject venusMeshObject = asyncSceneObject(gvrContext,
-                meshResource, "venusmap.jpg");
+                "venusmap.jpg");
         venusMeshObject.getTransform().setScale(0.8f, 0.8f, 0.8f);
         venusRotationObject.addChildObject(venusMeshObject);
 
@@ -117,7 +114,7 @@ public class SolarViewManager extends GVRScript {
         earthRevolutionObject.addChildObject(earthRotationObject);
 
         GVRSceneObject earthMeshObject = asyncSceneObject(gvrContext,
-                meshResource, "earthmap1k.jpg");
+                "earthmap1k.jpg");
         earthMeshObject.getTransform().setScale(1.0f, 1.0f, 1.0f);
         earthRotationObject.addChildObject(earthMeshObject);
 
@@ -135,7 +132,7 @@ public class SolarViewManager extends GVRScript {
         marsRevolutionObject.addChildObject(marsRotationObject);
 
         GVRSceneObject marsMeshObject = asyncSceneObject(gvrContext,
-                meshResource, "mars_1k_color.jpg");
+                "mars_1k_color.jpg");
         marsMeshObject.getTransform().setScale(0.6f, 0.6f, 0.6f);
         marsRotationObject.addChildObject(marsMeshObject);
 


### PR DESCRIPTION
The root cause of the bug was using the same GVRAndroidResource in
multiple load calls. This is now illegal, as it is problematic in
another way, as well: If the later request(s) can't be consolidated
with the earlier request(s) (because the earlier request(s) have
already been completed) the later request(s) will reload the
resource ... using a closed stream.

The proximate cause of the bug was the way that the
private FutureResource class (in GVRAsynchronousResourceLoader)
was using the user-supplied GVRAndroidResource for
synchronization. This has now been corrected, so that each
FutureResource uses a unique, private Object for synchronization.

Also cuts a bit of log spam, and fixes one or two minor issues
I ran into while tracking down the mandelbug.

GearVRf-DCO-1.0-Signed-off-by: Jon Shemitz
j.shemitz@samsung.com