### PR TITLE
Null check in case Assimp is not able to load scene

### DIFF
--- a/GVRf/Framework/jni/engine/importer/assimp_importer.cpp
+++ b/GVRf/Framework/jni/engine/importer/assimp_importer.cpp
@@ -26,6 +26,12 @@ namespace gvr {
 Mesh* AssimpImporter::getMesh(int index) {
     Mesh* mesh = new Mesh();
 
+    if (assimp_importer_->GetScene() == 0) {
+        LOGE("_ASSIMP_SCENE_NOT_FOUND_");
+        delete mesh;
+        return 0;
+    }
+
     aiMesh* ai_mesh = assimp_importer_->GetScene()->mMeshes[index];
 
     std::vector<glm::vec3> vertices;

--- a/GVRf/Framework/jni/engine/importer/assimp_importer.h
+++ b/GVRf/Framework/jni/engine/importer/assimp_importer.h
@@ -27,6 +27,7 @@
 #include "assimp/scene.h"
 
 #include "objects/hybrid_object.h"
+#include "util/gvr_log.h"
 
 namespace gvr {
 class Mesh;
@@ -42,7 +43,11 @@ public:
     }
 
     unsigned int getNumberOfMeshes() {
-        return assimp_importer_->GetScene()->mNumMeshes;
+        if (assimp_importer_->GetScene() != 0) {
+            return assimp_importer_->GetScene()->mNumMeshes;
+        }
+        LOGE("_ASSIMP_SCENE_NOT_FOUND_");
+        return 0;
     }
 
     Mesh* getMesh(int index);


### PR DESCRIPTION
If due to bad file format Assimp is not able to load a file, assimp_importer_->GetScene() will give NULL but GearVRf was not checking for it. Added NULL check for that. Now if a bad file format is loaded GearVRf will not crash and show a error log instead.

GearVRf-DCO-1.0-Signed-off-by: Deepak Rawat
drawat@usc.edu