### PR TITLE
Removed the usage of getOwnerObject from sample applications

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCamera.java
@@ -252,7 +252,10 @@ public abstract class GVRCamera extends GVRComponent {
      *         {@code null}.
      */
     public GVRTransform getTransform() {
-        return getOwnerObject().getTransform();
+        if (getOwnerObject() != null) {
+            return getOwnerObject().getTransform();
+        }
+        return null;
     }
 }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCamera.java
@@ -257,6 +257,46 @@ public abstract class GVRCamera extends GVRComponent {
         }
         return null;
     }
+
+    /**
+     * Add {@code child} as a child of this camera owner object.
+     * 
+     * @param child
+     *            {@link GVRSceneObject Object} to add as a child of this camera
+     *            owner object.
+     */
+    public void addChildObject(GVRSceneObject child) {
+        if (getOwnerObject() != null) {
+            getOwnerObject().addChildObject(child);
+        }
+    }
+
+    /**
+     * Remove {@code child} as a child of this camera owner object.
+     * 
+     * @param child
+     *            {@link GVRSceneObject Object} to remove as a child of this
+     *            camera owner object.
+     */
+    public void removeChildObject(GVRSceneObject child) {
+        if (getOwnerObject() != null) {
+            getOwnerObject().removeChildObject(child);
+        }
+    }
+
+    /**
+     * Get the number of child objects that belongs to owner object of this
+     * camera.
+     * 
+     * @return Number of {@link GVRSceneObject objects} added as children of
+     *         this camera owner object.
+     */
+    public int getChildrenCount() {
+        if (getOwnerObject() != null) {
+            return getOwnerObject().getChildrenCount();
+        }
+        return 0;
+    }
 }
 
 class NativeCamera {

--- a/GVRf/Framework/src/org/gearvrf/GVRCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCamera.java
@@ -217,6 +217,43 @@ public abstract class GVRCamera extends GVRComponent {
         mPostEffects.remove(postEffectData);
         NativeCamera.removePostEffect(getNative(), postEffectData.getNative());
     }
+
+    /**
+     * Replace the current {@link GVRTransform transform} for owner object of
+     * the camera.
+     * 
+     * @param transform
+     *            New transform.
+     */
+    void attachTransform(GVRTransform transform) {
+        if (getOwnerObject() != null) {
+            getOwnerObject().attachTransform(transform);
+        }
+    }
+
+    /**
+     * Remove the object's (owner object of camera) {@link GVRTransform
+     * transform}.
+     * 
+     */
+    void detachTransform() {
+        if (getOwnerObject() != null) {
+            getOwnerObject().detachTransform();
+        }
+    }
+
+    /**
+     * Get the {@link GVRTransform}.
+     * 
+     * 
+     * @return The current {@link GVRTransform transform} of owner object of
+     *         camera. Applying transform to owner object of camera moves it. If
+     *         no transform is currently attached to the object, returns
+     *         {@code null}.
+     */
+    public GVRTransform getTransform() {
+        return getOwnerObject().getTransform();
+    }
 }
 
 class NativeCamera {

--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -347,6 +347,75 @@ public class GVRCameraRig extends GVRComponent {
         return NativeCameraRig.getLookAt(getNative());
     }
 
+    /**
+     * Replace the current {@link GVRTransform transform} for owner object of
+     * the camera rig.
+     * 
+     * @param transform
+     *            New transform.
+     */
+    void attachTransform(GVRTransform transform) {
+        if (getOwnerObject() != null) {
+            getOwnerObject().attachTransform(transform);
+        }
+    }
+
+    /**
+     * Remove the object's (owner object of camera rig) {@link GVRTransform
+     * transform}.
+     * 
+     */
+    void detachTransform() {
+        if (getOwnerObject() != null) {
+            getOwnerObject().detachTransform();
+        }
+    }
+
+    /**
+     * Get the {@link GVRTransform}.
+     * 
+     * 
+     * @return The current {@link GVRTransform transform} of owner object of
+     *         camera rig. Applying transform to owner object of camera rig
+     *         moves it. If no transform is currently attached to the object,
+     *         returns {@code null}.
+     */
+    public GVRTransform getTransform() {
+        return getOwnerObject().getTransform();
+    }
+
+    /**
+     * Add {@code child} as a child of this camera rig owner object.
+     * 
+     * @param child
+     *            {@link GVRSceneObject Object} to add as a child of this camera
+     *            rig owner object..
+     */
+    public void addChildObject(GVRSceneObject child) {
+        getOwnerObject().addChildObject(child);
+    }
+
+    /**
+     * Remove {@code child} as a child of this camera rig owner object.
+     * 
+     * @param child
+     *            {@link GVRSceneObject Object} to remove as a child of this
+     *            camera rig owner object.
+     */
+    public void removeChildObject(GVRSceneObject child) {
+        getOwnerObject().removeChildObject(child);
+    }
+
+    /**
+     * Get the number of child objects that belongs to owner object of this
+     * camera rig.
+     * 
+     * @return Number of {@link GVRSceneObject objects} added as children of
+     *         this camera rig owner object.
+     */
+    public int getChildrenCount() {
+        return getOwnerObject().getChildrenCount();
+    }
 }
 
 class NativeCameraRig {

--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -381,7 +381,10 @@ public class GVRCameraRig extends GVRComponent {
      *         returns {@code null}.
      */
     public GVRTransform getTransform() {
-        return getOwnerObject().getTransform();
+        if (getOwnerObject() != null) {
+            return getOwnerObject().getTransform();
+        }
+        return null;
     }
 
     /**
@@ -392,7 +395,9 @@ public class GVRCameraRig extends GVRComponent {
      *            rig owner object..
      */
     public void addChildObject(GVRSceneObject child) {
-        getOwnerObject().addChildObject(child);
+        if (getOwnerObject() != null) {
+            getOwnerObject().addChildObject(child);
+        }
     }
 
     /**
@@ -403,7 +408,9 @@ public class GVRCameraRig extends GVRComponent {
      *            camera rig owner object.
      */
     public void removeChildObject(GVRSceneObject child) {
-        getOwnerObject().removeChildObject(child);
+        if (getOwnerObject() != null) {
+            getOwnerObject().removeChildObject(child);
+        }
     }
 
     /**
@@ -414,7 +421,10 @@ public class GVRCameraRig extends GVRComponent {
      *         this camera rig owner object.
      */
     public int getChildrenCount() {
-        return getOwnerObject().getChildrenCount();
+        if (getOwnerObject() != null) {
+            return getOwnerObject().getChildrenCount();
+        }
+        return 0;
     }
 }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -392,7 +392,7 @@ public class GVRCameraRig extends GVRComponent {
      * 
      * @param child
      *            {@link GVRSceneObject Object} to add as a child of this camera
-     *            rig owner object..
+     *            rig owner object.
      */
     public void addChildObject(GVRSceneObject child) {
         if (getOwnerObject() != null) {

--- a/GVRf/Framework/src/org/gearvrf/GVRPicker.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRPicker.java
@@ -254,6 +254,28 @@ public class GVRPicker {
     }
 
     /**
+     * Tests the {@link GVRSceneObject}s contained within scene against the
+     * camera rig's lookat vector.
+     * 
+     * <p>
+     * This method uses higher-level function
+     * {@linkplain #findObjects(GVRScene, float, float, float, float, float, float)
+     * findObjects()} internally.
+     * 
+     * @param scene
+     *            The {@link GVRScene} with all the objects to be tested.
+     * 
+     * @return A list of {@link GVRPickedObject}, sorted by distance from the
+     *         camera rig. Each {@link GVRPickedObject} contains the object
+     *         within the {@link GVREyePointeeHolder} along with the hit
+     *         location.
+     * 
+     */
+    public static final List<GVRPickedObject> findObjects(GVRScene scene) {
+        return findObjects(scene, 0, 0, 0, 0, 0, -1.0f);
+    }
+
+    /**
      * The result of a
      * {@link GVRPicker#findObjects(GVRScene, float, float, float, float, float, float)
      * findObjects()} call.

--- a/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
@@ -658,11 +658,11 @@ public class GVRSceneObject extends GVRHybridObject {
      * component is added as child). Adding a component will increase the
      * {@link getChildrenCount() getChildrenCount()} for this scene object.
      * 
-     * @param childComponet
+     * @param childComponent
      *            {@link GVRComponent Component} to add as a child of this
      *            object.
      */
-    public void addChildComponent(GVRComponent childComponent) {
+    public void addChildObject(GVRComponent childComponent) {
         if (childComponent.getOwnerObject() != null) {
             addChildObject(childComponent.getOwnerObject());
         }
@@ -677,7 +677,7 @@ public class GVRSceneObject extends GVRHybridObject {
      *            {@link GVRComponent Component} to remove as a child of this
      *            object.
      */
-    public void removeChildComponent(GVRComponent childComponent) {
+    public void removeChildObject(GVRComponent childComponent) {
         if (childComponent.getOwnerObject() != null) {
             removeChildObject(childComponent.getOwnerObject());
         }

--- a/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
@@ -652,6 +652,36 @@ public class GVRSceneObject extends GVRHybridObject {
             throw new UnsupportedOperationException();
         }
     }
+
+    /**
+     * Add {@code childComponent} as a child of this object (owner object of the
+     * component is added as child). Adding a component will increase the
+     * {@link getChildrenCount() getChildrenCount()} for this scene object.
+     * 
+     * @param childComponet
+     *            {@link GVRComponent Component} to add as a child of this
+     *            object.
+     */
+    public void addChildComponent(GVRComponent childComponent) {
+        if (childComponent.getOwnerObject() != null) {
+            addChildObject(childComponent.getOwnerObject());
+        }
+    }
+
+    /**
+     * Remove {@code childComponent} as a child of this object (owner object of
+     * the component is removed as child). Removing a component will decrease
+     * the {@link getChildrenCount() getChildrenCount()} for this scene object.
+     * 
+     * @param childComponent
+     *            {@link GVRComponent Component} to remove as a child of this
+     *            object.
+     */
+    public void removeChildComponent(GVRComponent childComponent) {
+        if (childComponent.getOwnerObject() != null) {
+            removeChildObject(childComponent.getOwnerObject());
+        }
+    }
 }
 
 class NativeSceneObject {

--- a/GVRf/Sample/eye-picking/src/org/gearvrf/eyepickingsample/SampleViewManager.java
+++ b/GVRf/Sample/eye-picking/src/org/gearvrf/eyepickingsample/SampleViewManager.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.gearvrf.*;
+import org.gearvrf.GVRPicker.GVRPickedObject;
 import org.gearvrf.utility.Log;
 
 public class SampleViewManager extends GVRScript {
@@ -47,9 +48,9 @@ public class SampleViewManager extends GVRScript {
     @Override
     public void onInit(GVRContext gvrContext) {
         mGVRContext = gvrContext;
-        
+
         GVRScene mainScene = mGVRContext.getNextMainScene();
-        
+
         mainScene.getMainCameraRig().getLeftCamera()
                 .setBackgroundColor(1.0f, 1.0f, 1.0f, 1.0f);
         mainScene.getMainCameraRig().getRightCamera()
@@ -124,7 +125,8 @@ public class SampleViewManager extends GVRScript {
             Log.e(TAG, "Mesh was not loaded. Stopping application!");
         }
         // activity was stored in order to stop the application if the mesh is
-        // not loaded. Since we don't need anymore, we set it to null to reduce chance of memory leak.
+        // not loaded. Since we don't need anymore, we set it to null to reduce
+        // chance of memory leak.
         mActivity = null;
 
         // These 2 are testing by the whole mesh.
@@ -164,10 +166,10 @@ public class SampleViewManager extends GVRScript {
                             UNPICKED_COLOR_G, UNPICKED_COLOR_B,
                             UNPICKED_COLOR_A);
         }
-        for (GVREyePointeeHolder eph : GVRPicker.pickScene(mGVRContext
-                .getMainScene())) {
+        for (GVRPickedObject pickedObject : GVRPicker.findObjects(
+                mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f)) {
             for (GVRSceneObject object : mObjects) {
-                if (eph.getOwnerObject().equals(object)) {
+                if (pickedObject.getHitObject().equals(object)) {
                     object.getRenderData()
                             .getMaterial()
                             .setVec4(ColorShader.COLOR_KEY, PICKED_COLOR_R,

--- a/GVRf/Sample/eye-picking/src/org/gearvrf/eyepickingsample/SampleViewManager.java
+++ b/GVRf/Sample/eye-picking/src/org/gearvrf/eyepickingsample/SampleViewManager.java
@@ -166,8 +166,8 @@ public class SampleViewManager extends GVRScript {
                             UNPICKED_COLOR_G, UNPICKED_COLOR_B,
                             UNPICKED_COLOR_A);
         }
-        for (GVRPickedObject pickedObject : GVRPicker.findObjects(
-                mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f)) {
+        for (GVRPickedObject pickedObject : GVRPicker.findObjects(mGVRContext
+                .getMainScene())) {
             for (GVRSceneObject object : mObjects) {
                 if (pickedObject.getHitObject().equals(object)) {
                     object.getRenderData()

--- a/GVRf/Sample/gvr-pickandmove/src/org/gearvrf/pickandmove/PickandmoveScript.java
+++ b/GVRf/Sample/gvr-pickandmove/src/org/gearvrf/pickandmove/PickandmoveScript.java
@@ -163,8 +163,8 @@ public class PickandmoveScript extends GVRScript {
             for (GVRSceneObject object : mObjects) {
                 object.getRenderData().getMaterial().setColor(1.0f, 1.0f, 1.0f);
             }
-            for (GVRPickedObject pickedObject : GVRPicker.findObjects(
-                    mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f)) {
+            for (GVRPickedObject pickedObject : GVRPicker
+                    .findObjects(mGVRContext.getMainScene())) {
                 pickedObject
                         .getHitObject()
                         .getRenderData()
@@ -198,8 +198,8 @@ public class PickandmoveScript extends GVRScript {
                     cameraRig.removeChildObject(attachedObject);
                     attachedObject = null;
                 } else {
-                    for (GVRPickedObject pickedObject : GVRPicker.findObjects(
-                            mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f)) {
+                    for (GVRPickedObject pickedObject : GVRPicker
+                            .findObjects(mGVRContext.getMainScene())) {
                         attachedObject = pickedObject.getHitObject();
                         cameraRig.addChildObject(attachedObject);
                         attachedObject

--- a/GVRf/Sample/gvr-pickandmove/src/org/gearvrf/pickandmove/PickandmoveScript.java
+++ b/GVRf/Sample/gvr-pickandmove/src/org/gearvrf/pickandmove/PickandmoveScript.java
@@ -33,6 +33,7 @@ import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRScript;
 import org.gearvrf.GVRTexture;
 import org.gearvrf.GVRTransform;
+import org.gearvrf.GVRPicker.GVRPickedObject;
 import org.gearvrf.pickandmove.R;
 
 import android.util.Log;
@@ -61,7 +62,7 @@ public class PickandmoveScript extends GVRScript {
         headTracker.getTransform().setPosition(0.0f, 0.0f, -1.0f);
         headTracker.getRenderData().setDepthTest(false);
         headTracker.getRenderData().setRenderingOrder(100000);
-        scene.getMainCameraRig().getOwnerObject().addChildObject(headTracker);
+        scene.getMainCameraRig().addChildObject(headTracker);
 
         FutureWrapper<GVRMesh> futureQuadMesh = new FutureWrapper<GVRMesh>(
                 gvrContext.createQuad(CUBE_WIDTH, CUBE_WIDTH));
@@ -162,10 +163,10 @@ public class PickandmoveScript extends GVRScript {
             for (GVRSceneObject object : mObjects) {
                 object.getRenderData().getMaterial().setColor(1.0f, 1.0f, 1.0f);
             }
-            for (GVREyePointeeHolder eyePointeeHolder : GVRPicker
-                    .pickScene(mGVRContext.getMainScene())) {
-                eyePointeeHolder
-                        .getOwnerObject()
+            for (GVRPickedObject pickedObject : GVRPicker.findObjects(
+                    mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f)) {
+                pickedObject
+                        .getHitObject()
                         .getRenderData()
                         .getMaterial()
                         .setColor(LOOKAT_COLOR_MASK_R, LOOKAT_COLOR_MASK_G,
@@ -193,15 +194,14 @@ public class PickandmoveScript extends GVRScript {
         case MotionEvent.ACTION_UP:
             if (isOnClick) {
                 GVRCameraRig cameraRig = scene.getMainCameraRig();
-                GVRSceneObject cameraRigObject = cameraRig.getOwnerObject();
                 if (attachedObject != null) {
-                    cameraRigObject.removeChildObject(attachedObject);
+                    cameraRig.removeChildObject(attachedObject);
                     attachedObject = null;
                 } else {
-                    for (GVREyePointeeHolder eyePointeeHolder : GVRPicker
-                            .pickScene(mGVRContext.getMainScene())) {
-                        attachedObject = eyePointeeHolder.getOwnerObject();
-                        cameraRigObject.addChildObject(attachedObject);
+                    for (GVRPickedObject pickedObject : GVRPicker.findObjects(
+                            mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f)) {
+                        attachedObject = pickedObject.getHitObject();
+                        cameraRig.addChildObject(attachedObject);
                         attachedObject
                                 .getRenderData()
                                 .getMaterial()

--- a/GVRf/Sample/gvr-sample/src/org/gearvrf/sample/SampleCubeScript.java
+++ b/GVRf/Sample/gvr-sample/src/org/gearvrf/sample/SampleCubeScript.java
@@ -158,8 +158,8 @@ public class SampleCubeScript extends GVRScript {
         mFrontFace.getRenderData().getMaterial().setOpacity(1.0f);
         mFrontFace2.getRenderData().getMaterial().setOpacity(1.0f);
         mFrontFace3.getRenderData().getMaterial().setOpacity(1.0f);
-        for (GVRPickedObject pickedObject : GVRPicker.findObjects(
-                mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f)) {
+        for (GVRPickedObject pickedObject : GVRPicker.findObjects(mGVRContext
+                .getMainScene())) {
             if (pickedObject.getHitObject().equals(mFrontFace)) {
                 mFrontFace.getRenderData().getMaterial().setOpacity(0.5f);
             }

--- a/GVRf/Sample/gvr-sample/src/org/gearvrf/sample/SampleCubeScript.java
+++ b/GVRf/Sample/gvr-sample/src/org/gearvrf/sample/SampleCubeScript.java
@@ -27,6 +27,7 @@ import org.gearvrf.GVREyePointeeHolder;
 import org.gearvrf.GVRMesh;
 import org.gearvrf.GVRMeshEyePointee;
 import org.gearvrf.GVRPicker;
+import org.gearvrf.GVRPicker.GVRPickedObject;
 import org.gearvrf.GVRRenderData.GVRRenderMaskBit;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
@@ -157,16 +158,15 @@ public class SampleCubeScript extends GVRScript {
         mFrontFace.getRenderData().getMaterial().setOpacity(1.0f);
         mFrontFace2.getRenderData().getMaterial().setOpacity(1.0f);
         mFrontFace3.getRenderData().getMaterial().setOpacity(1.0f);
-        GVREyePointeeHolder[] eyePointeeHolders = GVRPicker
-                .pickScene(mGVRContext.getMainScene());
-        for (GVREyePointeeHolder eyePointeeHolder : eyePointeeHolders) {
-            if (eyePointeeHolder.getOwnerObject().equals(mFrontFace)) {
+        for (GVRPickedObject pickedObject : GVRPicker.findObjects(
+                mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f)) {
+            if (pickedObject.getHitObject().equals(mFrontFace)) {
                 mFrontFace.getRenderData().getMaterial().setOpacity(0.5f);
             }
-            if (eyePointeeHolder.getOwnerObject().equals(mFrontFace2)) {
+            if (pickedObject.getHitObject().equals(mFrontFace2)) {
                 mFrontFace2.getRenderData().getMaterial().setOpacity(0.5f);
             }
-            if (eyePointeeHolder.getOwnerObject().equals(mFrontFace3)) {
+            if (pickedObject.getHitObject().equals(mFrontFace3)) {
                 mFrontFace3.getRenderData().getMaterial().setOpacity(0.5f);
             }
         }

--- a/GVRf/Sample/gvr-video/src/org/gearvrf/video/VideoScript.java
+++ b/GVRf/Sample/gvr-video/src/org/gearvrf/video/VideoScript.java
@@ -175,8 +175,7 @@ public class VideoScript extends GVRScript {
                     GVRRenderingOrder.OVERLAY);
             mHeadTracker.getRenderData().setDepthTest(false);
             mHeadTracker.getRenderData().setRenderingOrder(100000);
-            mainScene.getMainCameraRig().getOwnerObject()
-                    .addChildObject(mHeadTracker);
+            mainScene.getMainCameraRig().addChildObject(mHeadTracker);
 
             /*
              * FXGear Background
@@ -665,8 +664,7 @@ public class VideoScript extends GVRScript {
 
             mCameraSurfaceTexture = new SurfaceTexture(
                     passThroughTexture.getId());
-            mainScene.getMainCameraRig().getOwnerObject()
-                    .addChildObject(mPassThroughObject);
+            mainScene.getMainCameraRig().addChildObject(mPassThroughObject);
         } catch (IOException e) {
             e.printStackTrace();
             mActivity.finish();
@@ -1042,9 +1040,9 @@ public class VideoScript extends GVRScript {
             if (isLongButtonPressed) {
                 mIsGlobalMenuOn = true;
                 float yaw = mGVRContext.getMainScene().getMainCameraRig()
-                        .getOwnerObject().getTransform().getRotationYaw();
+                        .getTransform().getRotationYaw();
                 float pitch = mGVRContext.getMainScene().getMainCameraRig()
-                        .getOwnerObject().getTransform().getRotationPitch();
+                        .getTransform().getRotationPitch();
                 if (Math.abs(pitch) >= 90.0f) {
                     if (yaw > 0.0)
                         yaw = 180.0f - yaw;

--- a/GVRf/Sample/gvrbulletsample/src/org/gearvrf/bulletsample/BulletSampleViewManager.java
+++ b/GVRf/Sample/gvrbulletsample/src/org/gearvrf/bulletsample/BulletSampleViewManager.java
@@ -46,8 +46,7 @@ public class BulletSampleViewManager extends GVRScript {
         mainCameraRig.getLeftCamera().setBackgroundColor(Color.BLACK);
         mainCameraRig.getRightCamera().setBackgroundColor(Color.BLACK);
 
-        mainCameraRig.getOwnerObject().getTransform()
-                .setPosition(0.0f, 6.0f, 0.0f);
+        mainCameraRig.getTransform().setPosition(0.0f, 6.0f, 0.0f);
 
         /*
          * Create new Bullet instance.

--- a/GVRf/Sample/gvrcockpit_v1_5_0/src/org/gearvrf/cockpit/CockpitViewManager.java
+++ b/GVRf/Sample/gvrcockpit_v1_5_0/src/org/gearvrf/cockpit/CockpitViewManager.java
@@ -34,9 +34,9 @@ public class CockpitViewManager extends GVRScript {
 
         mGVRContext = gvrContext;
         GVRScene mainScene = mGVRContext.getNextMainScene();
-        
-        mainScene.getMainCameraRig().getOwnerObject()
-                .getTransform().setPosition(0.0f, 6.0f, 1.0f);
+
+        mainScene.getMainCameraRig().getTransform()
+                .setPosition(0.0f, 6.0f, 1.0f);
 
         GVRMesh shipMesh = mGVRContext.loadMesh(new GVRAndroidResource(
                 mGVRContext, R.raw.gvrf_ship_mesh));

--- a/GVRf/Sample/gvropacityanigallery/src/org/gearvrf/opacityanigallery/GalleryViewManager.java
+++ b/GVRf/Sample/gvropacityanigallery/src/org/gearvrf/opacityanigallery/GalleryViewManager.java
@@ -58,18 +58,18 @@ public class GalleryViewManager extends GVRScript {
     @Override
     public void onInit(GVRContext gvrContext) {
         mGVRContext = gvrContext;
-        
+
         mAnimationEngine = gvrContext.getAnimationEngine();
-        
+
         GVRScene mainScene = mGVRContext.getNextMainScene();
-        
+
         mainScene.getMainCameraRig().getLeftCamera()
                 .setBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
         mainScene.getMainCameraRig().getRightCamera()
                 .setBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
 
-        mainScene.getMainCameraRig().getOwnerObject()
-                .getTransform().setPosition(0.0f, 0.0f, 0.0f);
+        mainScene.getMainCameraRig().getTransform()
+                .setPosition(0.0f, 0.0f, 0.0f);
 
         GVRMesh sphereMesh = mGVRContext.loadMesh(new GVRAndroidResource(
                 mGVRContext, R.raw.sphere_mesh));
@@ -145,10 +145,8 @@ public class GalleryViewManager extends GVRScript {
         postEffect.setVec3("ratio_r", 0.393f, 0.769f, 0.189f);
         postEffect.setVec3("ratio_g", 0.349f, 0.686f, 0.168f);
         postEffect.setVec3("ratio_b", 0.272f, 0.534f, 0.131f);
-        mainScene.getMainCameraRig().getLeftCamera()
-                .addPostEffect(postEffect);
-        mainScene.getMainCameraRig().getRightCamera()
-                .addPostEffect(postEffect);
+        mainScene.getMainCameraRig().getLeftCamera().addPostEffect(postEffect);
+        mainScene.getMainCameraRig().getRightCamera().addPostEffect(postEffect);
 
     }
 

--- a/GVRf/Sample/gvrperformancetest_v1_5_0/src/org/gearvrf/performancetest/TestScript.java
+++ b/GVRf/Sample/gvrperformancetest_v1_5_0/src/org/gearvrf/performancetest/TestScript.java
@@ -57,7 +57,7 @@ public class TestScript extends GVRScript {
         mMainScene = gvrContext.getNextMainScene();
 
         GVRCameraRig mainCameraRig = mMainScene.getMainCameraRig();
-        
+
         GVRCamera leftCamera = mainCameraRig.getLeftCamera();
         GVRCamera rightCamera = mainCameraRig.getRightCamera();
 
@@ -70,8 +70,7 @@ public class TestScript extends GVRScript {
         rightCamera.setBackgroundColorG(0.2f);
         rightCamera.setBackgroundColorB(0.2f);
         rightCamera.setBackgroundColorA(1.0f);
-        mainCameraRig.getOwnerObject().getTransform()
-                .setPosition(0.0f, 0.0f, 0.0f);
+        mainCameraRig.getTransform().setPosition(0.0f, 0.0f, 0.0f);
         for (int i = 0; i < numberOfBunnies; ++i) {
 
             GVRSceneObject bunny = null;
@@ -104,7 +103,7 @@ public class TestScript extends GVRScript {
                     random.nextFloat() * 360.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
                     0.0f);
             bunny.getTransform().translate(0.0f, 0.0f, -10.0f);
-            mainCameraRig.getOwnerObject().addChildObject(bunny);
+            mainCameraRig.addChildObject(bunny);
 
             float x = random.nextFloat() - 0.5f;
             float y = random.nextFloat() - 0.5f;

--- a/GVRf/Sample/gvrsixaxissensortest_v1_5_0/src/org/gearvrf/sixaxissensortest/TestViewManager.java
+++ b/GVRf/Sample/gvrsixaxissensortest_v1_5_0/src/org/gearvrf/sixaxissensortest/TestViewManager.java
@@ -15,7 +15,6 @@
 
 package org.gearvrf.sixaxissensortest;
 
-
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -32,7 +31,6 @@ import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRScript;
 import org.gearvrf.sixaxissensortest.R;
-
 
 public class TestViewManager extends GVRScript {
 
@@ -66,9 +64,9 @@ public class TestViewManager extends GVRScript {
         mGyroscope = new Gyroscope(mGVRContext.getContext());
 
         GVRScene mainScene = mGVRContext.getNextMainScene();
-        
-        mainScene.getMainCameraRig()
-                .setCameraRigType(GVRCameraRig.GVRCameraRigType.YawOnly.ID);
+
+        mainScene.getMainCameraRig().setCameraRigType(
+                GVRCameraRig.GVRCameraRigType.YawOnly.ID);
 
         GVRMesh cylinderMesh = mGVRContext.loadMesh(new GVRAndroidResource(
                 mGVRContext, R.raw.cylinder_obj));
@@ -85,8 +83,7 @@ public class TestViewManager extends GVRScript {
         GVRSceneObject cursor = new GVRSceneObject(mGVRContext, 0.05f, 0.5f,
                 new GVRBitmapTexture(mGVRContext, cursorBitmap));
         cursor.getTransform().setPosition(0.0f, 0.0f, -5.0f);
-        mainScene.getMainCameraRig().getOwnerObject()
-                .addChildObject(cursor);
+        mainScene.getMainCameraRig().addChildObject(cursor);
 
         Bitmap degreeBitmap = GVRTextBitmapFactory2.create(1024, 128,
                 "degree : 0.00", 40, Align.LEFT, Color.YELLOW,
@@ -95,8 +92,7 @@ public class TestViewManager extends GVRScript {
                 new GVRBitmapTexture(mGVRContext, degreeBitmap));
         mDegreeBoard.getTransform().setPosition(-0.5f, 0.7f, -2.0f);
         degreeBitmap.recycle();
-        mainScene.getMainCameraRig().getOwnerObject()
-                .addChildObject(mDegreeBoard);
+        mainScene.getMainCameraRig().addChildObject(mDegreeBoard);
 
         Bitmap angularVelocityBitmap = GVRTextBitmapFactory2.create(1024, 128,
                 "velocity : 0.00", 50, Align.LEFT, Color.YELLOW,
@@ -105,8 +101,7 @@ public class TestViewManager extends GVRScript {
                 new GVRBitmapTexture(mGVRContext, angularVelocityBitmap));
         mAngularVelocityBoard.getTransform().setPosition(-0.5f, -0.7f, -2.0f);
         angularVelocityBitmap.recycle();
-        mainScene.getMainCameraRig().getOwnerObject()
-                .addChildObject(mAngularVelocityBoard);
+        mainScene.getMainCameraRig().addChildObject(mAngularVelocityBoard);
 
         Bitmap aValueBitmap = GVRTextBitmapFactory2.create(1024, 128, String
                 .format("ZRO : %.2f, Spec degree : %.2f", mAValue, mBValue),
@@ -115,8 +110,7 @@ public class TestViewManager extends GVRScript {
                 new GVRBitmapTexture(mGVRContext, aValueBitmap));
         mValueBoard.getTransform().setPosition(-0.5f, 0.5f, -2.0f);
         aValueBitmap.recycle();
-        mainScene.getMainCameraRig().getOwnerObject()
-                .addChildObject(mValueBoard);
+        mainScene.getMainCameraRig().addChildObject(mValueBoard);
 
         Bitmap stateBitmap = GVRTextBitmapFactory2.create(1024, 128, "", 50,
                 Align.LEFT, Color.TRANSPARENT, Color.TRANSPARENT);
@@ -124,8 +118,7 @@ public class TestViewManager extends GVRScript {
                 new GVRBitmapTexture(mGVRContext, stateBitmap));
         mStateBoard.getTransform().setPosition(-0.5f, -0.7f, -5.0f);
         stateBitmap.recycle();
-        mainScene.getMainCameraRig().getOwnerObject()
-                .addChildObject(mStateBoard);
+        mainScene.getMainCameraRig().addChildObject(mStateBoard);
 
     }
 

--- a/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/ViewerScript.java
+++ b/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/ViewerScript.java
@@ -949,8 +949,8 @@ public class ViewerScript extends GVRScript {
         mReflectionMaterial.setVec3(ReflectionShader.EYE_KEY, eye[0], eye[1],
                 eye[2]);
 
-        List<GVRPickedObject> pickedObjects = GVRPicker.findObjects(
-                mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f);
+        List<GVRPickedObject> pickedObjects = GVRPicker.findObjects(mGVRContext
+                .getMainScene());
         if (SelectionMode && pickedObjects.size() > 0) {
             GVRSceneObject pickedObject = pickedObjects.get(0).getHitObject();
             for (int i = 0; i < THUMBNAIL_NUM; ++i)

--- a/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/ViewerScript.java
+++ b/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/ViewerScript.java
@@ -16,8 +16,10 @@
 package org.gearvrf.modelviewer;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.gearvrf.*;
+import org.gearvrf.GVRPicker.GVRPickedObject;
 import org.gearvrf.GVRRenderData.GVRRenderMaskBit;
 
 import android.util.Log;
@@ -112,7 +114,7 @@ public class ViewerScript extends GVRScript {
         mPhongShader3 = new PhongShader3(mGVRContext);
 
         GVRScene mainScene = mGVRContext.getNextMainScene();
-        
+
         mainScene.getMainCameraRig().getLeftCamera()
                 .setBackgroundColor(1.0f, 1.0f, 1.0f, 1.0f);
         mainScene.getMainCameraRig().getRightCamera()
@@ -598,8 +600,7 @@ public class ViewerScript extends GVRScript {
             headTracker.getTransform().setPosition(0.0f, 0.0f, -EYE_TO_OBJECT);
             headTracker.getRenderData().setDepthTest(false);
             headTracker.getRenderData().setRenderingOrder(100000);
-            mainScene.getMainCameraRig().getOwnerObject()
-                    .addChildObject(headTracker);
+            mainScene.getMainCameraRig().addChildObject(headTracker);
         } catch (IOException e) {
             e.printStackTrace();
             mActivity.finish();
@@ -948,10 +949,10 @@ public class ViewerScript extends GVRScript {
         mReflectionMaterial.setVec3(ReflectionShader.EYE_KEY, eye[0], eye[1],
                 eye[2]);
 
-        GVREyePointeeHolder pickedHolders[] = GVRPicker.pickScene(mGVRContext
-                .getMainScene());
-        if (SelectionMode && pickedHolders.length > 0) {
-            GVRSceneObject pickedObject = pickedHolders[0].getOwnerObject();
+        List<GVRPickedObject> pickedObjects = GVRPicker.findObjects(
+                mGVRContext.getMainScene(), 0, 0, 0, 0, 0, -1.0f);
+        if (SelectionMode && pickedObjects.size() > 0) {
+            GVRSceneObject pickedObject = pickedObjects.get(0).getHitObject();
             for (int i = 0; i < THUMBNAIL_NUM; ++i)
                 if (ThumbnailObject[i].equals(pickedObject)) {
                     ThumbnailSelected = i;

--- a/GVRf/Sample/simple-gallery/src/org/gearvrf/simplegallery/GalleryViewManager.java
+++ b/GVRf/Sample/simple-gallery/src/org/gearvrf/simplegallery/GalleryViewManager.java
@@ -35,6 +35,7 @@ import org.gearvrf.scene_objects.GVRVideoSceneObject;
 import org.gearvrf.scene_objects.GVRVideoSceneObject.GVRVideoType;
 
 import android.media.MediaPlayer;
+
 public class GalleryViewManager extends GVRScript {
 
     private static final float ANIMATION_DURATION = 0.3f;
@@ -56,18 +57,18 @@ public class GalleryViewManager extends GVRScript {
     @Override
     public void onInit(GVRContext gvrContext) {
         mGVRContext = gvrContext;
-        
+
         mAnimationEngine = gvrContext.getAnimationEngine();
-        
+
         GVRScene mainScene = mGVRContext.getNextMainScene();
-        
+
         mainScene.getMainCameraRig().getLeftCamera()
                 .setBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
         mainScene.getMainCameraRig().getRightCamera()
                 .setBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
 
-        mainScene.getMainCameraRig().getOwnerObject()
-                .getTransform().setPosition(0.0f, 0.0f, 0.0f);
+        mainScene.getMainCameraRig().getTransform()
+                .setPosition(0.0f, 0.0f, 0.0f);
 
         GVRMesh sphereMesh = mGVRContext.loadMesh(new GVRAndroidResource(
                 mGVRContext, R.raw.sphere_mesh));
@@ -88,9 +89,8 @@ public class GalleryViewManager extends GVRScript {
 
         List<GVRTexture> numberTextures = new ArrayList<GVRTexture>();
         int[] resourceIds = new int[] { R.drawable.photo_1jpg,
-                R.drawable.photo_2, R.drawable.photo_3,
-                R.drawable.photo_4, R.drawable.photo_5,
-                R.drawable.photo_6, R.drawable.photo_7,
+                R.drawable.photo_2, R.drawable.photo_3, R.drawable.photo_4,
+                R.drawable.photo_5, R.drawable.photo_6, R.drawable.photo_7,
                 R.drawable.photo_8, R.drawable.photo_9 };
         for (int id : resourceIds) {
             numberTextures.add(mGVRContext.loadTexture(new GVRAndroidResource(
@@ -140,10 +140,8 @@ public class GalleryViewManager extends GVRScript {
         postEffect.setVec3("ratio_r", 0.393f, 0.769f, 0.189f);
         postEffect.setVec3("ratio_g", 0.349f, 0.686f, 0.168f);
         postEffect.setVec3("ratio_b", 0.272f, 0.534f, 0.131f);
-        mainScene.getMainCameraRig().getLeftCamera()
-                .addPostEffect(postEffect);
-        mainScene.getMainCameraRig().getRightCamera()
-                .addPostEffect(postEffect);
+        mainScene.getMainCameraRig().getLeftCamera().addPostEffect(postEffect);
+        mainScene.getMainCameraRig().getRightCamera().addPostEffect(postEffect);
 
     }
 

--- a/GVRf/Sample/solar-system/src/org/gearvrf/solarsystem/SolarViewManager.java
+++ b/GVRf/Sample/solar-system/src/org/gearvrf/solarsystem/SolarViewManager.java
@@ -122,7 +122,7 @@ public class SolarViewManager extends GVRScript {
         GVRSceneObject moonRevolutionObject = new GVRSceneObject(gvrContext);
         moonRevolutionObject.getTransform().setPosition(4.0f, 0.0f, 0.0f);
         earthRevolutionObject.addChildObject(moonRevolutionObject);
-        moonRevolutionObject.addChildComponent(mMainScene.getMainCameraRig());
+        moonRevolutionObject.addChildObject(mMainScene.getMainCameraRig());
 
         GVRSceneObject marsRevolutionObject = new GVRSceneObject(gvrContext);
         marsRevolutionObject.getTransform().setPosition(30.0f, 0.0f, 0.0f);

--- a/GVRf/Sample/solar-system/src/org/gearvrf/solarsystem/SolarViewManager.java
+++ b/GVRf/Sample/solar-system/src/org/gearvrf/solarsystem/SolarViewManager.java
@@ -62,13 +62,13 @@ public class SolarViewManager extends GVRScript {
         });
 
         mMainScene.setFrustumCulling(true);
-        
+
         mMainScene.getMainCameraRig().getLeftCamera()
                 .setBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
         mMainScene.getMainCameraRig().getRightCamera()
                 .setBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
 
-        mMainScene.getMainCameraRig().getOwnerObject().getTransform()
+        mMainScene.getMainCameraRig().getTransform()
                 .setPosition(0.0f, 0.0f, 0.0f);
 
         GVRSceneObject solarSystemObject = new GVRSceneObject(gvrContext);
@@ -150,8 +150,7 @@ public class SolarViewManager extends GVRScript {
 
         counterClockwise(moonRevolutionObject, 60f);
 
-        clockwise(mMainScene.getMainCameraRig().getOwnerObject().getTransform(),
-                60f);
+        clockwise(mMainScene.getMainCameraRig().getTransform(), 60f);
 
         counterClockwise(marsRevolutionObject, 1200f);
         counterClockwise(marsRotationObject, 200f);

--- a/GVRf/Sample/solar-system/src/org/gearvrf/solarsystem/SolarViewManager.java
+++ b/GVRf/Sample/solar-system/src/org/gearvrf/solarsystem/SolarViewManager.java
@@ -122,8 +122,7 @@ public class SolarViewManager extends GVRScript {
         GVRSceneObject moonRevolutionObject = new GVRSceneObject(gvrContext);
         moonRevolutionObject.getTransform().setPosition(4.0f, 0.0f, 0.0f);
         earthRevolutionObject.addChildObject(moonRevolutionObject);
-        moonRevolutionObject.addChildObject(mMainScene.getMainCameraRig()
-                .getOwnerObject());
+        moonRevolutionObject.addChildComponent(mMainScene.getMainCameraRig());
 
         GVRSceneObject marsRevolutionObject = new GVRSceneObject(gvrContext);
         marsRevolutionObject.getTransform().setPosition(30.0f, 0.0f, 0.0f);


### PR DESCRIPTION
Currently getOwnerObject is used in below scenarios in Sample applications (Also the changes made to get rid of the usage):

1 - GVRPicker.pickScene() returns an array of GVREyePointeeHolder and the GVRSceneObject which is currently in path of ray cast can be retrieved by doing getOwnerObject on eyePointeeHolder object.
=> A new API "GVRPicker.findObjects()" is provided since version 1.6 which will return List<GVRPickedObject> which is more cleaner to use. In this check-in this new API will replace all the usage of "GVRPicker.pickScene()"

2 - To transform the position of camera rig in the scene graph, currently the usage is 
mainScene.getMainCameraRig().getOwnerObject().getTransform().setPosition(0.0f, 6.0f, 1.0f);
=> A new API is provided by CameraRig which can set/get Transform

3 - Some of the sample attach scene objects to camera rig as child objects, so the object appear move with camera in scene graph. 
scene.getMainCameraRig().getOwnerObject().addChildObject(headTracker);
=> New API added so that scene object can be directly added to the camera rig instead of using getOwnerObject and then add scene object to it.

4 - At one place in Solar System demo app the owner object of camera rig is added as child object to some other scene object. I was not able to get rid of this usage of getOwnerObject().
moonRevolutionObject.addChildObject(mMainScene.getMainCameraRig().getOwnerObject());

Internally getOwnerObject is used though. This pull request is for fixing #97.

GearVRf-DCO-1.0-Signed-off-by: Deepak Rawat
drawat@usc.edu