### PR TITLE
Push a bounding box parameter down to the GVRMeshEyePointee constructor.

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRMeshEyePointee.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMeshEyePointee.java
@@ -33,7 +33,7 @@ public class GVRMeshEyePointee extends GVREyePointee {
     private GVRMesh mMesh;
 
     /**
-     * Constructor.
+     * Base constructor.
      * 
      * When the mesh is complicated, it will be cheaper - though less accurate -
      * to use {@link GVRMesh#getBoundingBox()} instead of the raw mesh.
@@ -60,6 +60,30 @@ public class GVRMeshEyePointee extends GVREyePointee {
      */
     public GVRMeshEyePointee(GVRMesh mesh) {
         this(mesh.getGVRContext(), mesh);
+    }
+
+    /**
+     * Constructor that can use the mesh's bounding box.
+     * 
+     * When the mesh is complicated, it will be cheaper - though less accurate -
+     * to use {@link GVRMesh#getBoundingBox()} instead of the raw mesh.
+     * 
+     * @param mesh
+     *            The {@link GVRMesh} that the picking ray will test against.
+     * @param useBoundingBox
+     *            When {@code true}, will use {@link GVRMesh#getBoundingBox()
+     *            mesh.getBoundingBox()}; when {@code false} will use
+     *            {@code mesh} directly.
+     */
+    /*
+     * TODO How much accuracy do we lose with bounding boxes?
+     * 
+     * Would it make sense for the useBoundingBox parameter to be a tri-state
+     * enum: mesh, box, box-then-mesh?
+     */
+    public GVRMeshEyePointee(GVRMesh mesh, boolean useBoundingBox) {
+        this(mesh.getGVRContext(), useBoundingBox ? mesh.getBoundingBox()
+                : mesh);
     }
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
@@ -430,12 +430,12 @@ public class GVRSceneObject extends GVRHybridObject {
      * Attach a default {@link GVREyePointeeHolder} to the object.
      * 
      * The default holder contains a single {@link GVRMeshEyePointee}, which
-     * refers to the {@linkplain GVRMesh mesh} in this scene object's
-     * {@linkplain GVRRenderData render data}. If you need anything more
-     * complicated (such as multiple meshes) use the
-     * {@linkplain #attachEyePointeeHolder(GVREyePointeeHolder) explicit
-     * overload.} If another {@link GVREyePointeeHolder} is currently attached,
-     * it is replaced with the new one.
+     * refers to the bounding box of the {@linkplain GVRMesh mesh} in this scene
+     * object's {@linkplain GVRRenderData render data}. If you need more control
+     * (multiple meshes, perhaps, or using the actual mesh instead of a bounding
+     * box) use the {@linkplain #attachEyePointeeHolder(GVREyePointeeHolder)
+     * explicit overload.} If another {@link GVREyePointeeHolder} is currently
+     * attached, it is replaced with the new one.
      * 
      * @return {@code true} if and only this scene object has render data
      *         <em>and</em> you have called either


### PR DESCRIPTION
Change GVRSceneObject.attachEyePointeeHolder() to use a bounding box.

GearVRf-DCO-1.0-Signed-off-by: Jon Shemitz
j.shemitz@samsung.com