### PR TITLE
Quad faces support to GearVRf

### DIFF
--- a/GVRf/Framework/jni/engine/importer/assimp_importer.cpp
+++ b/GVRf/Framework/jni/engine/importer/assimp_importer.cpp
@@ -62,6 +62,14 @@ Mesh* AssimpImporter::getMesh(int index) {
             triangles.push_back(ai_mesh->mFaces[i].mIndices[0]);
             triangles.push_back(ai_mesh->mFaces[i].mIndices[1]);
             triangles.push_back(ai_mesh->mFaces[i].mIndices[2]);
+        } else if (ai_mesh->mFaces[i].mNumIndices == 4) {
+            triangles.push_back(ai_mesh->mFaces[i].mIndices[0]);
+            triangles.push_back(ai_mesh->mFaces[i].mIndices[1]);
+            triangles.push_back(ai_mesh->mFaces[i].mIndices[2]);
+
+            triangles.push_back(ai_mesh->mFaces[i].mIndices[2]);
+            triangles.push_back(ai_mesh->mFaces[i].mIndices[3]);
+            triangles.push_back(ai_mesh->mFaces[i].mIndices[0]);
         }
     }
     mesh->set_triangles(std::move(triangles));


### PR DESCRIPTION
Added support for quad faces in mesh. GearVRf used to ignore quad faces. Now add 2 triangles for quad faces. Tested with wavefront obj and fbx file, working alright.

Will create a separate pull request for fbx file because need to figure out a correct way to get extension from Android resources.

GearVRf-DCO-1.0-Signed-off-by: Deepak Rawat
drawat@usc.edu