### PR TITLE
Enable dynamic switching between Oculus rotation sensor reading and internal sensor reading

### DIFF
--- a/GVRf/Framework/jni/oculus/activity_jni.cpp
+++ b/GVRf/Framework/jni/oculus/activity_jni.cpp
@@ -20,6 +20,7 @@
 #include "objects/scene_object.h"
 
 static const char * activityClassName = "org/gearvrf/GVRActivity";
+static const bool canSwitchToOculusHeadTracking = true;
 
 namespace gvr {
 
@@ -47,6 +48,23 @@ void Java_org_gearvrf_GVRActivity_nativeSetCameraRig(
 {
     GVRActivity *activity = (GVRActivity*)((OVR::App *)appPtr)->GetAppInterface();
     activity->cameraRig = reinterpret_cast<CameraRig*>(jCameraRig);
+}
+
+void Java_org_gearvrf_GVRActivity_nativeOnDock(
+        JNIEnv * jni, jclass clazz, jlong appPtr)
+{
+    GVRActivity *activity = (GVRActivity*)((OVR::App *)appPtr)->GetAppInterface();
+    if (canSwitchToOculusHeadTracking) {
+        LOGV("will start using orientation readings from oculus");
+        activity->useOculusOrientationReading = true;
+    }
+}
+
+void Java_org_gearvrf_GVRActivity_nativeOnUndock(
+        JNIEnv * jni, jclass clazz, jlong appPtr)
+{
+    GVRActivity *activity = (GVRActivity*)((OVR::App *)appPtr)->GetAppInterface();
+    activity->useOculusOrientationReading = false;
 }
 
 } // extern "C"
@@ -123,7 +141,6 @@ jclass GVRActivity::GetGlobalClassReference( const char * className ) const
 void GVRActivity::Configure( OVR::ovrSettings & settings )
 {
     settings.EyeBufferParms.multisamples = 2;
-    useOculusOrientationReading = false;
     // leave the rest as default for now.
     // TODO: take values specified in xml and set them here.
 }

--- a/GVRf/Framework/src/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRActivity.java
@@ -16,6 +16,7 @@
 package org.gearvrf;
 
 import org.gearvrf.utility.Log;
+import org.gearvrf.utility.DockEventReceiver;
 
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
@@ -56,6 +57,8 @@ public class GVRActivity extends VrActivity {
 
     static native void nativeSetCamera(long appPtr, long camera);
     static native void nativeSetCameraRig(long appPtr, long cameraRig);
+    static native void nativeOnDock(long appPtr);
+    static native void nativeOnUndock(long appPtr);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -77,6 +80,8 @@ public class GVRActivity extends VrActivity {
 
         setAppPtr(nativeSetAppInterface(this, fromPackageNameString,
                 commandString, uriString));
+
+        mDockEventReceiver = new DockEventReceiver(this, mRunOnDock, mRunOnUndock);
     }
 
     @Override
@@ -85,6 +90,9 @@ public class GVRActivity extends VrActivity {
         if (mGVRViewManager != null) {
             mGVRViewManager.onPause();
         }
+        if (null != mDockEventReceiver) {
+            mDockEventReceiver.stop();
+        }
     }
 
     @Override
@@ -92,6 +100,9 @@ public class GVRActivity extends VrActivity {
         super.onResume();
         if (mGVRViewManager != null) {
             mGVRViewManager.onResume();
+        }
+        if (null != mDockEventReceiver) {
+            mDockEventReceiver.start();
         }
     }
 
@@ -249,4 +260,19 @@ public class GVRActivity extends VrActivity {
                 : onKeyUp(keyCode, event);
     }
 
+    private final Runnable mRunOnDock = new Runnable() {
+        @Override
+        public void run() {
+            nativeOnDock(getAppPtr());
+        }
+    };
+
+    private final Runnable mRunOnUndock = new Runnable() {
+        @Override
+        public void run() {
+            nativeOnUndock(getAppPtr());
+        }
+    };
+
+    private DockEventReceiver mDockEventReceiver;
 }

--- a/GVRf/Framework/src/org/gearvrf/utility/DockEventReceiver.java
+++ b/GVRf/Framework/src/org/gearvrf/utility/DockEventReceiver.java
@@ -1,0 +1,54 @@
+
+package org.gearvrf.utility;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+public final class DockEventReceiver {
+    public DockEventReceiver(final Context context, final Runnable runOnDock,
+            final Runnable runOnUndock) {
+        mRunOnDock = runOnDock;
+        mRunOnUndock = runOnUndock;
+        mApplicationContext = context.getApplicationContext();
+    }
+
+    public void start() {
+        if (!mIsStarted) {
+            final IntentFilter dockEventFilter = new IntentFilter();
+            dockEventFilter.addAction(Intent.ACTION_DOCK_EVENT);
+            mApplicationContext.registerReceiver(mBroadcastReceiver, dockEventFilter);
+            mIsStarted = true;
+        }
+    }
+
+    public void stop() {
+        if (mIsStarted) {
+            mApplicationContext.unregisterReceiver(mBroadcastReceiver);
+            mIsStarted = false;
+        }
+    }
+
+    private final class BroadcastReceiverImpl extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, final Intent intent) {
+            if (Intent.ACTION_DOCK_EVENT.equals(intent.getAction())) {
+                final int dockState = intent.getIntExtra(Intent.EXTRA_DOCK_STATE, Intent.EXTRA_DOCK_STATE_UNDOCKED);
+                if (Intent.EXTRA_DOCK_STATE_UNDOCKED == dockState && null != mRunOnUndock) {
+                    mRunOnUndock.run();
+                } else if (EXTRA_DOCK_STATE_HMT == dockState && null != mRunOnDock) {
+                    mRunOnDock.run();
+                }
+            }
+        }
+    }
+
+    private final BroadcastReceiver mBroadcastReceiver = new BroadcastReceiverImpl();
+    private final Context mApplicationContext;
+    private boolean mIsStarted;
+    private final Runnable mRunOnDock;
+    private final Runnable mRunOnUndock;
+
+    private final static int EXTRA_DOCK_STATE_HMT = 11;   //Intent.EXTRA_DOCK_STATE_HMT
+}


### PR DESCRIPTION
By default Oculus reading is enabled now; the default can be changed via activity_jni.cpp:canSwitchToOculusHeadTracking.