### PR TITLE
GVRf: Add camera rotation support

### DIFF
--- a/GVRf/Framework/jni/engine/picker/picker.cpp
+++ b/GVRf/Framework/jni/engine/picker/picker.cpp
@@ -52,7 +52,7 @@ std::vector<EyePointeeHolder*> Picker::pickScene(Scene* scene, float ox,
 
     glm::mat4 view_matrix =
             glm::affineInverse(
-                    scene->main_camera_rig()->owner_object()->transform()->getModelMatrix());
+                    scene->main_camera_rig()->getHeadTransform()->getModelMatrix());
 
     std::vector<EyePointeeHolderData> picked_holder_data;
 
@@ -87,7 +87,7 @@ std::vector<EyePointeeHolder*> Picker::pickScene(Scene* scene) {
 float Picker::pickSceneObject(const SceneObject* scene_object,
         const CameraRig* camera_rig) {
     glm::mat4 view_matrix = glm::affineInverse(
-            camera_rig->owner_object()->transform()->getModelMatrix());
+            camera_rig->getHeadTransform()->getModelMatrix());
     if (scene_object->eye_pointee_holder() != 0) {
         EyePointeeHolder* eye_pointee_holder =
                 scene_object->eye_pointee_holder();

--- a/GVRf/Framework/jni/objects/components/camera_rig.cpp
+++ b/GVRf/Framework/jni/objects/components/camera_rig.cpp
@@ -151,14 +151,17 @@ glm::quat CameraRig::predict(float time) {
     return transform_rotation;
 }
 
-void CameraRig::setRotation(glm::quat transform_rotation) {
+void CameraRig::setRotation(const glm::quat& transform_rotation) {
+    // Get head transform (a child of camera rig object)
+    Transform* transform = getHeadTransform();
+
     if (camera_rig_type_ == FREE) {
-        owner_object()->transform()->set_rotation(transform_rotation);
+        transform->set_rotation(transform_rotation);
     } else if (camera_rig_type_ == YAW_ONLY) {
         glm::vec3 look_at = glm::rotate(transform_rotation,
                 glm::vec3(0.0f, 0.0f, -1.0f));
         float yaw = atan2f(-look_at.x, -look_at.z) * 180.0f / M_PI;
-        owner_object()->transform()->set_rotation(
+        transform->set_rotation(
                 glm::angleAxis(yaw, glm::vec3(0.0f, 1.0f, 0.0f)));
     } else if (camera_rig_type_ == ROLL_FREEZE) {
         glm::vec3 look_at = glm::rotate(transform_rotation,
@@ -167,20 +170,24 @@ void CameraRig::setRotation(glm::quat transform_rotation) {
                 sqrtf(look_at.x * look_at.x + look_at.z * look_at.z)) * 180.0f
                 / M_PI;
         float yaw = atan2f(-look_at.x, -look_at.z) * 180.0f / M_PI;
-        owner_object()->transform()->set_rotation(
+        transform->set_rotation(
                 glm::angleAxis(pitch, glm::vec3(1.0f, 0.0f, 0.0f)));
-        owner_object()->transform()->rotateByAxis(yaw, 0.0f, 1.0f, 0.0f);
+        transform->rotateByAxis(yaw, 0.0f, 1.0f, 0.0f);
     } else if (camera_rig_type_ == FREEZE) {
-        owner_object()->transform()->set_rotation(glm::quat());
+        transform->set_rotation(glm::quat());
     } else if (camera_rig_type_ == ORBIT_PIVOT) {
         glm::vec3 pivot(getVec3("pivot"));
-        owner_object()->transform()->set_position(pivot.x, pivot.y,
+        transform->set_position(pivot.x, pivot.y,
                 pivot.z + getFloat("distance"));
-        owner_object()->transform()->set_rotation(glm::quat());
-        owner_object()->transform()->rotateWithPivot(transform_rotation.w,
+        transform->set_rotation(glm::quat());
+        transform->rotateWithPivot(transform_rotation.w,
                 transform_rotation.x, transform_rotation.y,
                 transform_rotation.z, pivot.x, pivot.y, pivot.z);
     }
+}
+
+Transform* CameraRig::getHeadTransform() const {
+	return owner_object()->getChildByIndex(0)->transform();
 }
 
 glm::vec3 CameraRig::getLookAt() const {

--- a/GVRf/Framework/jni/objects/components/camera_rig.cpp
+++ b/GVRf/Framework/jni/objects/components/camera_rig.cpp
@@ -191,7 +191,7 @@ Transform* CameraRig::getHeadTransform() const {
 }
 
 glm::vec3 CameraRig::getLookAt() const {
-    glm::mat4 model_matrix = owner_object()->transform()->getModelMatrix();
+    glm::mat4 model_matrix = getHeadTransform()->getModelMatrix();
     float x0 = model_matrix[3][0];
     float y0 = model_matrix[3][1];
     float z0 = model_matrix[3][2];

--- a/GVRf/Framework/jni/objects/components/camera_rig.h
+++ b/GVRf/Framework/jni/objects/components/camera_rig.h
@@ -30,6 +30,7 @@
 #include "glm/gtx/quaternion.hpp"
 
 #include "objects/components/component.h"
+#include "objects/components/transform.h"
 #include "objects/rotation_sensor_data.h"
 
 namespace gvr {
@@ -144,9 +145,9 @@ public:
     void resetYawPitch();
     void setRotationSensorData(long long time_stamp, float w, float x, float y,
             float z, float gyro_x, float gyro_y, float gyro_z);
-    void setRotation(glm::quat transform_rotation);
     glm::quat predict(float time);
     void predictAndSetRotation(float time);
+    Transform* getHeadTransform() const; // for rotation/k-sensor
     glm::vec3 getLookAt() const;
 
 private:
@@ -154,6 +155,7 @@ private:
     CameraRig(CameraRig&& camera_rig);
     CameraRig& operator=(const CameraRig& camera_rig);
     CameraRig& operator=(CameraRig&& camera_rig);
+    void setRotation(const glm::quat& transform_rotation);
 
 private:
     static const CameraRigType DEFAULT_CAMERA_RIG_TYPE = FREE;

--- a/GVRf/Framework/jni/objects/components/camera_rig_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/camera_rig_jni.cpp
@@ -113,15 +113,14 @@ Java_org_gearvrf_NativeCameraRig_setRotationSensorData(
         jfloat gyro_z);
 
 JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeCameraRig_predict(JNIEnv * env,
-        jobject obj, jlong jcamera_rig, jfloat time);
-JNIEXPORT void JNICALL
 Java_org_gearvrf_NativeCameraRig_predictAndSetRotation(JNIEnv * env,
         jobject obj, jlong jcamera_rig, jfloat time);
+
 JNIEXPORT jfloatArray JNICALL
 Java_org_gearvrf_NativeCameraRig_getLookAt(JNIEnv * env,
         jobject obj, jlong jcamera_rig);
-};
+
+}; // extern "C"
 
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeCameraRig_ctor(JNIEnv * env,
@@ -336,13 +335,6 @@ Java_org_gearvrf_NativeCameraRig_setRotationSensorData(
     CameraRig* camera_rig = reinterpret_cast<CameraRig*>(jcamera_rig);
     camera_rig->setRotationSensorData(time_stamp, w, x, y, z, gyro_x, gyro_y,
             gyro_z);
-}
-
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeCameraRig_predict(JNIEnv * env,
-        jobject obj, jlong jcamera_rig, jfloat time) {
-    CameraRig* camera_rig = reinterpret_cast<CameraRig*>(jcamera_rig);
-    camera_rig->predict(time);
 }
 
 JNIEXPORT void JNICALL

--- a/GVRf/Framework/jni/oculus/activity_jni.cpp
+++ b/GVRf/Framework/jni/oculus/activity_jni.cpp
@@ -410,7 +410,7 @@ template <class PredictionTrait> OVR::Matrix4f GVRActivity<PredictionTrait>::Dra
     SetMVPMatrix(mvp_matrix);
 
     glm::quat headRotation = PredictionTrait::getPrediction(this, (1 == eye ? 4.0f : 3.5f) / 60.0f);
-    cameraRig->setRotation(headRotation);
+    cameraRig->getHeadTransform()->set_rotation(headRotation);
 
     JNIEnv* jni = app->GetVrJni();
     jni->CallVoidMethod(javaObject, drawEyeViewMethodId, eye, fovDegrees);

--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -70,6 +70,20 @@ public class GVRCameraRig extends GVRComponent {
 
     /** Constructor helper */
     private void init(GVRContext gvrContext) {
+        /*
+         * Create an object hierarchy
+         *
+         *             [camera rig object]
+         *                     |
+         *           [head transform object]
+         *            /        |          \
+         * [left cam obj] [right cam obj] [center cam obj]
+         *
+         * 1. camera rig object: used for camera rig moving and turning via
+         *    CameraRig.getTransform()
+         * 2. head transform object: used internally to do sensor-based rotation
+         */
+
         setOwnerObject(new GVRSceneObject(gvrContext));
         getOwnerObject().attachCameraRig(this);
 
@@ -275,7 +289,7 @@ public class GVRCameraRig extends GVRComponent {
      */
     public void attachLeftCamera(GVRCamera camera) {
         if (camera.hasOwnerObject()) {
-            throw new IllegalArgumentException("Owner object should not be set");
+            camera.getOwnerObject().detachCamera();
         }
 
         leftCameraObject.attachCamera(camera);
@@ -291,7 +305,7 @@ public class GVRCameraRig extends GVRComponent {
      */
     public void attachRightCamera(GVRCamera camera) {
         if (camera.hasOwnerObject()) {
-            throw new IllegalArgumentException("Owner object should not be set");
+            camera.getOwnerObject().detachCamera();
         }
 
         rightCameraObject.attachCamera(camera);
@@ -307,7 +321,7 @@ public class GVRCameraRig extends GVRComponent {
      */
     public void attachCenterCamera(GVRPerspectiveCamera camera) {
         if (camera.hasOwnerObject()) {
-            throw new IllegalArgumentException("Owner object should not be set");
+            camera.getOwnerObject().detachCamera();
         }
 
         centerCameraObject.attachCamera(camera);

--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -463,9 +463,7 @@ public class GVRCameraRig extends GVRComponent {
      *            rig owner object.
      */
     public void addChildObject(GVRSceneObject child) {
-        if (getOwnerObject() != null) {
-            getOwnerObject().addChildObject(child);
-        }
+        headTransformObject.addChildObject(child);
     }
 
     /**
@@ -476,9 +474,7 @@ public class GVRCameraRig extends GVRComponent {
      *            camera rig owner object.
      */
     public void removeChildObject(GVRSceneObject child) {
-        if (getOwnerObject() != null) {
-            getOwnerObject().removeChildObject(child);
-        }
+        headTransformObject.removeChildObject(child);
     }
 
     /**
@@ -489,10 +485,7 @@ public class GVRCameraRig extends GVRComponent {
      *         this camera rig owner object.
      */
     public int getChildrenCount() {
-        if (getOwnerObject() != null) {
-            return getOwnerObject().getChildrenCount();
-        }
-        return 0;
+        return headTransformObject.getChildrenCount();
     }
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -19,8 +19,13 @@ import static org.gearvrf.utility.Assert.*;
 
 /** Holds the GVRCameras. */
 public class GVRCameraRig extends GVRComponent {
+    private GVRSceneObject headTransformObject;
+
     private GVRCamera leftCamera, rightCamera;
     private GVRPerspectiveCamera centerCamera;
+
+    private GVRSceneObject leftCameraObject, rightCameraObject;
+    private GVRSceneObject centerCameraObject;
 
     /** Ways to use the rotation sensor data. */
     public abstract static class GVRCameraRigType {
@@ -55,10 +60,29 @@ public class GVRCameraRig extends GVRComponent {
     /** Constructs a camera rig without cameras attached. */
     public GVRCameraRig(GVRContext gvrContext) {
         super(gvrContext, NativeCameraRig.ctor());
+        init(gvrContext);
     }
 
     private GVRCameraRig(GVRContext gvrContext, long ptr) {
         super(gvrContext, ptr);
+        init(gvrContext);
+    }
+
+    /** Constructor helper */
+    private void init(GVRContext gvrContext) {
+        setOwnerObject(new GVRSceneObject(gvrContext));
+        getOwnerObject().attachCameraRig(this);
+
+        headTransformObject = new GVRSceneObject(gvrContext);
+        getOwnerObject().addChildObject(headTransformObject);
+
+        leftCameraObject = new GVRSceneObject(gvrContext);
+        rightCameraObject = new GVRSceneObject(gvrContext);
+        centerCameraObject = new GVRSceneObject(gvrContext);
+
+        headTransformObject.addChildObject(leftCameraObject);
+        headTransformObject.addChildObject(rightCameraObject);
+        headTransformObject.addChildObject(centerCameraObject);
     }
 
     /** @return The {@link GVRCameraRigType type} of the camera rig. */
@@ -250,9 +274,11 @@ public class GVRCameraRig extends GVRComponent {
      *            {@link GVRCamera Camera} to attach.
      */
     public void attachLeftCamera(GVRCamera camera) {
-        if (camera.getOwnerObject() == null) {
-            throw new IllegalArgumentException("Owner object not set correctly");
+        if (camera.hasOwnerObject()) {
+            throw new IllegalArgumentException("Owner object should not be set");
         }
+
+        leftCameraObject.attachCamera(camera);
         leftCamera = camera;
         NativeCameraRig.attachLeftCamera(getNative(), camera.getNative());
     }
@@ -264,9 +290,11 @@ public class GVRCameraRig extends GVRComponent {
      *            {@link GVRCamera Camera} to attach.
      */
     public void attachRightCamera(GVRCamera camera) {
-        if (camera.getOwnerObject() == null) {
-            throw new IllegalArgumentException("Owner object not set correctly");
+        if (camera.hasOwnerObject()) {
+            throw new IllegalArgumentException("Owner object should not be set");
         }
+
+        rightCameraObject.attachCamera(camera);
         rightCamera = camera;
         NativeCameraRig.attachRightCamera(getNative(), camera.getNative());
     }
@@ -278,13 +306,14 @@ public class GVRCameraRig extends GVRComponent {
      *            {@link GVRPerspectiveCamera Camera} to attach.
      */
     public void attachCenterCamera(GVRPerspectiveCamera camera) {
-        if (camera.getOwnerObject() == null) {
-            throw new IllegalArgumentException("Owner object not set correctly");
+        if (camera.hasOwnerObject()) {
+            throw new IllegalArgumentException("Owner object should not be set");
         }
+
+        centerCameraObject.attachCamera(camera);
         centerCamera = camera;
         NativeCameraRig.attachCenterCamera(getNative(), camera.getNative());
     }
-
 
     /**
      * Resets the rotation of the camera rig by multiplying further rotations by
@@ -450,6 +479,17 @@ public class GVRCameraRig extends GVRComponent {
             return getOwnerObject().getChildrenCount();
         }
         return 0;
+    }
+
+    /**
+     * Get the head {@link GVRTransform transform} for setting sensor data. In contrast,
+     * use {@link #getTransform()} for additional camera positioning, such as the game
+     * character moving and turning.
+     *
+     * @return The head {@link GVRTransform transform} object.
+     */
+    public GVRTransform getHeadTransform() {
+        return headTransformObject.getTransform();
     }
 }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRComponent.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRComponent.java
@@ -82,4 +82,13 @@ class GVRComponent extends GVRHybridObject {
     protected void setOwnerObject(GVRSceneObject owner) {
         this.owner = owner;
     }
+
+    /**
+     * Checks if the {@link GVRComponent} is attached to a {@link GVRSceneObject}.
+     *
+     * @return true if a {@link GVRSceneObject} is attached.
+     */
+    public boolean hasOwnerObject() {
+        return owner != null;
+    }
 }

--- a/GVRf/Framework/src/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRScene.java
@@ -43,31 +43,20 @@ public class GVRScene extends GVRHybridObject {
 
         GVRCamera leftCamera = new GVRPerspectiveCamera(gvrContext);
         leftCamera.setRenderMask(GVRRenderMaskBit.Left);
-        GVRSceneObject leftCameraObject = new GVRSceneObject(gvrContext);
-        leftCameraObject.attachCamera(leftCamera);
 
         GVRCamera rightCamera = new GVRPerspectiveCamera(gvrContext);
         rightCamera.setRenderMask(GVRRenderMaskBit.Right);
-        GVRSceneObject rightCameraObject = new GVRSceneObject(gvrContext);
-        rightCameraObject.attachCamera(rightCamera);
 
         GVRPerspectiveCamera centerCamera = new GVRPerspectiveCamera(gvrContext);
         centerCamera.setRenderMask(GVRRenderMaskBit.Left | GVRRenderMaskBit.Right);
-        GVRSceneObject centerCameraObject = new GVRSceneObject(gvrContext);
-        centerCameraObject.attachCamera(centerCamera);
 
-
-        GVRSceneObject cameraRigObject = new GVRSceneObject(gvrContext);
         GVRCameraRig cameraRig = new GVRCameraRig(gvrContext);
         cameraRig.attachLeftCamera(leftCamera);
         cameraRig.attachRightCamera(rightCamera);
         cameraRig.attachCenterCamera(centerCamera);
-        cameraRigObject.attachCameraRig(cameraRig);
 
-        addSceneObject(cameraRigObject);
-        cameraRigObject.addChildObject(leftCameraObject);
-        cameraRigObject.addChildObject(rightCameraObject);
-        cameraRigObject.addChildObject(centerCameraObject);
+        addSceneObject(cameraRig.getOwnerObject());
+
         setMainCameraRig(cameraRig);
     }
 


### PR DESCRIPTION
Two types of camera rotation are supported:
  1) Rotation based on the (game) character position and orientation
  2) Rotation based on head-rotation sensor

The former transform is accessed via CameraRig.getTransform(), the latter is accessed via
CameraRig.getHeadTransform().

They are cascaded in the object hierarchy inside CameraRig.