### PR TITLE
Remove redundant uses of GVRRenderTexture in GVRRenderBundle.

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -470,7 +470,7 @@ bool Renderer::is_cube_in_frustum(float frustum[6][4],
 }
 
 void Renderer::renderCamera(Scene* scene, Camera* camera,
-        RenderTexture* render_texture, ShaderManager* shader_manager,
+        ShaderManager* shader_manager,
         PostEffectShaderManager* post_effect_shader_manager,
         RenderTexture* post_effect_render_texture_a,
         RenderTexture* post_effect_render_texture_b, glm::mat4 vp_matrix) {

--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -473,7 +473,7 @@ void Renderer::renderCamera(Scene* scene, Camera* camera,
         ShaderManager* shader_manager,
         PostEffectShaderManager* post_effect_shader_manager,
         RenderTexture* post_effect_render_texture_a,
-        RenderTexture* post_effect_render_texture_b, glm::mat4 vp_matrix) {
+        RenderTexture* post_effect_render_texture_b) {
     GLint curFBO;
     GLint viewport[4];
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &curFBO);

--- a/GVRf/Framework/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/jni/engine/renderer/renderer.h
@@ -79,7 +79,6 @@ public:
 
     static void renderCamera(Scene* scene,
             Camera* camera,
-            RenderTexture* render_texture,
             ShaderManager* shader_manager,
             PostEffectShaderManager* post_effect_shader_manager,
             RenderTexture* post_effect_render_texture_a,

--- a/GVRf/Framework/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/jni/engine/renderer/renderer.h
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-
 /***************************************************************************
  * Renders a scene, a screen.
  ***************************************************************************/
@@ -52,38 +51,31 @@ private:
     Renderer();
 
 public:
-    static void renderCamera(Scene* scene,
-            Camera* camera,
-            int framebufferId,
+    static void renderCamera(Scene* scene, Camera* camera, int framebufferId,
             int viewportX, int viewportY, int viewportWidth, int viewportHeight,
             ShaderManager* shader_manager,
             PostEffectShaderManager* post_effect_shader_manager,
             RenderTexture* post_effect_render_texture_a,
             RenderTexture* post_effect_render_texture_b);
 
-    static void renderCamera(Scene* scene,
-            Camera* camera,
-            RenderTexture* render_texture,
+    static void renderCamera(Scene* scene, Camera* camera,
+            RenderTexture* render_texture, ShaderManager* shader_manager,
+            PostEffectShaderManager* post_effect_shader_manager,
+            RenderTexture* post_effect_render_texture_a,
+            RenderTexture* post_effect_render_texture_b);
+
+    static void renderCamera(Scene* scene, Camera* camera, int viewportX,
+            int viewportY, int viewportWidth, int viewportHeight,
             ShaderManager* shader_manager,
             PostEffectShaderManager* post_effect_shader_manager,
             RenderTexture* post_effect_render_texture_a,
             RenderTexture* post_effect_render_texture_b);
 
-    static void renderCamera(Scene* scene,
-            Camera* camera,
-            int viewportX, int viewportY, int viewportWidth, int viewportHeight,
+    static void renderCamera(Scene* scene, Camera* camera,
             ShaderManager* shader_manager,
             PostEffectShaderManager* post_effect_shader_manager,
             RenderTexture* post_effect_render_texture_a,
             RenderTexture* post_effect_render_texture_b);
-
-    static void renderCamera(Scene* scene,
-            Camera* camera,
-            ShaderManager* shader_manager,
-            PostEffectShaderManager* post_effect_shader_manager,
-            RenderTexture* post_effect_render_texture_a,
-            RenderTexture* post_effect_render_texture_b,
-            glm::mat4 vp_matrix);
 
     static void initializeStats();
     static void resetStats();
@@ -92,21 +84,21 @@ public:
 
 private:
     static void renderRenderData(RenderData* render_data,
-    		const glm::mat4& view_matrix, const glm::mat4& projection_matrix, int render_mask,
-            ShaderManager* shader_manager);
+            const glm::mat4& view_matrix, const glm::mat4& projection_matrix,
+            int render_mask, ShaderManager* shader_manager);
     static void renderPostEffectData(Camera* camera,
-            RenderTexture* render_texture,
-            PostEffectData* post_effect_data,
+            RenderTexture* render_texture, PostEffectData* post_effect_data,
             PostEffectShaderManager* post_effect_shader_manager);
 
-    static void occlusion_cull(Scene* scene, std::vector <  SceneObject* > scene_objects);
+    static void occlusion_cull(Scene* scene,
+            std::vector<SceneObject*> scene_objects);
     static void frustum_cull(Scene* scene, Camera *camera,
-        std::vector < SceneObject* > scene_objects,
-        std::vector < RenderData* >& render_data_vector,
-        glm::mat4 vp_matrix,
-        ShaderManager* shader_manager);
+            std::vector<SceneObject*> scene_objects,
+            std::vector<RenderData*>& render_data_vector, glm::mat4 vp_matrix,
+            ShaderManager* shader_manager);
     static void build_frustum(float frustum[6][4], float mvp_matrix[16]);
-    static bool is_cube_in_frustum( float frustum[6][4], const float *vertex_limit);
+    static bool is_cube_in_frustum(float frustum[6][4],
+            const float *vertex_limit);
 
     static void set_face_culling(int cull_face);
 

--- a/GVRf/Framework/jni/oculus/view_manager.cpp
+++ b/GVRf/Framework/jni/oculus/view_manager.cpp
@@ -24,56 +24,57 @@ namespace gvr {
 extern "C" {
 
 void Java_org_gearvrf_GVRViewManager_renderCamera(JNIEnv * jni, jclass clazz,
-		jlong appPtr, jlong jscene, jlong jcamera, jlong jrender_texture,
-		jlong jshader_manager, jlong jpost_effect_shader_manager,
-		jlong jpost_effect_render_texture_a,
-		jlong jpost_effect_render_texture_b) {
-	GVRActivity *activity = (GVRActivity*) ((OVR::App *) appPtr)->GetAppInterface();
+        jlong appPtr, jlong jscene, jlong jcamera, jlong jshader_manager,
+        jlong jpost_effect_shader_manager, jlong jpost_effect_render_texture_a,
+        jlong jpost_effect_render_texture_b) {
+    GVRActivity *activity =
+            (GVRActivity*) ((OVR::App *) appPtr)->GetAppInterface();
 
-	Scene* scene = reinterpret_cast<Scene*>(jscene);
-	Camera* camera = reinterpret_cast<Camera*>(jcamera);
-	RenderTexture* render_texture = reinterpret_cast<RenderTexture*>(jrender_texture);
-	ShaderManager* shader_manager = reinterpret_cast<ShaderManager*>(jshader_manager);
-	PostEffectShaderManager* post_effect_shader_manager =
-			reinterpret_cast<PostEffectShaderManager*>(jpost_effect_shader_manager);
-	RenderTexture* post_effect_render_texture_a =
-			reinterpret_cast<RenderTexture*>(jpost_effect_render_texture_a);
-	RenderTexture* post_effect_render_texture_b =
-			reinterpret_cast<RenderTexture*>(jpost_effect_render_texture_b);
+    Scene* scene = reinterpret_cast<Scene*>(jscene);
+    Camera* camera = reinterpret_cast<Camera*>(jcamera);
+    ShaderManager* shader_manager =
+            reinterpret_cast<ShaderManager*>(jshader_manager);
+    PostEffectShaderManager* post_effect_shader_manager =
+            reinterpret_cast<PostEffectShaderManager*>(jpost_effect_shader_manager);
+    RenderTexture* post_effect_render_texture_a =
+            reinterpret_cast<RenderTexture*>(jpost_effect_render_texture_a);
+    RenderTexture* post_effect_render_texture_b =
+            reinterpret_cast<RenderTexture*>(jpost_effect_render_texture_b);
 
-	activity->viewManager->renderCamera(activity->Scene, scene, camera,
-			render_texture, shader_manager, post_effect_shader_manager,
-			post_effect_render_texture_a, post_effect_render_texture_b,
-			activity->viewManager->mvp_matrix);
+    activity->viewManager->renderCamera(activity->Scene, scene, camera,
+            shader_manager, post_effect_shader_manager,
+            post_effect_render_texture_a, post_effect_render_texture_b,
+            activity->viewManager->mvp_matrix);
 }
 
 void Java_org_gearvrf_GVRViewManager_readRenderResultNative(JNIEnv * jni,
-		jclass clazz, jlong jrender_texture, jobject jreadback_buffer) {
+        jclass clazz, jlong jrender_texture, jobject jreadback_buffer) {
 
-	uint8_t *pReadbackBuffer = (uint8_t *) jni->GetDirectBufferAddress(
-			jreadback_buffer);
-	RenderTexture* render_texture = reinterpret_cast<RenderTexture*>(jrender_texture);
-	int width = render_texture->width();
-	int height = render_texture->height();
+    uint8_t *pReadbackBuffer = (uint8_t *) jni->GetDirectBufferAddress(
+            jreadback_buffer);
+    RenderTexture* render_texture =
+            reinterpret_cast<RenderTexture*>(jrender_texture);
+    int width = render_texture->width();
+    int height = render_texture->height();
 
-	// remember current FBO bindings
-	GLint currentReadFBO, currentDrawFBO;
-	glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &currentReadFBO);
-	glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &currentDrawFBO);
+    // remember current FBO bindings
+    GLint currentReadFBO, currentDrawFBO;
+    glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &currentReadFBO);
+    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &currentDrawFBO);
 
-	// blit the multisampled FBO to a normal FBO and read from it
-	GLuint renderTextureFBO = render_texture->getFrameBufferId();
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, renderTextureFBO);
-	glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
-			GL_COLOR_BUFFER_BIT, GL_NEAREST);
-	glBindFramebuffer(GL_READ_FRAMEBUFFER, renderTextureFBO);
+    // blit the multisampled FBO to a normal FBO and read from it
+    GLuint renderTextureFBO = render_texture->getFrameBufferId();
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, renderTextureFBO);
+    glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
+            GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, renderTextureFBO);
 
-	glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
-			pReadbackBuffer);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
+            pReadbackBuffer);
 
-	// recover FBO bindings
-	glBindFramebuffer(GL_READ_FRAMEBUFFER, currentReadFBO);
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, currentDrawFBO);
+    // recover FBO bindings
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, currentReadFBO);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, currentDrawFBO);
 }
 
 } // extern "C"
@@ -83,66 +84,62 @@ void Java_org_gearvrf_GVRViewManager_readRenderResultNative(JNIEnv * jni,
 //=============================================================================
 
 GVRViewManager::GVRViewManager(JNIEnv & jni_, jobject activityObject_) {
-	// initial
-	m_frameRendered = 0;
-	m_fps = 0.0;
-	m_startTime = m_currentTime = 0.0f;
-	gNumFrame = 0;
+    // initial
+    m_frameRendered = 0;
+    m_fps = 0.0;
+    m_startTime = m_currentTime = 0.0f;
+    gNumFrame = 0;
 
-	LOG("GVRViewManager::GVRViewManager");
+    LOG("GVRViewManager::GVRViewManager");
 }
 
 GVRViewManager::~GVRViewManager() {
-	LOG("GVRViewManager::~GVRViewManager()");
+    LOG("GVRViewManager::~GVRViewManager()");
 }
 
-void GVRViewManager::renderCamera(OVR::OvrSceneView &ovr_scene,
-		Scene* scene,
-		Camera* camera,
-		RenderTexture* render_texture,
-		ShaderManager* shader_manager,
-		PostEffectShaderManager* post_effect_shader_manager,
-		RenderTexture* post_effect_render_texture_a,
-		RenderTexture* post_effect_render_texture_b,
-		glm::mat4 mvp) {
+void GVRViewManager::renderCamera(OVR::OvrSceneView &ovr_scene, Scene* scene,
+        Camera* camera, ShaderManager* shader_manager,
+        PostEffectShaderManager* post_effect_shader_manager,
+        RenderTexture* post_effect_render_texture_a,
+        RenderTexture* post_effect_render_texture_b, glm::mat4 mvp) {
 #ifdef GVRF_FBO_FPS
-	// starting to collect rendering time
-	// first flash GPU tasks
-	glFinish();
+    // starting to collect rendering time
+    // first flash GPU tasks
+    glFinish();
 
-	// collect data
-	struct timeval start, end;
-	double t1, t2;
-	float fps = 0.0;
-	gettimeofday(&start, NULL);
+    // collect data
+    struct timeval start, end;
+    double t1, t2;
+    float fps = 0.0;
+    gettimeofday(&start, NULL);
 #endif
 
-	if (camera->render_mask() == 1) {
-		glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
-	} else {
-		glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
-	}
-	glClear (GL_COLOR_BUFFER_BIT);
+    if (camera->render_mask() == 1) {
+        glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
+    } else {
+        glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
+    }
+    glClear (GL_COLOR_BUFFER_BIT);
 
-	Renderer::renderCamera(scene, camera, render_texture, shader_manager,
-			post_effect_shader_manager, post_effect_render_texture_a,
-			post_effect_render_texture_b, mvp);
+    Renderer::renderCamera(scene, camera, shader_manager,
+            post_effect_shader_manager, post_effect_render_texture_a,
+            post_effect_render_texture_b, mvp);
 
 #ifdef GVRF_FBO_FPS
-	// finish rendering
-	glFinish();// force rendering
+    // finish rendering
+    glFinish();// force rendering
 
-	gettimeofday(&end, NULL);
-	t1 = start.tv_sec + (start.tv_usec / 1000000.0);
-	t2 = end.tv_sec + (end.tv_usec / 1000000.0);
-	gTotalSec += (t2 - t1);
-	gNumFrame++;
+    gettimeofday(&end, NULL);
+    t1 = start.tv_sec + (start.tv_usec / 1000000.0);
+    t2 = end.tv_sec + (end.tv_usec / 1000000.0);
+    gTotalSec += (t2 - t1);
+    gNumFrame++;
 
-	fps = (float)gNumFrame/gTotalSec;
-	if(!(gNumFrame%50) )
-	{
-		LOGI("FPS is %.2f gNumFrame=%d, gTotalSec = %.2f", fps, gNumFrame, gTotalSec);
-	}
+    fps = (float)gNumFrame/gTotalSec;
+    if(!(gNumFrame%50) )
+    {
+        LOGI("FPS is %.2f gNumFrame=%d, gTotalSec = %.2f", fps, gNumFrame, gTotalSec);
+    }
 #endif
 
 }

--- a/GVRf/Framework/jni/oculus/view_manager.cpp
+++ b/GVRf/Framework/jni/oculus/view_manager.cpp
@@ -43,8 +43,7 @@ void Java_org_gearvrf_GVRViewManager_renderCamera(JNIEnv * jni, jclass clazz,
 
     activity->viewManager->renderCamera(activity->Scene, scene, camera,
             shader_manager, post_effect_shader_manager,
-            post_effect_render_texture_a, post_effect_render_texture_b,
-            activity->viewManager->mvp_matrix);
+            post_effect_render_texture_a, post_effect_render_texture_b);
 }
 
 void Java_org_gearvrf_GVRViewManager_readRenderResultNative(JNIEnv * jni,
@@ -57,12 +56,12 @@ void Java_org_gearvrf_GVRViewManager_readRenderResultNative(JNIEnv * jni,
     int width = render_texture->width();
     int height = render_texture->height();
 
-    // remember current FBO bindings
+// remember current FBO bindings
     GLint currentReadFBO, currentDrawFBO;
     glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &currentReadFBO);
     glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &currentDrawFBO);
 
-    // blit the multisampled FBO to a normal FBO and read from it
+// blit the multisampled FBO to a normal FBO and read from it
     GLuint renderTextureFBO = render_texture->getFrameBufferId();
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, renderTextureFBO);
     glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
@@ -72,7 +71,7 @@ void Java_org_gearvrf_GVRViewManager_readRenderResultNative(JNIEnv * jni,
     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
             pReadbackBuffer);
 
-    // recover FBO bindings
+// recover FBO bindings
     glBindFramebuffer(GL_READ_FRAMEBUFFER, currentReadFBO);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, currentDrawFBO);
 }
@@ -101,7 +100,7 @@ void GVRViewManager::renderCamera(OVR::OvrSceneView &ovr_scene, Scene* scene,
         Camera* camera, ShaderManager* shader_manager,
         PostEffectShaderManager* post_effect_shader_manager,
         RenderTexture* post_effect_render_texture_a,
-        RenderTexture* post_effect_render_texture_b, glm::mat4 mvp) {
+        RenderTexture* post_effect_render_texture_b) {
 #ifdef GVRF_FBO_FPS
     // starting to collect rendering time
     // first flash GPU tasks
@@ -123,7 +122,7 @@ void GVRViewManager::renderCamera(OVR::OvrSceneView &ovr_scene, Scene* scene,
 
     Renderer::renderCamera(scene, camera, shader_manager,
             post_effect_shader_manager, post_effect_render_texture_a,
-            post_effect_render_texture_b, mvp);
+            post_effect_render_texture_b);
 
 #ifdef GVRF_FBO_FPS
     // finish rendering

--- a/GVRf/Framework/jni/oculus/view_manager.h
+++ b/GVRf/Framework/jni/oculus/view_manager.h
@@ -50,7 +50,6 @@ public:
     void renderCamera(OVR::OvrSceneView &ovr_scene,
                         Scene* scene,
                         Camera* camera,
-                        RenderTexture* render_texture,
                         ShaderManager* shader_manager,
                         PostEffectShaderManager* post_effect_shader_manager,
                         RenderTexture* post_effect_render_texture_a,

--- a/GVRf/Framework/jni/oculus/view_manager.h
+++ b/GVRf/Framework/jni/oculus/view_manager.h
@@ -53,8 +53,7 @@ public:
                         ShaderManager* shader_manager,
                         PostEffectShaderManager* post_effect_shader_manager,
                         RenderTexture* post_effect_render_texture_a,
-                        RenderTexture* post_effect_render_texture_b,
-                        glm::mat4 mvp);
+                        RenderTexture* post_effect_render_texture_b);
 
     glm::mat4 mvp_matrix;
 

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderBundle.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderBundle.java
@@ -21,8 +21,6 @@ class GVRRenderBundle {
     private final GVRLensInfo mData;
     private final GVRMaterialShaderManager mMaterialShaderManager;
     private final GVRPostEffectShaderManager mPostEffectShaderManager;
-    private GVRRenderTexture mLeftRenderTexture = null;
-    private GVRRenderTexture mRightRenderTexture = null;
     private GVRRenderTexture mPostEffectRenderTextureA = null;
     private GVRRenderTexture mPostEffectRenderTextureB = null;
 
@@ -57,14 +55,6 @@ class GVRRenderBundle {
         return mPostEffectShaderManager;
     }
 
-    GVRRenderTexture getLeftRenderTexture() {
-        return mLeftRenderTexture;
-    }
-
-    GVRRenderTexture getRightRenderTexture() {
-        return mRightRenderTexture;
-    }
-
     GVRRenderTexture getPostEffectRenderTextureA() {
         return mPostEffectRenderTextureA;
     }
@@ -83,19 +73,11 @@ class GVRRenderBundle {
             }
         }
         if (sampleCount <= 1) {
-            mLeftRenderTexture = new GVRRenderTexture(mGVRContext,
-                    mData.getFBOWidth(), mData.getFBOHeight());
-            mRightRenderTexture = new GVRRenderTexture(mGVRContext,
-                    mData.getFBOWidth(), mData.getFBOHeight());
             mPostEffectRenderTextureA = new GVRRenderTexture(mGVRContext,
                     mData.getFBOWidth(), mData.getFBOHeight());
             mPostEffectRenderTextureB = new GVRRenderTexture(mGVRContext,
                     mData.getFBOWidth(), mData.getFBOHeight());
         } else {
-            mLeftRenderTexture = new GVRRenderTexture(mGVRContext,
-                    mData.getFBOWidth(), mData.getFBOHeight(), sampleCount);
-            mRightRenderTexture = new GVRRenderTexture(mGVRContext,
-                    mData.getFBOWidth(), mData.getFBOHeight(), sampleCount);
             mPostEffectRenderTextureA = new GVRRenderTexture(mGVRContext,
                     mData.getFBOWidth(), mData.getFBOHeight(), sampleCount);
             mPostEffectRenderTextureB = new GVRRenderTexture(mGVRContext,

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -107,9 +107,8 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
     int mReadbackBufferWidth = 0, mReadbackBufferHeight = 0;
 
     private native void renderCamera(long appPtr, long scene, long camera,
-            long renderTexture, long shaderManager,
-            long postEffectShaderManager, long postEffectRenderTextureA,
-            long postEffectRenderTextureB);
+            long shaderManager, long postEffectShaderManager,
+            long postEffectRenderTextureA, long postEffectRenderTextureB);
 
     private native void readRenderResultNative(long renderTexture,
             Object readbackBuffer);
@@ -238,13 +237,11 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
     }
 
     private void renderCamera(long activity_ptr, GVRScene scene,
-            GVRCamera camera, GVRRenderTexture renderTexture,
-            GVRRenderBundle renderBundle) {
+            GVRCamera camera, GVRRenderBundle renderBundle) {
         renderCamera(activity_ptr, scene.getNative(), camera.getNative(),
-                renderTexture.getNative(), renderBundle
-                        .getMaterialShaderManager().getNative(), renderBundle
-                        .getPostEffectShaderManager().getNative(), renderBundle
-                        .getPostEffectRenderTextureA().getNative(),
+                renderBundle.getMaterialShaderManager().getNative(),
+                renderBundle.getPostEffectShaderManager().getNative(),
+                renderBundle.getPostEffectRenderTextureA().getNative(),
                 renderBundle.getPostEffectRenderTextureB().getNative());
     }
 
@@ -294,10 +291,9 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
 
     private void readRenderResult() {
         if (mReadbackBuffer == null) {
-            GVRRenderTexture renderTexture = mRenderBundle
-                    .getRightRenderTexture();
-            mReadbackBufferWidth = renderTexture.getWidth();
-            mReadbackBufferHeight = renderTexture.getHeight();
+
+            mReadbackBufferWidth = mLensInfo.getFBOWidth();
+            mReadbackBufferHeight = mLensInfo.getFBOHeight();
             mReadbackBuffer = ByteBuffer.allocateDirect(mReadbackBufferWidth
                     * mReadbackBufferHeight * 4);
             mReadbackBuffer.order(ByteOrder.nativeOrder());
@@ -344,7 +340,7 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
             int index) {
 
         renderCamera(mActivity.getAppPtr(), mMainScene, centerCamera,
-                mRenderBundle.getRightRenderTexture(), mRenderBundle);
+                mRenderBundle);
         readRenderResult();
         byteArrays[index] = Arrays.copyOf(mReadbackBuffer.array(),
                 mReadbackBuffer.array().length);
@@ -459,7 +455,7 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                 mainCameraRig.predict(4.0f / 60.0f);
                 GVRCamera rightCamera = mainCameraRig.getRightCamera();
                 renderCamera(mActivity.getAppPtr(), mMainScene, rightCamera,
-                        mRenderBundle.getRightRenderTexture(), mRenderBundle);
+                        mRenderBundle);
 
                 // if mScreenshotRightCallback is not null, capture right eye
                 if (mScreenshotRightCallback != null) {
@@ -486,9 +482,7 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                             centerCameraObject);
 
                     renderCamera(mActivity.getAppPtr(), mMainScene,
-                            centerCamera,
-                            mRenderBundle.getRightRenderTexture(),
-                            mRenderBundle);
+                            centerCamera, mRenderBundle);
 
                     centerCameraObject.detachCamera();
                     mainCameraRig.getOwnerObject().removeChildObject(
@@ -514,7 +508,7 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
 
                 GVRCamera leftCamera = mainCameraRig.getLeftCamera();
                 renderCamera(mActivity.getAppPtr(), mMainScene, leftCamera,
-                        mRenderBundle.getLeftRenderTexture(), mRenderBundle);
+                        mRenderBundle);
 
                 // if mScreenshotLeftCallback is not null, capture left eye
                 if (mScreenshotLeftCallback != null) {


### PR DESCRIPTION
Currently we are not using the left texture and right FBO created
on our own. So that those two GVRRenderTextures can be removed.
And related codes are also refactored.

GearVRf-DCO-1.0-Signed-off-by: Chao Chen
