### PR TITLE
Fixed the bug in cubemap_reflection_shader for GLES 2.0.

### DIFF
--- a/GVRf/Framework/jni/shaders/material/cubemap_reflection_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/cubemap_reflection_shader.cpp
@@ -163,6 +163,10 @@ void CubemapReflectionShader::render(const glm::mat4& mv_matrix,
             mesh->vertices().data());
     glEnableVertexAttribArray(a_position_);
 
+    glVertexAttribPointer(a_normal_, 3, GL_FLOAT, GL_FALSE, 0,
+            mesh->normals().data());
+    glEnableVertexAttribArray(a_normal_);
+
     glUniformMatrix4fv(u_mv_, 1, GL_FALSE, glm::value_ptr(mv_matrix));
     glUniformMatrix4fv(u_mv_it_, 1, GL_FALSE, glm::value_ptr(mv_it_matrix));
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(mvp_matrix));


### PR DESCRIPTION
The previous version only setup normals in the 3.0 branch.
Added the corresponding setup for 2.0 branch.

GearVRf-DCO-1.0-Signed-off-by: Guodong Rong
rongguodong@hotmail.com