### PR TITLE
Support head tracking based on sensor readings supplied by Oculus

### DIFF
--- a/GVRf/Framework/jni/objects/components/camera_rig_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/camera_rig_jni.cpp
@@ -114,8 +114,7 @@ Java_org_gearvrf_NativeCameraRig_predict(JNIEnv * env,
 JNIEXPORT jfloatArray JNICALL
 Java_org_gearvrf_NativeCameraRig_getLookAt(JNIEnv * env,
         jobject obj, jlong jcamera_rig);
-}
-;
+};
 
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeCameraRig_ctor(JNIEnv * env,

--- a/GVRf/Framework/jni/oculus/activity_jni.cpp
+++ b/GVRf/Framework/jni/oculus/activity_jni.cpp
@@ -60,6 +60,7 @@ GVRActivity::GVRActivity(JNIEnv & jni_, jobject activityObject_)
     , ModelLoaded( false )
     , UiJni(&jni_)
     , viewManager(NULL)
+    , cameraRig(nullptr)
 {
     viewManager = new GVRViewManager(jni_,activityObject_);
     javaObject = UiJni->NewGlobalRef( activityObject_ );
@@ -182,7 +183,7 @@ OVR::Matrix4f GVRActivity::DrawEyeView( const int eye, const float fovDegrees )
 
     SetMVPMatrix(mvp_matrix);
 
-    if (!useOculusOrientationReading) {
+    if (!useOculusOrientationReading && nullptr != cameraRig) {
        if (1 == eye) {
           cameraRig->predict(4.0f / 60.0f);
        } else {
@@ -217,7 +218,7 @@ OVR::Matrix4f GVRActivity::Frame( const OVR::VrFrame & vrFrame )
     jni->CallVoidMethod( javaObject, beforeDrawEyesMethodId );
     jni->CallVoidMethod( javaObject, drawFrameMethodId );
 
-    if (useOculusOrientationReading) {
+    if (useOculusOrientationReading && nullptr != cameraRig) {
        const ovrQuatf& orientation = vrFrame.Tracking.HeadPose.Pose.Orientation;
        glm::quat quat(orientation.w, orientation.x, orientation.y, orientation.z);
        cameraRig->owner_object()->transform()->set_rotation(glm::conjugate(glm::inverse(quat)));

--- a/GVRf/Framework/jni/oculus/activity_jni.h
+++ b/GVRf/Framework/jni/oculus/activity_jni.h
@@ -23,6 +23,7 @@
 #include "Input.h"
 #include "view_manager.h"
 #include "../objects/components/camera.h"
+#include "../objects/components/camera_rig.h"
 
 namespace gvr {
 
@@ -54,6 +55,8 @@ public:
     GVRViewManager*     viewManager;
 
     Camera*             camera;
+    CameraRig*          cameraRig;
+    bool                useOculusOrientationReading;
 private:
     glm::mat4           mvp_matrix;
     void                SetMVPMatrix(glm::mat4 mvp){

--- a/GVRf/Framework/src/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRActivity.java
@@ -55,6 +55,7 @@ public class GVRActivity extends VrActivity {
             String fromPackageName, String commandString, String uriString);
 
     static native void nativeSetCamera(long appPtr, long camera);
+    static native void nativeSetCameraRig(long appPtr, long cameraRig);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -204,6 +205,10 @@ public class GVRActivity extends VrActivity {
         mCamera = camera;
 
         nativeSetCamera(getAppPtr(), camera.getNative());
+    }
+
+    void setCameraRig(GVRCameraRig cameraRig) {
+        nativeSetCameraRig(getAppPtr(), cameraRig.getNative());
     }
 
     @Override

--- a/GVRf/Framework/src/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRScene.java
@@ -119,6 +119,11 @@ public class GVRScene extends GVRHybridObject {
     public void setMainCameraRig(GVRCameraRig cameraRig) {
         mMainCameraRig = cameraRig;
         NativeScene.setMainCameraRig(getNative(), cameraRig.getNative());
+
+        final GVRContext gvrContext = getGVRContext();
+        if (this == gvrContext.getMainScene()) {
+            gvrContext.getActivity().setCameraRig(getMainCameraRig());
+        }
     }
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -234,7 +234,7 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
          * GL Initializations.
          */
         mRenderBundle = new GVRRenderBundle(this, mLensInfo);
-        mMainScene = new GVRScene(this);
+        setMainScene(new GVRScene(this));
     }
 
     private void renderCamera(long activity_ptr, GVRScene scene,
@@ -536,7 +536,6 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
 
     /** Called once per frame, before {@link #onDrawEyeView(int, float)}. */
     void onDrawFrame() {
-        mActivity.setCameraRig(mMainScene.getMainCameraRig());
         if (mCurrentEye == 1) {
             mActivity.setCamera(mMainScene.getMainCameraRig().getLeftCamera());
         } else {
@@ -802,6 +801,9 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                 mOnSwitchMainScene.run();
                 mOnSwitchMainScene = null;
             }
+        }
+        if (null != mMainScene) {
+            getActivity().setCameraRig(mMainScene.getMainCameraRig());
         }
     }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -456,7 +456,6 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
             GVRCameraRig mainCameraRig = mMainScene.getMainCameraRig();
 
             if (eye == 1) {
-                mainCameraRig.predict(4.0f / 60.0f);
                 GVRCamera rightCamera = mainCameraRig.getRightCamera();
                 renderCamera(mActivity.getAppPtr(), mMainScene, rightCamera,
                         mRenderBundle.getRightRenderTexture(), mRenderBundle);
@@ -471,8 +470,6 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
 
                 mActivity.setCamera(rightCamera);
             } else {
-                mainCameraRig.predict(3.5f / 60.0f);
-
                 // if mScreenshotCenterCallback is not null, capture center eye
                 if (mScreenshotCenterCallback != null) {
 
@@ -539,6 +536,7 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
 
     /** Called once per frame, before {@link #onDrawEyeView(int, float)}. */
     void onDrawFrame() {
+        mActivity.setCameraRig(mMainScene.getMainCameraRig());
         if (mCurrentEye == 1) {
             mActivity.setCamera(mMainScene.getMainCameraRig().getLeftCamera());
         } else {


### PR DESCRIPTION
oculus tracking disabled by default but whomever needs it can enable
it from GVRActivity::Configure

need to work on supporting all camera rig types but planning to do
so in subsequent commit as it is not immediately needed as far as I
know