### PR TITLE
Add bounding sphere info to the mesh.

### DIFF
--- a/GVRf/Framework/jni/objects/mesh.cpp
+++ b/GVRf/Framework/jni/objects/mesh.cpp
@@ -149,8 +149,9 @@ const float* Mesh::getBoundingBoxInfo() {
 void Mesh::getTransformedBoundingBoxInfo(glm::mat4 *Mat,
         float *transformed_bounding_box) {
 
-    if (have_bounding_box_ == false)
+    if (have_bounding_box_ == false) {
         getBoundingBoxInfo();
+    }
 
     glm::mat4 M = *Mat;
     float a, b;
@@ -202,6 +203,46 @@ void Mesh::getTransformedBoundingBoxInfo(glm::mat4 *Mat,
             transformed_bounding_box[5] += a;
         }
     }
+}
+
+// This gives us a really coarse bounding sphere given the already calcuated bounding box.  This won't be a tight-fitting sphere because it is based on the bounding box.  We can revisit this later if we decide we need a tighter sphere.
+const float *Mesh::getBoundingSphereInfo() {
+    if (have_bounding_box_ == false) {
+        getBoundingBoxInfo();
+    }
+
+    if (have_bounding_sphere_ == true) {
+        return bounding_sphere_info_;
+    }
+
+    // get the bounding box into nicely readable variables
+    float min_x = bounding_box_info_[0];
+    float max_x = bounding_box_info_[3];
+    float min_y = bounding_box_info_[1];
+    float max_y = bounding_box_info_[4];
+    float min_z = bounding_box_info_[2];
+    float max_z = bounding_box_info_[5];
+
+    // find center
+    float center_x = (min_x + max_x) / 2.0f;
+    float center_y = (min_y + max_y) / 2.0f;
+    float center_z = (min_z + max_z) / 2.0f;
+
+    // find radius
+    float x_squared = (min_x - center_x) * (min_x - center_x);
+    float y_squared = (min_y - center_y) * (min_y - center_y);
+    float z_squared = (min_z - center_z) * (min_z - center_z);
+    float radius = sqrtf(x_squared + y_squared + z_squared);
+
+    // assign the sphere
+    bounding_sphere_info_[0] = center_x;
+    bounding_sphere_info_[1] = center_y;
+    bounding_sphere_info_[2] = center_z;
+    bounding_sphere_info_[3] = radius;
+
+    have_bounding_sphere_ = true;
+
+    return bounding_sphere_info_;
 }
 
 // generate vertex array object

--- a/GVRf/Framework/jni/objects/mesh.cpp
+++ b/GVRf/Framework/jni/objects/mesh.cpp
@@ -207,11 +207,11 @@ void Mesh::getTransformedBoundingBoxInfo(glm::mat4 *Mat,
 
 // This gives us a really coarse bounding sphere given the already calcuated bounding box.  This won't be a tight-fitting sphere because it is based on the bounding box.  We can revisit this later if we decide we need a tighter sphere.
 const float *Mesh::getBoundingSphereInfo() {
-    if (have_bounding_box_ == false) {
+    if (!have_bounding_box_) {
         getBoundingBoxInfo();
     }
 
-    if (have_bounding_sphere_ == true) {
+    if (have_bounding_sphere_) {
         return bounding_sphere_info_;
     }
 

--- a/GVRf/Framework/jni/objects/mesh.h
+++ b/GVRf/Framework/jni/objects/mesh.h
@@ -89,6 +89,8 @@ public:
             gl_delete.queueBuffer(iterator->second);
         }
         tex_vboID_map_.clear();
+        have_bounding_box_ = false;
+        have_bounding_sphere_ = false;
     }
 
     std::vector<glm::vec3>& vertices() {

--- a/GVRf/Framework/jni/objects/mesh.h
+++ b/GVRf/Framework/jni/objects/mesh.h
@@ -39,8 +39,7 @@ class Mesh: public HybridObject {
 public:
     Mesh() :
             vertices_(), normals_(), tex_coords_(), triangles_(), float_vectors_(), vec2_vectors_(), vec3_vectors_(), vec4_vectors_(), vertexLoc_(
-                    -1), normalLoc_(-1), texCoordLoc_(-1), have_bounding_box_(
-                    false) {
+                    -1), normalLoc_(-1), texCoordLoc_(-1), have_bounding_box_(false), have_bounding_sphere_(false) {
     }
 
     ~Mesh() {
@@ -102,10 +101,12 @@ public:
 
     void set_vertices(const std::vector<glm::vec3>& vertices) {
         vertices_ = vertices;
+        getBoundingSphereInfo(); // calculate bounding sphere
     }
 
     void set_vertices(std::vector<glm::vec3>&& vertices) {
         vertices_ = std::move(vertices);
+        getBoundingSphereInfo(); // calculate bounding sphere
     }
 
     std::vector<glm::vec3>& normals() {
@@ -260,6 +261,7 @@ public:
     const float* getBoundingBoxInfo(); // Xmin, Ymin, Zmin and Xmax, Ymax, Zmax
     void getTransformedBoundingBoxInfo(glm::mat4 *M,
             float *transformed_bounding_box); //Get Bounding box info transformed by matrix
+    const float *getBoundingSphereInfo(); // Get bounding sphere based on the bounding box
 
     // /////////////////////////////////////////////////
     //  code for vertex attribute location
@@ -356,6 +358,10 @@ private:
     // bounding box info
     bool have_bounding_box_;
     float bounding_box_info_[6];
+
+    // bounding sphere info
+    bool have_bounding_sphere_;
+    float bounding_sphere_info_[4]; // [0-2] center x,y,z; [3] radius
 
     bool vao_dirty_;
 };


### PR DESCRIPTION
Adds bounding sphere info for the mesh.  This bounding sphere is based
on the bounding box that we're already using for frustum culling.  As
such, the sphere will likely be a little larger than necessary, but will
be accurate enough for now.

The bounding sphere (at least the center of it) will be used in upcoming
check-ins dealing with transparency sorting, and LOD.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn 
tom.flynn@samsung.com