### PR TITLE
 Fixed a issues which was causing material native ptr to be null.

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
@@ -346,7 +346,6 @@ public class GVRRenderData extends GVRComponent {
     public void setMaterial(GVRMaterial material, int passIndex) {
         if (passIndex < mRenderPassList.size()) {
             mRenderPassList.get(passIndex).setMaterial(material);
-            //NativeRenderData.setMaterial(getNative(), material.getNative(), passIndex);
         } else {
             Log.e(TAG, "Trying to set material from invalid pass. Pass " + passIndex + " was not created.");
         }

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderPass.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderPass.java
@@ -80,7 +80,7 @@ public class GVRRenderPass extends GVRHybridObject {
      */
     public GVRRenderPass(GVRContext gvrContext) {
         super(gvrContext, NativeRenderPass.ctor());
-        mMaterial = new GVRMaterial(gvrContext, 0);
+        mMaterial = new GVRMaterial(gvrContext);
         mCullFace = GVRCullFaceEnum.Back;
     }
 


### PR DESCRIPTION
On GVRRenderPass a material was being construct with wrong constructor call causing native ptr to be set to null by mistake.

GearVRf-DCO-1.0-Signed-off-by: Phil Lira
f.lira@samsung.com