### PR TITLE
FBX and other 3d mesh support

### DIFF
--- a/GVRf/Framework/jni/engine/importer/importer.cpp
+++ b/GVRf/Framework/jni/engine/importer/importer.cpp
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-
 /***************************************************************************
  * Imports a scene file using Assimp.
  ***************************************************************************/
@@ -21,11 +20,20 @@
 #include "importer.h"
 
 namespace gvr {
-AssimpImporter* Importer::readFileFromAssets(char* buffer,
-        long size, const char * hint_string) {
+AssimpImporter* Importer::readFileFromAssets(char* buffer, long size,
+        const char * filename) {
     Assimp::Importer* importer = new Assimp::Importer();
+    char* hint = 0;
+
+    if (filename != 0) {
+        hint = strrchr(filename, '.');
+        if (hint && hint != filename) {
+            hint = hint + 1;
+        }
+    }
     importer->ReadFileFromMemory(buffer, size,
-            aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs, hint_string);
+            aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs, hint);
+
     return new AssimpImporter(importer);
 }
 

--- a/GVRf/Framework/jni/engine/importer/importer.cpp
+++ b/GVRf/Framework/jni/engine/importer/importer.cpp
@@ -29,14 +29,10 @@ AssimpImporter* Importer::readFileFromAssets(char* buffer,
     return new AssimpImporter(importer);
 }
 
-AssimpImporter* Importer::readFileFromSDCard(std::string str) {
+AssimpImporter* Importer::readFileFromSDCard(const char * filename) {
     Assimp::Importer* importer = new Assimp::Importer();
-    const char* c_str = str.c_str();
-    importer->ReadFile(str,
+    importer->ReadFile(filename,
             aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs);
-    /* No need to load call ReadFileFromMemory as ReadFile is already called */
-    /*importer->ReadFileFromMemory(c_str, str.size(),
-            aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs, 0);*/
     return new AssimpImporter(importer);
 }
 }

--- a/GVRf/Framework/jni/engine/importer/importer.cpp
+++ b/GVRf/Framework/jni/engine/importer/importer.cpp
@@ -22,10 +22,10 @@
 
 namespace gvr {
 AssimpImporter* Importer::readFileFromAssets(char* buffer,
-        long size) {
+        long size, const char * hint_string) {
     Assimp::Importer* importer = new Assimp::Importer();
     importer->ReadFileFromMemory(buffer, size,
-            aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs, 0);
+            aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs, hint_string);
     return new AssimpImporter(importer);
 }
 
@@ -34,8 +34,9 @@ AssimpImporter* Importer::readFileFromSDCard(std::string str) {
     const char* c_str = str.c_str();
     importer->ReadFile(str,
             aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs);
-    importer->ReadFileFromMemory(c_str, str.size(),
-            aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs, 0);
+    /* No need to load call ReadFileFromMemory as ReadFile is already called */
+    /*importer->ReadFileFromMemory(c_str, str.size(),
+            aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs, 0);*/
     return new AssimpImporter(importer);
 }
 }

--- a/GVRf/Framework/jni/engine/importer/importer.h
+++ b/GVRf/Framework/jni/engine/importer/importer.h
@@ -34,7 +34,7 @@ private:
     Importer();
 
 public:
-    static AssimpImporter* readFileFromAssets(char* buffer, long size, const char * hint_string);
+    static AssimpImporter* readFileFromAssets(char* buffer, long size, const char * filename);
     static AssimpImporter* readFileFromSDCard(const char * filename);
 };
 }

--- a/GVRf/Framework/jni/engine/importer/importer.h
+++ b/GVRf/Framework/jni/engine/importer/importer.h
@@ -34,7 +34,7 @@ private:
     Importer();
 
 public:
-    static AssimpImporter* readFileFromAssets(char* buffer, long size);
+    static AssimpImporter* readFileFromAssets(char* buffer, long size, const char * hint_string);
     static AssimpImporter* readFileFromSDCard(std::string str);
 };
 }

--- a/GVRf/Framework/jni/engine/importer/importer.h
+++ b/GVRf/Framework/jni/engine/importer/importer.h
@@ -35,7 +35,7 @@ private:
 
 public:
     static AssimpImporter* readFileFromAssets(char* buffer, long size, const char * hint_string);
-    static AssimpImporter* readFileFromSDCard(std::string str);
+    static AssimpImporter* readFileFromSDCard(const char * filename);
 };
 }
 #endif

--- a/GVRf/Framework/jni/engine/importer/importer_jni.cpp
+++ b/GVRf/Framework/jni/engine/importer/importer_jni.cpp
@@ -36,7 +36,7 @@ Java_org_gearvrf_NativeImporter_readFileFromSDCard(JNIEnv * env,
         jobject obj, jstring filename);
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeImporter_readFromByteArray(JNIEnv * env,
-        jobject obj, jbyteArray bytes, jstring hint);
+        jobject obj, jbyteArray bytes, jstring filename);
 }
 
 JNIEXPORT jlong JNICALL
@@ -53,14 +53,8 @@ Java_org_gearvrf_NativeImporter_readFileFromAssets(JNIEnv * env,
     char* buffer = (char*) malloc(sizeof(char) * size);
     AAsset_read(asset, buffer, size);
 
-    AssimpImporter* assimp_scene = NULL;
-    /* Retrieve the file extension and pass it as hint */
-    char* dot = strrchr(native_string, '.');
-    if (!dot || dot == native_string) {
-        assimp_scene = Importer::readFileFromAssets(buffer, size, 0);
-    } else {
-        assimp_scene = Importer::readFileFromAssets(buffer, size, dot + 1);
-    }
+    AssimpImporter* assimp_scene = Importer::readFileFromAssets(
+            buffer, size, native_string);
 
     AAsset_close(asset);
 
@@ -73,16 +67,16 @@ Java_org_gearvrf_NativeImporter_readFileFromAssets(JNIEnv * env,
 
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeImporter_readFromByteArray(JNIEnv * env,jobject obj,
-        jbyteArray bytes, jstring hint) {
+        jbyteArray bytes, jstring filename) {
     jbyte* data = env->GetByteArrayElements(bytes, 0);
     int length = static_cast<int>(env->GetArrayLength(bytes));
-    const char* native_hint_string = env->GetStringUTFChars(hint, 0);
+    const char* native_string = env->GetStringUTFChars(filename, 0);
 
     AssimpImporter* assimp_scene = Importer::readFileFromAssets(
-            (char*)data, length, native_hint_string);
+            (char*)data, length, native_string);
 
     env->ReleaseByteArrayElements(bytes, data, 0);
-    env->ReleaseStringUTFChars(hint, native_hint_string);
+    env->ReleaseStringUTFChars(filename, native_string);
 
     return reinterpret_cast<jlong>(assimp_scene);
 }

--- a/GVRf/Framework/jni/engine/importer/importer_jni.cpp
+++ b/GVRf/Framework/jni/engine/importer/importer_jni.cpp
@@ -91,14 +91,7 @@ JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeImporter_readFileFromSDCard(JNIEnv * env,
         jobject obj, jstring filename) {
     const char* native_string = env->GetStringUTFChars(filename, 0);
-
-    std::ifstream ifs(native_string);
-    std::string str((std::istreambuf_iterator<char>(ifs)),
-            std::istreambuf_iterator<char>());
-
-    AssimpImporter* assimp_scene = Importer::readFileFromSDCard(str);
-
-    ifs.close();
+    AssimpImporter* assimp_scene = Importer::readFileFromSDCard(native_string);
 
     env->ReleaseStringUTFChars(filename, native_string);
 

--- a/GVRf/Framework/src/org/gearvrf/GVRAndroidResource.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRAndroidResource.java
@@ -59,7 +59,7 @@ public class GVRAndroidResource {
     private final int resourceId;
     private final String assetPath;
     // For hint to Assimp
-    private String resFilePath;
+    private String resourceFilePath;
 
     /**
      * Open any file you have permission to read.
@@ -77,7 +77,7 @@ public class GVRAndroidResource {
         filePath = path;
         resourceId = 0; // No R.whatever field will ever be 0
         assetPath = null;
-        resFilePath = null;
+        resourceFilePath = null;
     }
 
     /**
@@ -123,7 +123,7 @@ public class GVRAndroidResource {
         assetPath = null;
         TypedValue value = new TypedValue();
         resources.getValue(resourceId, value, true);
-        resFilePath = value.string.toString();
+        resourceFilePath = value.string.toString();
     }
 
     /**
@@ -166,7 +166,7 @@ public class GVRAndroidResource {
         filePath = null;
         resourceId = 0; // No R.whatever field will ever be 0
         assetPath = assetRelativeFilename;
-        resFilePath = null;
+        resourceFilePath = null;
     }
 
     /**
@@ -253,8 +253,8 @@ public class GVRAndroidResource {
         if (filePath != null) {
             return filePath.substring(filePath.lastIndexOf(File.separator) + 1);
         } else if (resourceId != 0) {
-            if (resFilePath != null) {
-                return resFilePath.substring(resFilePath
+            if (resourceFilePath != null) {
+                return resourceFilePath.substring(resourceFilePath
                         .lastIndexOf(File.separator) + 1);
             }
         } else if (assetPath != null) {

--- a/GVRf/Framework/src/org/gearvrf/GVRAndroidResource.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRAndroidResource.java
@@ -235,6 +235,25 @@ public class GVRAndroidResource {
         }
     }
 
+    /**
+     * Returns the filename of the resource with extension.
+     * 
+     * @return Filename of the GVRAndroidResource. May return null if the
+     *         resource is not associated with any file
+     */
+    public String getResourceFilename() {
+        if (filePath != null) {
+            return filePath.substring(filePath.lastIndexOf(File.separator) + 1);
+        } else if (resourceId != 0) {
+            // TODO: Get Android resource filename.
+            return null;
+        } else if (assetPath != null) {
+            return assetPath
+                    .substring(assetPath.lastIndexOf(File.separator) + 1);
+        }
+        return null;
+    }
+
     /*
      * Auto-generated hashCode() and equals(), for container support &c.
      * 

--- a/GVRf/Framework/src/org/gearvrf/GVRAndroidResource.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRAndroidResource.java
@@ -26,6 +26,7 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
+import android.util.TypedValue;
 
 /**
  * A class to minimize overload fan-out.
@@ -57,6 +58,8 @@ public class GVRAndroidResource {
     private final String filePath;
     private final int resourceId;
     private final String assetPath;
+    // For hint to Assimp
+    private String resFilePath;
 
     /**
      * Open any file you have permission to read.
@@ -74,6 +77,7 @@ public class GVRAndroidResource {
         filePath = path;
         resourceId = 0; // No R.whatever field will ever be 0
         assetPath = null;
+        resFilePath = null;
     }
 
     /**
@@ -117,6 +121,9 @@ public class GVRAndroidResource {
         filePath = null;
         this.resourceId = resourceId;
         assetPath = null;
+        TypedValue value = new TypedValue();
+        resources.getValue(resourceId, value, true);
+        resFilePath = value.string.toString();
     }
 
     /**
@@ -159,6 +166,7 @@ public class GVRAndroidResource {
         filePath = null;
         resourceId = 0; // No R.whatever field will ever be 0
         assetPath = assetRelativeFilename;
+        resFilePath = null;
     }
 
     /**
@@ -245,8 +253,10 @@ public class GVRAndroidResource {
         if (filePath != null) {
             return filePath.substring(filePath.lastIndexOf(File.separator) + 1);
         } else if (resourceId != 0) {
-            // TODO: Get Android resource filename.
-            return null;
+            if (resFilePath != null) {
+                return resFilePath.substring(resFilePath
+                        .lastIndexOf(File.separator) + 1);
+            }
         } else if (assetPath != null) {
             return assetPath
                     .substring(assetPath.lastIndexOf(File.separator) + 1);

--- a/GVRf/Framework/src/org/gearvrf/GVRImporter.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRImporter.java
@@ -69,17 +69,12 @@ class GVRImporter {
             } finally {
                 resource.closeStream();
             }
-            /* File extension as hint to Assimp */
             String resourceFilename = resource.getResourceFilename();
-            String extention = "";
-            if (resourceFilename != null) {
-                int dot = resourceFilename.lastIndexOf(".");
-                if (dot > 0) {
-                    extention = resourceFilename.substring(dot + 1);
-                }
+            if (resourceFilename == null) {
+                resourceFilename = ""; // Passing null causes JNI exception.
             }
             long nativeValue = NativeImporter.readFromByteArray(bytes,
-                    extention);
+                    resourceFilename);
             return new GVRAssimpImporter(gvrContext, nativeValue);
         } catch (IOException e) {
             e.printStackTrace();
@@ -113,5 +108,5 @@ class NativeImporter {
 
     static native long readFileFromSDCard(String filename);
 
-    static native long readFromByteArray(byte[] bytes, String hint);
+    static native long readFromByteArray(byte[] bytes, String filename);
 }

--- a/GVRf/Framework/src/org/gearvrf/GVRImporter.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRImporter.java
@@ -43,7 +43,6 @@ class GVRImporter {
      * @return An instance of {@link GVRAssimpImporter} or {@code null} if the
      *         file does not exist (or cannot be read)
      */
-    @SuppressWarnings("resource")
     static GVRAssimpImporter readFileFromAssets(GVRContext gvrContext,
             String filename) {
         long nativeValue = NativeImporter.readFileFromAssets(gvrContext
@@ -70,7 +69,17 @@ class GVRImporter {
             } finally {
                 resource.closeStream();
             }
-            long nativeValue = NativeImporter.readFromByteArray(bytes);
+            /* File extension as hint to Assimp */
+            String resourceFilename = resource.getResourceFilename();
+            String extention = "";
+            if (resourceFilename != null) {
+                int dot = resourceFilename.lastIndexOf(".");
+                if (dot > 0) {
+                    extention = resourceFilename.substring(dot + 1);
+                }
+            }
+            long nativeValue = NativeImporter.readFromByteArray(bytes,
+                    extention);
             return new GVRAssimpImporter(gvrContext, nativeValue);
         } catch (IOException e) {
             e.printStackTrace();
@@ -104,5 +113,5 @@ class NativeImporter {
 
     static native long readFileFromSDCard(String filename);
 
-    static native long readFromByteArray(byte[] bytes);
+    static native long readFromByteArray(byte[] bytes, String hint);
 }


### PR DESCRIPTION
Now passing hint parameter to Assimp::Importer.ReadFileFromMemory() function. Without hint Assimp fail to determine the format for some mesh type and result in no mesh loading. To verify this change can try to load any fbx file. Currently only FBX mesh is supported as GearVRf don't have support for embedded texture, UV from models.

PS - Pull request #153 is needed for this patch to work.

GearVRf-DCO-1.0-Signed-off-by: Deepak Rawat
drawat@usc.edu