### PR TITLE
Add resource caching.

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRVersion.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRVersion.java
@@ -85,5 +85,8 @@ public class GVRVersion {
      */
     public static final String V_2_0_1 = "2.0.1";
 
-    public static final String CURRENT = V_2_0_1;
+    /** Resource caching */
+    public static final String V_2_0_2 = "2.0.2";
+
+    public static final String CURRENT = V_2_0_2;
 }

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/Throttler.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/Throttler.java
@@ -328,6 +328,9 @@ abstract class Throttler {
                                 threadId(), pending, request);
                     }
                     threadLimiter.reschedule(pending);
+
+                    // No one will ever read this stream
+                    request.closeStream();
                 } else {
                     // There is no current request for this resource. Create a
                     // new PendingRequest, using a threadFactory to create the

--- a/GVRf/Framework/src/org/gearvrf/utility/ResourceCache.java
+++ b/GVRf/Framework/src/org/gearvrf/utility/ResourceCache.java
@@ -1,0 +1,172 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf.utility;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.gearvrf.GVRAndroidResource;
+import org.gearvrf.GVRAndroidResource.BitmapTextureCallback;
+import org.gearvrf.GVRAndroidResource.CompressedTextureCallback;
+import org.gearvrf.GVRHybridObject;
+import org.gearvrf.GVRAndroidResource.Callback;
+import org.gearvrf.GVRAndroidResource.CancelableCallback;
+import org.gearvrf.GVRTexture;
+
+/**
+ * Basic cache-by-resource-description.
+ * 
+ * Keeps system from reloading resources, so long as a previous copy is still in
+ * memory. Generic, so there can be separate caches for meshes and textures: a
+ * 'unified cache' (mapping resource to hybrid-object) with hooks in
+ * {@link org.gearvrf.asynchronous.Throttler Throttler} would not be safe.
+ * Passing the descriptor for a cached mesh to a get-texture call would return
+ * the mesh ....
+ * 
+ * @since 2.0.2
+ */
+public class ResourceCache<T extends GVRHybridObject> {
+    // private static final String TAG = Log.tag(ResourceCache.class);
+
+    private final Map<GVRAndroidResource, WeakReference<T>> cache //
+    = new HashMap<GVRAndroidResource, WeakReference<T>>();
+
+    /** Save a weak reference to the resource */
+    public void put(GVRAndroidResource androidResource, T resource) {
+        // Log.d(TAG, "put(%s) saving %s", androidResource, resource);
+
+        cache.put(androidResource, new WeakReference<T>(resource));
+    }
+
+    /** Get the cached resource, or {@code null} */
+    public T get(GVRAndroidResource androidResource) {
+        WeakReference<T> reference = cache.get(androidResource);
+        if (reference == null) {
+            // Not in map
+            // Log.d(TAG, "get(%s) returning %s", androidResource, null);
+            return null;
+        }
+        T cached = reference.get();
+        if (cached == null) {
+            // In map, but not in memory
+            cache.remove(androidResource);
+        } else {
+            // No one will ever read this stream
+            androidResource.closeStream();
+        }
+        // Log.d(TAG, "get(%s) returning %s", androidResource, cached);
+        return cached;
+    }
+
+    /**
+     * Wrap the callback, to cache the
+     * {@link Callback#loaded(GVRHybridObject, GVRAndroidResource) loaded()}
+     * resource
+     */
+    public Callback<T> wrapCallback(Callback<T> callback) {
+        return new CallbackWrapper<T>(this, callback);
+    }
+
+    /**
+     * Wrap the callback, to cache the
+     * {@link CancelableCallback#loaded(GVRHybridObject, GVRAndroidResource)
+     * loaded()} resource
+     */
+    public CancelableCallback<T> wrapCallback(CancelableCallback<T> callback) {
+        return new CancelableCallbackWrapper<T>(this, callback);
+    }
+
+    /**
+     * Wrap the callback, to cache the
+     * {@link CompressedTextureCallback#loaded(GVRHybridObject, GVRAndroidResource)
+     * loaded()} resource
+     */
+    public static CompressedTextureCallback wrapCallback(
+            ResourceCache<GVRTexture> cache, CompressedTextureCallback callback) {
+        return new CompressedTextureCallbackWrapper(cache, callback);
+    }
+
+    /**
+     * Wrap the callback, to cache the
+     * {@link BitmapTextureCallback#loaded(GVRHybridObject, GVRAndroidResource)
+     * loaded()} resource
+     */
+    public static BitmapTextureCallback wrapCallback(
+            ResourceCache<GVRTexture> cache, BitmapTextureCallback callback) {
+        return new BitmapTextureCallbackWrapper(cache, callback);
+    }
+
+    private static class CallbackWrapper<T extends GVRHybridObject> implements
+            Callback<T> {
+
+        protected final ResourceCache<T> cache;
+        protected final Callback<T> callback;
+
+        CallbackWrapper(ResourceCache<T> cache, Callback<T> callback) {
+            Assert.checkNotNull("cache", cache);
+            Assert.checkNotNull("callback", callback);
+
+            this.cache = cache;
+            this.callback = callback;
+        }
+
+        @Override
+        public void loaded(T resource, GVRAndroidResource androidResource) {
+            cache.put(androidResource, resource);
+            callback.loaded(resource, androidResource);
+        }
+
+        @Override
+        public void failed(Throwable t, GVRAndroidResource androidResource) {
+            callback.failed(t, androidResource);
+        }
+    }
+
+    private static class CancelableCallbackWrapper<T extends GVRHybridObject>
+            extends CallbackWrapper<T> implements CancelableCallback<T> {
+
+        private CancelableCallbackWrapper(ResourceCache<T> cache,
+                CancelableCallback<T> cancelableCallback) {
+            super(cache, cancelableCallback);
+        }
+
+        @Override
+        public boolean stillWanted(GVRAndroidResource androidResource) {
+            return ((CancelableCallback<T>) callback)
+                    .stillWanted(androidResource);
+        }
+    }
+
+    // Those 'convenience' interfaces are getting to be a real annoyance
+    private static class CompressedTextureCallbackWrapper extends
+            CallbackWrapper<GVRTexture> implements CompressedTextureCallback {
+
+        CompressedTextureCallbackWrapper(ResourceCache<GVRTexture> cache,
+                CompressedTextureCallback callback) {
+            super(cache, callback);
+        }
+    }
+
+    private static class BitmapTextureCallbackWrapper extends
+            CancelableCallbackWrapper<GVRTexture> implements
+            BitmapTextureCallback {
+        BitmapTextureCallbackWrapper(ResourceCache<GVRTexture> cache,
+                BitmapTextureCallback callback) {
+            super(cache, callback);
+        }
+    }
+}


### PR DESCRIPTION
Adds a simple Map<> from GVRAndroidResource to
WeakReference<GVRHybridObject>. Adds hooks to
all the resource loading methods to use the
cache. Now, loading a resource that's still
in memory should simply yield the existing
resource, even if that load was finished before
the new request.

Also closes all 'redundant' GVRAndroidResource-s,
to minimize the number of open file handles.

There is some ugliness here, because of the 
asynchronous package: the cache is often read
in the org.gearvrf package, but mostly populated
in the org.gearvrf.asynchronous package. I started
to move the asynchronous classes into the 'root'
package, but this made for a *lot* of changes: in 
the end, I put the new ResourceCache class in the
utility directory, and passed pointers to cache 
instances down into the async package.

GearVRf-DCO-1.0-Signed-off-by: Jon Shemitz
j.shemitz@samsung.com