### PR TITLE
fixing monoscopic renderer

### DIFF
--- a/GVRf/Framework/jni/objects/components/camera_rig_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/camera_rig_jni.cpp
@@ -115,6 +115,9 @@ Java_org_gearvrf_NativeCameraRig_setRotationSensorData(
 JNIEXPORT void JNICALL
 Java_org_gearvrf_NativeCameraRig_predict(JNIEnv * env,
         jobject obj, jlong jcamera_rig, jfloat time);
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeCameraRig_predictAndSetRotation(JNIEnv * env,
+        jobject obj, jlong jcamera_rig, jfloat time);
 JNIEXPORT jfloatArray JNICALL
 Java_org_gearvrf_NativeCameraRig_getLookAt(JNIEnv * env,
         jobject obj, jlong jcamera_rig);
@@ -340,6 +343,13 @@ Java_org_gearvrf_NativeCameraRig_predict(JNIEnv * env,
         jobject obj, jlong jcamera_rig, jfloat time) {
     CameraRig* camera_rig = reinterpret_cast<CameraRig*>(jcamera_rig);
     camera_rig->predict(time);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeCameraRig_predictAndSetRotation(JNIEnv * env,
+        jobject obj, jlong jcamera_rig, jfloat time) {
+    CameraRig* camera_rig = reinterpret_cast<CameraRig*>(jcamera_rig);
+    camera_rig->predictAndSetRotation(time);
 }
 
 JNIEXPORT jfloatArray JNICALL


### PR DESCRIPTION
Seems it broke recently.  Seems to need a native predictAndSetRotation()
    method now.  adding it.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn 
tom.flynn@samsung.com
