### PR TITLE
Adding a reset() to GVRTransform.

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRTransform.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRTransform.java
@@ -396,6 +396,19 @@ public class GVRTransform extends GVRComponent {
         NativeTransform.rotateByAxisWithPivot(getNative(), angle, axisX, axisY,
                 axisZ, pivotX, pivotY, pivotZ);
     }
+
+
+    /**
+     * Reset the transform
+     *
+     * This will undo any translations, rotations, or scaling and reset the Transform back to default values.  This is the equivilent to setting the Transform to an identity matrix.
+     */
+    public void reset() {
+        setPosition(0, 0, 0);
+        setRotation(1, 0, 0, 0);
+        setScale(1, 1, 1);
+    }
+
 }
 
 class NativeTransform {


### PR DESCRIPTION
Adding a reset() to GVRTransform.  This will be the equivilent to
glLoadIdentity().

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn 
tom.flynn@samsung.com