### PR TITLE
Added support for an installable external renderer

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -581,6 +581,10 @@ void Renderer::renderRenderData(RenderData* render_data,
                                     mv_matrix, glm::inverseTranspose(mv_matrix),
                                     mvp_matrix, render_data, curr_material);
                             break;
+                        case Material::ShaderType::EXTERNAL_RENDERER_SHADER:
+                            shader_manager->getExternalRendererShader()->render(
+                                    mvp_matrix, render_data);
+                            break;
                         default:
                             shader_manager->getCustomShader(
                                     curr_material->shader_type())->render(

--- a/GVRf/Framework/jni/objects/material.h
+++ b/GVRf/Framework/jni/objects/material.h
@@ -43,6 +43,7 @@ public:
         CUBEMAP_SHADER = 5,
         CUBEMAP_REFLECTION_SHADER = 6,
         TEXTURE_SHADER = 7,
+        EXTERNAL_RENDERER_SHADER = 8,
         TEXTURE_SHADER_NOLIGHT = 100
     };
 

--- a/GVRf/Framework/jni/objects/textures/external_renderer_texture.h
+++ b/GVRf/Framework/jni/objects/textures/external_renderer_texture.h
@@ -1,0 +1,47 @@
+
+#ifndef EXTERNAL_RENDERER_TEXTURE_H_
+#define EXTERNAL_RENDERER_TEXTURE_H_
+
+#define __gl2_h_
+#include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
+
+#include "objects/textures/base_texture.h"
+
+// this is the texture to be used with an external renderer
+// the data field can be used to pass data between the gvrf application
+// and the external renderer
+
+namespace gvr {
+
+class ExternalRendererTexture: public Texture {
+public:
+    ExternalRendererTexture() : Texture(0), mData(0) {
+    }
+
+    GLenum getTarget() const {
+        return TARGET;
+    }
+
+    virtual void setData(long data) {
+        mData = data;
+    }
+
+    virtual long getData() const {
+        return mData;
+    }
+
+    static const GLenum TARGET = GL_TEXTURE_EXTERNAL_OES + 1000;
+
+private:
+    ExternalRendererTexture(const ExternalRendererTexture& render_texture);
+    ExternalRendererTexture(ExternalRendererTexture&& render_texture);
+    ExternalRendererTexture& operator=(const ExternalRendererTexture& render_texture);
+    ExternalRendererTexture& operator=(ExternalRendererTexture&& render_texture);
+
+private:
+    long mData;
+};
+
+}
+#endif

--- a/GVRf/Framework/jni/objects/textures/external_renderer_texture_jni.cpp
+++ b/GVRf/Framework/jni/objects/textures/external_renderer_texture_jni.cpp
@@ -1,0 +1,40 @@
+/***************************************************************************
+ * JNI
+ ***************************************************************************/
+
+#include "external_renderer_texture.h"
+
+#include "util/gvr_jni.h"
+
+namespace gvr {
+extern "C" {
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeExternalRendererTexture_ctor(JNIEnv * env,
+        jobject obj);
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeExternalRendererTexture_setData(JNIEnv * env,
+        jobject obj, jlong ptr, jlong data);
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeExternalRendererTexture_getData(JNIEnv * env,
+        jobject obj, jlong ptr);
+}
+;
+
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeExternalRendererTexture_ctor(JNIEnv * env, jobject obj) {
+    return reinterpret_cast<jlong>(new ExternalRendererTexture());
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeExternalRendererTexture_setData(JNIEnv * env,
+        jobject obj, jlong ptr, jlong data) {
+    reinterpret_cast<ExternalRendererTexture*>(ptr)->setData(data);
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeExternalRendererTexture_getData(JNIEnv * env,
+        jobject obj, jlong ptr) {
+    return reinterpret_cast<ExternalRendererTexture*>(ptr)->getData();
+}
+
+}

--- a/GVRf/Framework/jni/shaders/material/external_renderer_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/external_renderer_shader.cpp
@@ -9,6 +9,7 @@
 #include "objects/components/render_data.h"
 #include "objects/textures/texture.h"
 #include "objects/textures/external_renderer_texture.h"
+#include "util/gvr_gl.h"
 #include "util/gvr_log.h"
 
 static GVRF_ExternalRenderer externalRenderer = NULL;

--- a/GVRf/Framework/jni/shaders/material/external_renderer_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/external_renderer_shader.cpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+ * installable external renderer
+ ***************************************************************************/
+
+#include "external_renderer_shader.h"
+
+#include "objects/material.h"
+#include "objects/mesh.h"
+#include "objects/components/render_data.h"
+#include "objects/textures/texture.h"
+#include "objects/textures/external_renderer_texture.h"
+#include "util/gvr_log.h"
+
+static GVRF_ExternalRenderer externalRenderer = NULL;
+
+void GVRF_installExternalRenderer(GVRF_ExternalRenderer fct) {
+    externalRenderer = fct;
+}
+
+namespace gvr {
+
+void ExternalRendererShader::render(const glm::mat4& mvp_matrix, RenderData* render_data) {
+    if (externalRenderer == NULL) {
+        LOGE("External renderer not installed");
+        return;
+    }
+
+    Texture* texture = render_data->material()->getTexture("main_texture");
+    if (texture->getTarget() != ExternalRendererTexture::TARGET) {
+        LOGE("External renderer only takes external renderer textures");
+        return;
+    }
+
+    externalRenderer(reinterpret_cast<ExternalRendererTexture*>(texture)->getData(),
+                     render_data->mesh()->getBoundingBoxInfo(), 6,
+                     glm::value_ptr(mvp_matrix), 16);
+
+    checkGlError("ExternalRendererShader::render");
+}
+
+}
+

--- a/GVRf/Framework/jni/shaders/material/external_renderer_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/external_renderer_shader.cpp
@@ -25,7 +25,7 @@ void ExternalRendererShader::render(const glm::mat4& mvp_matrix, RenderData* ren
         return;
     }
 
-    Texture* texture = render_data->material()->getTexture("main_texture");
+    Texture* texture = render_data->pass(0)->material()->getTexture("main_texture");
     if (texture->getTarget() != ExternalRendererTexture::TARGET) {
         LOGE("External renderer only takes external renderer textures");
         return;

--- a/GVRf/Framework/jni/shaders/material/external_renderer_shader.h
+++ b/GVRf/Framework/jni/shaders/material/external_renderer_shader.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+ * installable external renderer
+ ***************************************************************************/
+
+#ifndef EXTERNAL_RENDERER_SHADER_H_
+#define EXTERNAL_RENDERER_SHADER_H_
+
+#include "glm/glm.hpp"
+#include "glm/gtc/type_ptr.hpp"
+
+#include "objects/recyclable_object.h"
+
+typedef void (*GVRF_ExternalRenderer)(long data, const float* vertices,
+                                      int vcount, const float* projection, int pcount);
+extern "C" void GVRF_installExternalRenderer(GVRF_ExternalRenderer renderer);
+
+namespace gvr {
+class RenderData;
+
+class ExternalRendererShader : public RecyclableObject {
+public:
+    ExternalRendererShader() {}
+    void render(const glm::mat4& mvp_matrix, RenderData* render_data);
+
+private:
+    ExternalRendererShader(
+            const ExternalRendererShader& shader);
+    ExternalRendererShader(
+            ExternalRendererShader&& shader);
+    ExternalRendererShader& operator=(
+            const ExternalRendererShader& shader);
+    ExternalRendererShader& operator=(
+            ExternalRendererShader&& shader);
+};
+
+}
+
+#endif

--- a/GVRf/Framework/jni/shaders/shader_manager.h
+++ b/GVRf/Framework/jni/shaders/shader_manager.h
@@ -32,6 +32,7 @@
 #include "shaders/material/cubemap_shader.h"
 #include "shaders/material/cubemap_reflection_shader.h"
 #include "shaders/material/texture_shader.h"
+#include "shaders/material/external_renderer_shader.h"
 #include "util/gvr_log.h"
 
 namespace gvr {
@@ -42,7 +43,7 @@ public:
             unlit_horizontal_stereo_shader_(), unlit_vertical_stereo_shader_(),
             oes_shader_(), oes_horizontal_stereo_shader_(), oes_vertical_stereo_shader_(),
             cubemap_shader_(), cubemap_reflection_shader_(), texture_shader_(),
-            error_shader_(), latest_custom_shader_id_(
+            external_renderer_shader_(), error_shader_(), latest_custom_shader_id_(
                     INITIAL_CUSTOM_SHADER_INDEX), custom_shaders_() {
     }
     ~ShaderManager() {
@@ -54,6 +55,7 @@ public:
         delete cubemap_shader_;
         delete cubemap_reflection_shader_;
         delete texture_shader_;
+        delete external_renderer_shader_;
         delete error_shader_;
         // We don't delete the custom shaders, as their Java owner-objects will do that for us.
     }
@@ -111,6 +113,12 @@ public:
         }
         return texture_shader_;
     }
+    ExternalRendererShader* getExternalRendererShader() {
+        if (!external_renderer_shader_) {
+            external_renderer_shader_ = new ExternalRendererShader();
+        }
+        return external_renderer_shader_;
+    }
     ErrorShader* getErrorShader() {
         if (!error_shader_) {
             error_shader_ = new ErrorShader();
@@ -152,6 +160,7 @@ private:
     CubemapShader* cubemap_shader_;
     CubemapReflectionShader* cubemap_reflection_shader_;
     TextureShader* texture_shader_;
+    ExternalRendererShader* external_renderer_shader_;
     ErrorShader* error_shader_;
     int latest_custom_shader_id_;
     std::map<int, CustomShader*> custom_shaders_;

--- a/GVRf/Framework/src/org/gearvrf/GVRExternalRendererTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRExternalRendererTexture.java
@@ -1,0 +1,30 @@
+package org.gearvrf;
+
+/**
+ * Wrapper for a (pseudo) texture to be used with an external
+ * renderer. Data to be passed to the external renderer can be
+ * attached to this texture object 
+ */
+public class GVRExternalRendererTexture extends GVRTexture {
+    /**
+     * @param gvrContext Current gvrContext
+     */
+    public GVRExternalRendererTexture(GVRContext gvrContext) {
+        super(gvrContext, NativeExternalRendererTexture.ctor());
+    }
+
+    public void setData(long data) {
+        NativeExternalRendererTexture.setData(getNative(), data);
+    }
+
+    public long getData() {
+        return NativeExternalRendererTexture.getData(getNative());
+    }
+}
+
+class NativeExternalRendererTexture {
+    static native long ctor();
+    static native void setData(long ptr, long data);
+    static native long getData(long ptr);
+}
+

--- a/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
@@ -112,6 +112,11 @@ public class GVRMaterial extends GVRHybridObject implements
             public static final GVRMaterialShaderId ID = new GVRStockMaterialShaderId(
                     7);
         }
+
+        public abstract static class ExternalRenderer {
+            public static final GVRMaterialShaderId ID = new GVRStockMaterialShaderId(
+                    8);
+        }
     };
 
     /**


### PR DESCRIPTION
This allows an external renderer outside gvrf to act
as a shader and participate in the rendering of the scene.
The external renderer receives the bounding box of the mesh
to be rendered, the projection matrix, and data received
from the application.
The main texture of the material must be a new
ExternalRendererTexture when using an external renderer.