### PR TITLE
 Fixed Assimp warnings regarding gcc_struct being ignored. This chang…

### DIFF
--- a/GVRf/Framework/jni/contrib/assimp/include/assimp/Compiler/pushpack1.h
+++ b/GVRf/Framework/jni/contrib/assimp/include/assimp/Compiler/pushpack1.h
@@ -26,7 +26,7 @@
 #	pragma pack(push,1)
 #	define PACK_STRUCT
 #elif defined( __GNUC__ )
-#	if defined(__clang__)
+#	if !defined(HOST_MINGW)
 #		define PACK_STRUCT	__attribute__((__packed__))
 #	else
 #		define PACK_STRUCT	__attribute__((gcc_struct, __packed__))


### PR DESCRIPTION
This fixes the many warnings regarding gcc_struct. This changed is self contained and it was taken from new version in assimp repo. 

GearVRf-DCO-1.0-Signed-off-by: Phil Lira 
f.lira@samsung.com