### PR TITLE
Upgraded shaders in model-viewer sample to GLSL3

### DIFF
--- a/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/DiffuseShader2.java
+++ b/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/DiffuseShader2.java
@@ -34,9 +34,10 @@ public class DiffuseShader2 {
     public static final String MAT4_KEY = "u_mat4";
 
     private static final String VERTEX_SHADER = "" //
-            + "attribute vec4 a_position;\n"
-            + "attribute vec3 a_normal;\n" //
-            + "attribute vec2 a_tex_coord;\n"
+            + "#version 300 es\n"
+            + "in vec4 a_position;\n"
+            + "in vec3 a_normal;\n" //
+            + "in vec2 a_tex_coord;\n"
             + "uniform mat4 u_mvp;\n" //
             + "uniform vec4 u_mat1;\n"
             + "uniform vec4 u_mat2;\n" //
@@ -44,10 +45,10 @@ public class DiffuseShader2 {
             + "uniform vec4 u_mat4;\n" //
             + "uniform vec3 u_eye;\n"
             + "uniform vec3 u_light;\n" //
-            + "varying vec3 n;\n"
-            + "varying vec3 v;\n" //
-            + "varying vec3 l;\n"
-            + "varying vec2  coord;\n" //
+            + "out vec3 n;\n"
+            + "out vec3 v;\n" //
+            + "out vec3 l;\n"
+            + "out vec2  coord;\n" //
             + "void main() {\n"
             + "  mat4 model;\n"
             + "  model[0] = u_mat1;\n" //
@@ -65,15 +66,17 @@ public class DiffuseShader2 {
             + "}\n";
 
     private static final String FRAGMENT_SHADER = "" //
+            + "#version 300 es\n"
             + "precision mediump float;\n"
             + "uniform vec4  u_color;\n" //
-            + "varying vec2  coord;\n"
-            + "varying vec3  n;\n" //
-            + "varying vec3  v;\n"
-            + "varying vec3  l;\n" //
-            + "uniform sampler2D texture;\n"
+            + "in vec2  coord;\n"
+            + "in vec3  n;\n" //
+            + "in vec3  v;\n"
+            + "in vec3  l;\n" //
+            + "uniform sampler2D intexture;\n"
+            + "out vec4 FragColor;\n"
             + "void main() {\n" //
-            + "  vec4 color = texture2D(texture, coord);\n"
+            + "  vec4 color = texture(intexture, coord);\n"
             + "  vec3  h = normalize(v+l);\n"
             + "  float diffuse  = max ( dot(l,n), 0.1 );\n"
             + "  float specular = max ( dot(h,n), 0.0 );\n"
@@ -81,7 +84,7 @@ public class DiffuseShader2 {
             + "  color.rgb *= diffuse;\n" //
             + "  color.rgb *= u_color.rgb;\n"
             + "  color.rgb += 0.5*(1.0- color.rgb)*specular;\n"
-            + "  gl_FragColor = vec4( color );\n" //
+            + "  FragColor = vec4( color );\n" //
             + "}\n";
 
     private GVRCustomMaterialShaderId mShaderId;
@@ -95,7 +98,7 @@ public class DiffuseShader2 {
         mCustomShader.addUniformVec4Key("u_color", COLOR_KEY);
         mCustomShader.addUniformVec3Key("u_light", LIGHT_KEY);
         mCustomShader.addUniformVec3Key("u_eye", EYE_KEY);
-        mCustomShader.addTextureKey("texture", TEXTURE_KEY);
+        mCustomShader.addTextureKey("intexture", TEXTURE_KEY);
 
         mCustomShader.addUniformVec4Key("u_mat1", MAT1_KEY);
         mCustomShader.addUniformVec4Key("u_mat2", MAT2_KEY);

--- a/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/GlassShader2.java
+++ b/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/GlassShader2.java
@@ -35,9 +35,10 @@ public class GlassShader2 {
     public static final String MAT4_KEY = "u_mat4";
 
     private static final String VERTEX_SHADER = "" //
-            + "attribute vec4 a_position;\n"
-            + "attribute vec3 a_normal;\n" //
-            + "attribute vec2 a_tex_coord;\n"
+            + "#version 300 es\n"
+            + "in vec4 a_position;\n"
+            + "in vec3 a_normal;\n" //
+            + "in vec2 a_tex_coord;\n"
             + "uniform mat4 u_mvp;\n" //
             + "uniform vec4 u_mat1;\n"
             + "uniform vec4 u_mat2;\n" //
@@ -45,11 +46,11 @@ public class GlassShader2 {
             + "uniform vec4 u_mat4;\n" //
             + "uniform vec3 u_eye;\n"
             + "uniform vec3 u_light;\n" //
-            + "varying vec3  n;\n"
-            + "varying vec3  v;\n" //
-            + "varying vec3  l;\n"
-            + "varying vec3  p;\n" //
-            + "varying vec2  coord;\n"
+            + "out vec3  n;\n"
+            + "out vec3  v;\n" //
+            + "out vec3  l;\n"
+            + "out vec3  p;\n" //
+            + "out vec2  coord;\n"
             + "void main() {\n" //
             + "  mat4 model;\n" //
             + "  model[0] = u_mat1;\n"
@@ -68,15 +69,17 @@ public class GlassShader2 {
             + "}\n";
 
     private static final String FRAGMENT_SHADER = "" //
+            + "#version 300 es\n"
             + "precision mediump float;\n"
-            + "varying vec2  coord;\n"
+            + "in vec2  coord;\n"
             + "uniform vec4  u_color;\n"
             + "uniform float u_radius;\n"
-            + "varying vec3  n;\n"
-            + "varying vec3  v;\n"
-            + "varying vec3  l;\n"
-            + "varying vec3  p;\n"
-            + "uniform sampler2D texture;\n"
+            + "in vec3  n;\n"
+            + "in vec3  v;\n"
+            + "in vec3  l;\n"
+            + "in vec3  p;\n"
+            + "uniform sampler2D intexture;\n"
+            + "out vec4 FragColor;\n"
             + "void main() {\n"
             + "  vec3  r = normalize(reflect(v,n));\n"
             // + "  vec3  r = normalize(refract(v,n,0.86));\n"
@@ -94,7 +97,7 @@ public class GlassShader2 {
             + "  reflect_coord.y  = ray.y;\n"
             + "  reflect_coord.x = 0.5 + 0.6*asin(reflect_coord.x)/1.57079632675;\n"
             + "  reflect_coord.y = 0.5 + 0.6*asin(reflect_coord.y)/1.57079632675;\n"
-            + "  vec3 color = texture2D(texture, reflect_coord).rgb;\n"
+            + "  vec3 color = texture(intexture, reflect_coord).rgb;\n"
             + "  vec3  h = normalize(v+l);\n"
             + "  float diffuse  = max ( dot(l,n), 0.0 );\n"
             + "  float specular = max ( dot(h,n), 0.0 );\n"
@@ -102,8 +105,8 @@ public class GlassShader2 {
             + "  color *= diffuse;\n" //
             + "  color *= u_color.rgb;\n"
             + "  color += 1.5*(1.0- color)*specular;\n"
-            + "  gl_FragColor = vec4( color, 0.7 );\n"
-            + "  gl_FragColor.rgb *= gl_FragColor.a;\n" //
+            + "  FragColor = vec4( color, 0.7 );\n"
+            + "  FragColor.rgb *= FragColor.a;\n" //
             + "}\n";
 
     private GVRCustomMaterialShaderId mShaderId;
@@ -118,7 +121,7 @@ public class GlassShader2 {
         mCustomShader.addUniformVec3Key("u_light", LIGHT_KEY);
         mCustomShader.addUniformVec3Key("u_eye", EYE_KEY);
         mCustomShader.addUniformFloatKey("u_radius", RADIUS_KEY);
-        mCustomShader.addTextureKey("texture", TEXTURE_KEY);
+        mCustomShader.addTextureKey("intexture", TEXTURE_KEY);
 
         mCustomShader.addUniformVec4Key("u_mat1", MAT1_KEY);
         mCustomShader.addUniformVec4Key("u_mat2", MAT2_KEY);

--- a/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/MetalShader2.java
+++ b/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/MetalShader2.java
@@ -35,9 +35,10 @@ public class MetalShader2 {
     public static final String MAT4_KEY = "u_mat4";
 
     private static final String VERTEX_SHADER = "" //
-            + "attribute vec4 a_position;\n"
-            + "attribute vec3 a_normal;\n" //
-            + "attribute vec2 a_tex_coord;\n"
+            + "#version 300 es\n"
+            + "in vec4 a_position;\n"
+            + "in vec3 a_normal;\n" //
+            + "in vec2 a_tex_coord;\n"
             + "uniform mat4 u_mvp;\n" //
             + "uniform vec4 u_mat1;\n"
             + "uniform vec4 u_mat2;\n" //
@@ -45,11 +46,11 @@ public class MetalShader2 {
             + "uniform vec4 u_mat4;\n" //
             + "uniform vec3 u_eye;\n"
             + "uniform vec3 u_light;\n" //
-            + "varying vec3  n;\n" //
-            + "varying vec3  v;\n" //
-            + "varying vec3  l;\n"
-            + "varying vec3  p;\n" //
-            + "varying vec2  coord;\n"
+            + "out vec3  n;\n" //
+            + "out vec3  v;\n" //
+            + "out vec3  l;\n"
+            + "out vec3  p;\n" //
+            + "out vec2  coord;\n"
             + "void main() {\n" //
             + "  mat4 model;\n" //
             + "  model[0] = u_mat1;\n" //
@@ -68,15 +69,17 @@ public class MetalShader2 {
             + "}\n";
 
     private static final String FRAGMENT_SHADER = "" //
+            + "#version 300 es\n"
             + "precision mediump float;\n"
-            + "varying vec2  coord;\n"
+            + "in vec2  coord;\n"
             + "uniform vec4  u_color;\n"
             + "uniform float u_radius;\n"
-            + "varying vec3  n;\n"
-            + "varying vec3  v;\n"
-            + "varying vec3  l;\n"
-            + "varying vec3  p;\n"
-            + "uniform sampler2D texture;\n"
+            + "in vec3  n;\n"
+            + "in vec3  v;\n"
+            + "in vec3  l;\n"
+            + "in vec3  p;\n"
+            + "uniform sampler2D intexture;\n"
+            + "out vec4 FragColor;\n"
             + "void main() {\n"
             + "  vec3  r = normalize(reflect(v,n));\n"
             + "  float b = dot(r,p);\n"
@@ -93,7 +96,7 @@ public class MetalShader2 {
             + "  reflect_coord.y  = ray.y;\n"
             + "  reflect_coord.x = 0.5 + 0.6*asin(reflect_coord.x)/1.57079632675;\n"
             + "  reflect_coord.y = 0.5 + 0.6*asin(reflect_coord.y)/1.57079632675;\n"
-            + "  vec3 color = texture2D(texture, reflect_coord).rgb;\n"
+            + "  vec3 color = texture(intexture, reflect_coord).rgb;\n"
             + "  vec3  h = normalize(v+l);\n"
             + "  float viewing  = max ( dot(v,n), 0.0 );\n"
             + "  float diffuse  = max ( dot(l,n), 0.12 );\n"
@@ -102,7 +105,7 @@ public class MetalShader2 {
             + "  color *= diffuse;\n" //
             + "  color *= u_color.rgb;\n" //
             + "  color += specular;\n" //
-            + "  gl_FragColor = vec4( color, 1.0 );\n" //
+            + "  FragColor = vec4( color, 1.0 );\n" //
             + "}\n";
 
     private GVRCustomMaterialShaderId mShaderId;
@@ -117,7 +120,7 @@ public class MetalShader2 {
         mCustomShader.addUniformVec3Key("u_light", LIGHT_KEY);
         mCustomShader.addUniformVec3Key("u_eye", EYE_KEY);
         mCustomShader.addUniformFloatKey("u_radius", RADIUS_KEY);
-        mCustomShader.addTextureKey("texture", TEXTURE_KEY);
+        mCustomShader.addTextureKey("intexture", TEXTURE_KEY);
 
         mCustomShader.addUniformVec4Key("u_mat1", MAT1_KEY);
         mCustomShader.addUniformVec4Key("u_mat2", MAT2_KEY);

--- a/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/PhongShader2.java
+++ b/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/PhongShader2.java
@@ -35,9 +35,10 @@ public class PhongShader2 {
     public static final String MAT4_KEY = "u_mat4";
 
     private static final String VERTEX_SHADER = "" //
-            + "attribute vec4 a_position;\n"
-            + "attribute vec3 a_normal;\n" //
-            + "attribute vec2 a_tex_coord;\n"
+            + "#version 300 es\n"
+            + "in vec4 a_position;\n"
+            + "in vec3 a_normal;\n" //
+            + "in vec2 a_tex_coord;\n"
             + "uniform mat4 u_mvp;\n" //
             + "uniform vec4 u_mat1;\n"
             + "uniform vec4 u_mat2;\n" //
@@ -45,11 +46,11 @@ public class PhongShader2 {
             + "uniform vec4 u_mat4;\n" //
             + "uniform vec3 u_eye;\n"
             + "uniform vec3 u_light;\n" //
-            + "varying vec3 n;\n"
-            + "varying vec3 v;\n" //
-            + "varying vec3 l;\n"
-            + "varying vec3 p;\n"
-            + "varying vec2  coord;\n" //
+            + "out vec3 n;\n"
+            + "out vec3 v;\n" //
+            + "out vec3 l;\n"
+            + "out vec3 p;\n"
+            + "out vec2  coord;\n" //
             + "void main() {\n"
             + "  mat4 model;\n"
             + "  model[0] = u_mat1;\n" //
@@ -68,15 +69,17 @@ public class PhongShader2 {
             + "}\n";
 
     private static final String FRAGMENT_SHADER = "" //
+            + "#version 300 es\n"
             + "precision mediump float;\n"
-            + "varying vec2  coord;\n"
+            + "in vec2  coord;\n"
             + "uniform vec4  u_color;\n"
-            + "varying vec3  n;\n"
-            + "varying vec3  v;\n"
-            + "varying vec3  l;\n"
-            + "varying vec3  p;\n"
+            + "in vec3  n;\n"
+            + "in vec3  v;\n"
+            + "in vec3  l;\n"
+            + "in vec3  p;\n"
             + "uniform float u_radius;\n"
-            + "uniform sampler2D texture;\n"
+            + "uniform sampler2D intexture;\n"
+            + "out vec4 FragColor;\n"
             + "void main() {\n"
             + "  vec3  r = normalize(reflect(v,n));\n"
             + "  float b = dot(r,p);\n"
@@ -93,7 +96,7 @@ public class PhongShader2 {
             + "  reflect_coord.y  = ray.y;\n"
             + "  reflect_coord.x = 0.5 + 0.6*asin(reflect_coord.x)/1.57079632675;\n"
             + "  reflect_coord.y = 0.5 + 0.6*asin(reflect_coord.y)/1.57079632675;\n"
-            + "  vec3 color = texture2D(texture, reflect_coord).rgb;\n"
+            + "  vec3 color = texture(intexture, reflect_coord).rgb;\n"
             + "  vec3  h = normalize(v+l);\n"
             + "  float diffuse  = max ( dot(l,n), 0.0 );\n"
             + "  float specular = max ( dot(h,n), 0.0 );\n"
@@ -101,7 +104,7 @@ public class PhongShader2 {
             + "  vec3 color1 = vec3(diffuse);\n" //
             + "  color1 *= u_color.rgb;\n"
             + "  color1 += 0.5*(1.0- color1)*specular;\n"
-            + "  gl_FragColor = vec4( 0.1*color + 0.9*color1, 1.0 );\n" //
+            + "  FragColor = vec4( 0.1*color + 0.9*color1, 1.0 );\n" //
             + "}\n";
 
     private GVRCustomMaterialShaderId mShaderId;
@@ -116,7 +119,7 @@ public class PhongShader2 {
         mCustomShader.addUniformVec3Key("u_light", LIGHT_KEY);
         mCustomShader.addUniformVec3Key("u_eye", EYE_KEY);
         mCustomShader.addUniformFloatKey("u_radius", RADIUS_KEY);
-        mCustomShader.addTextureKey("texture", TEXTURE_KEY);
+        mCustomShader.addTextureKey("intexture", TEXTURE_KEY);
 
         mCustomShader.addUniformVec4Key("u_mat1", MAT1_KEY);
         mCustomShader.addUniformVec4Key("u_mat2", MAT2_KEY);

--- a/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/PhongShader3.java
+++ b/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/PhongShader3.java
@@ -35,9 +35,10 @@ public class PhongShader3 {
     public static final String MAT4_KEY = "u_mat4";
 
     private static final String VERTEX_SHADER = "" //
-            + "attribute vec4 a_position;\n"
-            + "attribute vec3 a_normal;\n" //
-            + "attribute vec2 a_tex_coord;\n"
+            + "#version 300 es\n"
+            + "in vec4 a_position;\n"
+            + "in vec3 a_normal;\n" //
+            + "in vec2 a_tex_coord;\n"
             + "uniform mat4 u_mvp;\n" //
             + "uniform vec4 u_mat1;\n"
             + "uniform vec4 u_mat2;\n" //
@@ -45,11 +46,11 @@ public class PhongShader3 {
             + "uniform vec4 u_mat4;\n" //
             + "uniform vec3 u_eye;\n"
             + "uniform vec3 u_light;\n" //
-            + "varying vec3 n;\n"
-            + "varying vec3 v;\n" //
-            + "varying vec3 l;\n"
-            + "varying vec3 p;\n"
-            + "varying vec2  coord;\n" //
+            + "out vec3 n;\n"
+            + "out vec3 v;\n" //
+            + "out vec3 l;\n"
+            + "out vec3 p;\n"
+            + "out vec2  coord;\n" //
             + "void main() {\n"
             + "  mat4 model;\n"
             + "  model[0] = u_mat1;\n" //
@@ -68,16 +69,18 @@ public class PhongShader3 {
             + "}\n";
 
     private static final String FRAGMENT_SHADER = "" //
+            + "#version 300 es\n"
             + "precision mediump float;\n"
-            + "varying vec2  coord;\n"
+            + "in vec2  coord;\n"
             + "uniform vec4  u_color;\n"
-            + "varying vec3  n;\n"
-            + "varying vec3  v;\n"
-            + "varying vec3  l;\n"
-            + "varying vec3  p;\n"
+            + "in vec3  n;\n"
+            + "in vec3  v;\n"
+            + "in vec3  l;\n"
+            + "in vec3  p;\n"
             + "uniform float u_radius;\n"
             + "uniform sampler2D env;\n"
-            + "uniform sampler2D texture;\n"
+            + "uniform sampler2D intexture;\n"
+            + "out vec4 FragColor;\n"
             + "void main() {\n"
             + "  vec3  r = normalize(reflect(v,n));\n"
             + "  float b = dot(r,p);\n"
@@ -94,15 +97,15 @@ public class PhongShader3 {
             + "  reflect_coord.y  = ray.y;\n"
             + "  reflect_coord.x = 0.5 + 0.6*asin(reflect_coord.x)/1.57079632675;\n"
             + "  reflect_coord.y = 0.5 + 0.6*asin(reflect_coord.y)/1.57079632675;\n"
-            + "  vec3 color = texture2D(env, reflect_coord).rgb;\n"
+            + "  vec3 color = texture(env, reflect_coord).rgb;\n"
             + "  vec3  h = normalize(v+l);\n"
             + "  float diffuse  = max ( dot(l,n), 0.0 );\n"
             + "  float specular = max ( dot(h,n), 0.0 );\n"
             + "  specular = pow (specular, 300.0);\n"
             + "  vec3 color1 = vec3(diffuse);\n"
-            + "  color1 *= texture2D(texture, coord).rgb;\n"
+            + "  color1 *= texture(intexture, coord).rgb;\n"
             + "  color1 += 0.5*(1.0- color1)*specular;\n"
-            + "  gl_FragColor = vec4( 0.1*color + 0.9*color1, 1.0 );\n" //
+            + "  FragColor = vec4( 0.1*color + 0.9*color1, 1.0 );\n" //
             + "}\n";
 
     private GVRCustomMaterialShaderId mShaderId;
@@ -116,7 +119,7 @@ public class PhongShader3 {
         mCustomShader.addUniformVec3Key("u_light", LIGHT_KEY);
         mCustomShader.addUniformVec3Key("u_eye", EYE_KEY);
         mCustomShader.addUniformFloatKey("u_radius", RADIUS_KEY);
-        mCustomShader.addTextureKey("texture", TEXTURE_KEY);
+        mCustomShader.addTextureKey("intexture", TEXTURE_KEY);
         mCustomShader.addTextureKey("env", ENV_KEY);
 
         mCustomShader.addUniformVec4Key("u_mat1", MAT1_KEY);

--- a/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/ReflectionShader.java
+++ b/GVRf/Sample/model-viewer/src/org/gearvrf/modelviewer/ReflectionShader.java
@@ -35,9 +35,11 @@ public class ReflectionShader {
     public static final String MAT4_KEY = "u_mat4";
 
     private static final String VERTEX_SHADER = "" //
-            + "attribute vec4 a_position;\n"
-            + "attribute vec3 a_normal;\n"
-            + "attribute vec2 a_tex_coord;\n"
+            + "#version 300 es\n"
+            + "precision mediump float;\n"
+            + "in vec4 a_position;\n"
+            + "in vec3 a_normal;\n"
+            + "in vec2 a_tex_coord;\n"
             + "uniform mat4 u_mvp;\n"
             + "uniform vec4 u_mat1;\n"
             + "uniform vec4 u_mat2;\n"
@@ -45,12 +47,12 @@ public class ReflectionShader {
             + "uniform vec4 u_mat4;\n"
             + "uniform vec3 u_eye;\n"
             + "uniform vec3 u_light;\n"
-            + "varying vec3  n;\n"
-            + "varying vec3  v;\n"
-            + "varying vec3  l;\n"
+            + "out vec3  n;\n"
+            + "out vec3  v;\n"
+            + "out vec3  l;\n"
             + "uniform float u_radius;\n"
-            + "varying vec2 coord;\n"
-            + "varying vec2 reflect_coord;\n"
+            + "out vec2 coord;\n"
+            + "out vec2 reflect_coord;\n"
             + "void main() {\n"
             + "  mat4 model;\n"
             + "  model[0] = u_mat1;\n"
@@ -84,17 +86,19 @@ public class ReflectionShader {
             + "}\n";
 
     private static final String FRAGMENT_SHADER = "" //
+            + "#version 300 es\n"
             + "precision mediump float;\n"
-            + "varying vec2  coord;\n" //
+            + "in vec2  coord;\n" //
             + "uniform vec4  u_color;\n"
             + "uniform float u_radius;\n" //
-            + "varying vec3  n;\n"
-            + "varying vec3  v;\n" //
-            + "varying vec3  l;\n"
-            + "varying vec2 reflect_coord;\n" //
-            + "uniform sampler2D texture;\n"
+            + "in vec3  n;\n"
+            + "in vec3  v;\n" //
+            + "in vec3  l;\n"
+            + "in vec2 reflect_coord;\n" //
+            + "uniform sampler2D intexture;\n"
+            + "out vec4 FragColor;\n"
             + "void main() {\n"
-            + "  vec3 color = texture2D(texture, reflect_coord).rgb;\n"
+            + "  vec3 color = texture(intexture, reflect_coord).rgb;\n"
             + "  vec3  h = normalize(v+l);\n"
             + "  float viewing  = max ( dot(v,n), 0.0 );\n"
             + "  float diffuse  = max ( dot(l,n), 0.0 );\n"
@@ -103,8 +107,8 @@ public class ReflectionShader {
             + "  color *= pow(diffuse,0.2);\n" //
             + "  color *= u_color.rgb;\n"
             + "  color += 1.5*(1.0- color)*specular;\n"
-            + "  gl_FragColor = vec4( color, 0.7-0.3*viewing );\n"
-            + "  gl_FragColor.rgb *= gl_FragColor.a;\n" //
+            + "  FragColor = vec4( color, 0.7-0.3*viewing );\n"
+            + "  FragColor.rgb *= FragColor.a;\n" //
             + "}\n";
 
     private GVRCustomMaterialShaderId mShaderId;
@@ -119,7 +123,7 @@ public class ReflectionShader {
         mCustomShader.addUniformVec3Key("u_light", LIGHT_KEY);
         mCustomShader.addUniformVec3Key("u_eye", EYE_KEY);
         mCustomShader.addUniformFloatKey("u_radius", RADIUS_KEY);
-        mCustomShader.addTextureKey("texture", TEXTURE_KEY);
+        mCustomShader.addTextureKey("intexture", TEXTURE_KEY);
 
         mCustomShader.addUniformVec4Key("u_mat1", MAT1_KEY);
         mCustomShader.addUniformVec4Key("u_mat2", MAT2_KEY);


### PR DESCRIPTION
Half of the shaders in the model-viewer sample didn't work on S6.  S6 is using Mali which is
apparently more strict when compiling shaders.  A lot of these shaders
required inverse(), which is only in GLSL3.  Upgraded the shaders to
GLSL3.  Things seem to look correct now.


GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com