### PR TITLE
Support dynamic switching between Oculus and the internal sensor for head tracking

### DIFF
--- a/GVRf/Framework/jni/oculus/activity_jni.cpp
+++ b/GVRf/Framework/jni/oculus/activity_jni.cpp
@@ -21,7 +21,6 @@
 #include "VrApi_Types.h"
 
 static const char * activityClassName = "org/gearvrf/GVRActivity";
-static const char * app_settings_name = "org/gearvrf/utility/VrAppSettings";
 
 namespace gvr {
 
@@ -151,8 +150,6 @@ template <class PredictionTrait> void GVRActivity<PredictionTrait>::Configure(OV
     settings.UseProtectedFramebuffer = env->GetBooleanField(vrSettings,
             env->GetFieldID(vrAppSettingsClass, "useProtectedFramebuffer",
                     "Z"));
-
-
 
     //Settings for EyeBufferParms.
     jobject eyeParmsSettings = env->GetObjectField(vrSettings,

--- a/GVRf/Framework/jni/oculus/activity_jni.cpp
+++ b/GVRf/Framework/jni/oculus/activity_jni.cpp
@@ -21,6 +21,7 @@
 #include "VrApi_Types.h"
 
 static const char * activityClassName = "org/gearvrf/GVRActivity";
+static const char * app_settings_name = "org/gearvrf/utility/VrAppSettings";
 
 namespace gvr {
 
@@ -49,6 +50,20 @@ void Java_org_gearvrf_GVRActivity_nativeSetCameraRig(
     activity->cameraRig = reinterpret_cast<CameraRig*>(jCameraRig);
 }
 
+void Java_org_gearvrf_GVRActivity_nativeOnDock(
+        JNIEnv * jni, jclass clazz, jlong appPtr)
+{
+    GVRActivityReal* activity = (GVRActivityReal*)((OVR::App *)appPtr)->GetAppInterface();
+    activity->deviceIsDocked = true;
+}
+
+void Java_org_gearvrf_GVRActivity_nativeOnUndock(
+        JNIEnv * jni, jclass clazz, jlong appPtr)
+{
+    GVRActivityReal* activity = (GVRActivityReal*)((OVR::App *)appPtr)->GetAppInterface();
+    activity->deviceIsDocked = false;
+}
+
 } // extern "C"
 
 //=============================================================================
@@ -61,6 +76,7 @@ template <class PredictionTrait> GVRActivity<PredictionTrait>::GVRActivity(JNIEn
     , UiJni(&jni_)
     , viewManager(NULL)
     , cameraRig(nullptr)
+    , deviceIsDocked(false)
 {
     viewManager = new GVRViewManager(jni_,activityObject_);
     javaObject = UiJni->NewGlobalRef( activityObject_ );
@@ -368,20 +384,6 @@ template <class PredictionTrait> bool GVRActivity<PredictionTrait>::OnKeyEvent(c
     }
 
     return handled;
-}
-
-void Java_org_gearvrf_GVRActivity_nativeOnDock(
-        JNIEnv * jni, jclass clazz, jlong appPtr)
-{
-    GVRActivity *activity = (GVRActivity*)((OVR::App *)appPtr)->GetAppInterface();
-    activity->deviceIsDocked = true;
-}
-
-void Java_org_gearvrf_GVRActivity_nativeOnUndock(
-        JNIEnv * jni, jclass clazz, jlong appPtr)
-{
-    GVRActivity *activity = (GVRActivity*)((OVR::App *)appPtr)->GetAppInterface();
-    activity->deviceIsDocked = false;
 }
 
 }

--- a/GVRf/Framework/jni/oculus/activity_jni.cpp
+++ b/GVRf/Framework/jni/oculus/activity_jni.cpp
@@ -329,8 +329,6 @@ template <class PredictionTrait> OVR::Matrix4f GVRActivity<PredictionTrait>::Fra
     jni->CallVoidMethod(javaObject, beforeDrawEyesMethodId);
     jni->CallVoidMethod(javaObject, drawFrameMethodId);
 
-    deviceIsDocked = vrFrame.DeviceStatus.DeviceIsDocked;
-
 	//This is called once while DrawEyeView is called twice, when eye=0 and eye 1.
 	//So camera is set in java as one of left and right camera.
 	//Centerview camera matrix can be retrieved from its parent, CameraRig
@@ -370,6 +368,20 @@ template <class PredictionTrait> bool GVRActivity<PredictionTrait>::OnKeyEvent(c
     }
 
     return handled;
+}
+
+void Java_org_gearvrf_GVRActivity_nativeOnDock(
+        JNIEnv * jni, jclass clazz, jlong appPtr)
+{
+    GVRActivity *activity = (GVRActivity*)((OVR::App *)appPtr)->GetAppInterface();
+    activity->deviceIsDocked = true;
+}
+
+void Java_org_gearvrf_GVRActivity_nativeOnUndock(
+        JNIEnv * jni, jclass clazz, jlong appPtr)
+{
+    GVRActivity *activity = (GVRActivity*)((OVR::App *)appPtr)->GetAppInterface();
+    activity->deviceIsDocked = false;
 }
 
 }

--- a/GVRf/Framework/jni/oculus/activity_jni.h
+++ b/GVRf/Framework/jni/oculus/activity_jni.h
@@ -119,7 +119,7 @@ public:
     }
 };
 
-typedef GVRActivity<KSensorPrediction> GVRActivityReal;
+typedef GVRActivity<OculusPrediction> GVRActivityReal;
 
 }
 #endif

--- a/GVRf/Framework/src/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRActivity.java
@@ -24,7 +24,6 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Build;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.Window;
@@ -94,6 +93,14 @@ public class GVRActivity extends VrActivity {
                 commandString, uriString));
 
         mDockEventReceiver = new DockEventReceiver(this, mRunOnDock, mRunOnUndock);
+    }
+
+    protected void onInitAppSettings(VrAppSettings appSettings) {
+
+    }
+
+    public VrAppSettings getAppSettings(){
+        return mAppSettings;
     }
 
     @Override

--- a/GVRf/Framework/src/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRActivity.java
@@ -16,6 +16,7 @@
 package org.gearvrf;
 
 import org.gearvrf.utility.Log;
+import org.gearvrf.utility.DockEventReceiver;
 import org.gearvrf.utility.VrAppSettings;
 
 import android.app.Activity;
@@ -23,6 +24,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Build;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.Window;
@@ -67,6 +69,8 @@ public class GVRActivity extends VrActivity {
 
     static native void nativeSetCamera(long appPtr, long camera);
     static native void nativeSetCameraRig(long appPtr, long cameraRig);
+    static native void nativeOnDock(long appPtr);
+    static native void nativeOnUndock(long appPtr);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -88,13 +92,8 @@ public class GVRActivity extends VrActivity {
 
         setAppPtr(nativeSetAppInterface(this, fromPackageNameString,
                 commandString, uriString));
-    }
 
-    protected void onInitAppSettings(VrAppSettings appSettings) {
-
-    }
-    public VrAppSettings getAppSettings(){
-        return mAppSettings;
+        mDockEventReceiver = new DockEventReceiver(this, mRunOnDock, mRunOnUndock);
     }
 
     @Override
@@ -103,6 +102,9 @@ public class GVRActivity extends VrActivity {
         if (mGVRViewManager != null) {
             mGVRViewManager.onPause();
         }
+        if (null != mDockEventReceiver) {
+            mDockEventReceiver.stop();
+        }
     }
 
     @Override
@@ -110,6 +112,9 @@ public class GVRActivity extends VrActivity {
         super.onResume();
         if (mGVRViewManager != null) {
             mGVRViewManager.onResume();
+        }
+        if (null != mDockEventReceiver) {
+            mDockEventReceiver.start();
         }
     }
 
@@ -290,4 +295,20 @@ public class GVRActivity extends VrActivity {
     public boolean onKeyMax(int keyCode) {
         return false;
     }
+
+    private final Runnable mRunOnDock = new Runnable() {
+        @Override
+        public void run() {
+            nativeOnDock(getAppPtr());
+        }
+    };
+
+    private final Runnable mRunOnUndock = new Runnable() {
+        @Override
+        public void run() {
+            nativeOnUndock(getAppPtr());
+        }
+    };
+
+    private DockEventReceiver mDockEventReceiver;
 }

--- a/GVRf/Framework/src/org/gearvrf/utility/DockEventReceiver.java
+++ b/GVRf/Framework/src/org/gearvrf/utility/DockEventReceiver.java
@@ -1,0 +1,54 @@
+
+package org.gearvrf.utility;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+public final class DockEventReceiver {
+    public DockEventReceiver(final Context context, final Runnable runOnDock,
+            final Runnable runOnUndock) {
+        mRunOnDock = runOnDock;
+        mRunOnUndock = runOnUndock;
+        mApplicationContext = context.getApplicationContext();
+    }
+
+    public void start() {
+        if (!mIsStarted) {
+            final IntentFilter dockEventFilter = new IntentFilter();
+            dockEventFilter.addAction(Intent.ACTION_DOCK_EVENT);
+            mApplicationContext.registerReceiver(mBroadcastReceiver, dockEventFilter);
+            mIsStarted = true;
+        }
+    }
+
+    public void stop() {
+        if (mIsStarted) {
+            mApplicationContext.unregisterReceiver(mBroadcastReceiver);
+            mIsStarted = false;
+        }
+    }
+
+    private final class BroadcastReceiverImpl extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, final Intent intent) {
+            if (Intent.ACTION_DOCK_EVENT.equals(intent.getAction())) {
+                final int dockState = intent.getIntExtra(Intent.EXTRA_DOCK_STATE, Intent.EXTRA_DOCK_STATE_UNDOCKED);
+                if (Intent.EXTRA_DOCK_STATE_UNDOCKED == dockState && null != mRunOnUndock) {
+                    mRunOnUndock.run();
+                } else if (EXTRA_DOCK_STATE_HMT == dockState && null != mRunOnDock) {
+                    mRunOnDock.run();
+                }
+            }
+        }
+    }
+
+    private final BroadcastReceiver mBroadcastReceiver = new BroadcastReceiverImpl();
+    private final Context mApplicationContext;
+    private boolean mIsStarted;
+    private final Runnable mRunOnDock;
+    private final Runnable mRunOnUndock;
+
+    private final static int EXTRA_DOCK_STATE_HMT = 11;   //Intent.EXTRA_DOCK_STATE_HMT
+}


### PR DESCRIPTION
Using the Oculus docked flag is unreliable unfortunately (may have something to do with our lower-level changes but still..); have to resort to use our own dock observer to be certain switching would work.