### PR TITLE
Assimp shader, support for adding features to shader

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -586,6 +586,11 @@ void Renderer::renderRenderData(RenderData* render_data,
                             shader_manager->getExternalRendererShader()->render(
                                     mvp_matrix, render_data);
                             break;
+                        case Material::ShaderType::ASSIMP_SHADER:
+                            shader_manager->getAssimpShader()->render(
+                                    mv_matrix, glm::inverseTranspose(mv_matrix),
+                                    mvp_matrix, render_data, curr_material);
+                            break;
                         default:
                             shader_manager->getCustomShader(
                                     curr_material->shader_type())->render(

--- a/GVRf/Framework/jni/gl/gl_program.h
+++ b/GVRf/Framework/jni/gl/gl_program.h
@@ -43,9 +43,9 @@ public:
     GLProgram(const char** pVertexSourceStrings,
             const GLint* pVertexSourceStringLengths,
             const char** pFragmentSourceStrings,
-            const GLint* pFragmentSourceStringLengths) :
+            const GLint* pFragmentSourceStringLengths, int count) :
             id_(
-                    createProgram(2, pVertexSourceStrings,
+                    createProgram(count, pVertexSourceStrings,
                             pVertexSourceStringLengths, pFragmentSourceStrings,
                             pFragmentSourceStringLengths)) {
     }

--- a/GVRf/Framework/jni/objects/material.h
+++ b/GVRf/Framework/jni/objects/material.h
@@ -153,6 +153,14 @@ public:
         mat4s_[key] = matrix;
     }
 
+    int get_shader_feature_set() {
+        return shader_feature_set;
+    }
+
+    void set_shader_feature_set(int feature_set) {
+        shader_feature_set = feature_set;
+    }
+
 private:
     Material(const Material& material);
     Material(Material&& material);
@@ -167,6 +175,7 @@ private:
     std::map<std::string, glm::vec3> vec3s_;
     std::map<std::string, glm::vec4> vec4s_;
     std::map<std::string, glm::mat4> mat4s_;
+    int shader_feature_set;
 };
 }
 #endif

--- a/GVRf/Framework/jni/objects/material.h
+++ b/GVRf/Framework/jni/objects/material.h
@@ -49,7 +49,8 @@ public:
     };
 
     explicit Material(ShaderType shader_type) :
-            shader_type_(shader_type), textures_(), floats_(), vec2s_(), vec3s_(), vec4s_() {
+            shader_type_(shader_type), textures_(), floats_(), vec2s_(), vec3s_(), vec4s_(), shader_feature_set_(
+                    0) {
         switch (shader_type) {
         default:
             vec3s_["color"] = glm::vec3(1.0f, 1.0f, 1.0f);
@@ -154,11 +155,11 @@ public:
     }
 
     int get_shader_feature_set() {
-        return shader_feature_set;
+        return shader_feature_set_;
     }
 
     void set_shader_feature_set(int feature_set) {
-        shader_feature_set = feature_set;
+        shader_feature_set_ = feature_set;
     }
 
 private:
@@ -175,7 +176,7 @@ private:
     std::map<std::string, glm::vec3> vec3s_;
     std::map<std::string, glm::vec4> vec4s_;
     std::map<std::string, glm::mat4> mat4s_;
-    int shader_feature_set;
+    unsigned int shader_feature_set_;
 };
 }
 #endif

--- a/GVRf/Framework/jni/objects/material.h
+++ b/GVRf/Framework/jni/objects/material.h
@@ -44,6 +44,7 @@ public:
         CUBEMAP_REFLECTION_SHADER = 6,
         TEXTURE_SHADER = 7,
         EXTERNAL_RENDERER_SHADER = 8,
+        ASSIMP_SHADER = 9,
         TEXTURE_SHADER_NOLIGHT = 100
     };
 

--- a/GVRf/Framework/jni/objects/material_jni.cpp
+++ b/GVRf/Framework/jni/objects/material_jni.cpp
@@ -71,6 +71,9 @@ Java_org_gearvrf_NativeMaterial_setMat4(JNIEnv * env,
         jfloat z1, jfloat w1, jfloat x2, jfloat y2, jfloat z2, jfloat w2,
         jfloat x3, jfloat y3, jfloat z3, jfloat w3, jfloat x4, jfloat y4,
         jfloat z4, jfloat w4);
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeMaterial_setShaderFeatureSet(JNIEnv * env, jobject obj,
+        jlong jmaterial, jint feature_set);
 }
 ;
 
@@ -207,6 +210,13 @@ glm::mat4 mat(x1, y1, z1, w1, x2, y2, z2, w2, x3, y3, z3, w3, x4, y4, z4,
         w4);
 material->setMat4(native_key, mat);
 env->ReleaseStringUTFChars(key, char_key);
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeMaterial_setShaderFeatureSet(JNIEnv * env, jobject obj,
+    jlong jmaterial, jint feature_set) {
+Material* material = reinterpret_cast<Material*>(jmaterial);
+material->set_shader_feature_set(feature_set);
 }
 
 }

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
@@ -82,7 +82,7 @@ static const char FRAGMENT_SHADER[] =
 AssimpShader::AssimpShader() :
         program_(0), a_position_(0), u_mvp_(0), a_tex_coord_(0), u_diffuse_color_(
                 0), u_ambient_color_(0), u_texture_(0), u_color_(0), u_opacity_(
-                0) {
+                0), program_list_(0) {
     program_list_ = new GLProgram*[AS_TOTAL_GL_PROGRAM_COUNT];
 
     const char* vertex_shader_strings[AS_TOTAL_SHADER_STRINGS_COUNT];

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
@@ -158,21 +158,17 @@ void AssimpShader::render(const glm::mat4& mv_matrix,
         const glm::mat4& mv_it_matrix, const glm::mat4& mvp_matrix,
         RenderData* render_data, Material* material) {
     Mesh* mesh = render_data->mesh();
-
-    // Which feature are enabled should come from Java material, as an integer
-    // TODO: Get rid of this code and pass from Java, and can get rid of try catch
     Texture* texture;
-    int feature_set = 0;
-    try {
+    int feature_set = material->get_shader_feature_set();
+
+    /* Get the texture only diffuese texture is set */
+    if (ISSET(feature_set, AS_DIFFUSE_TEXTURE)) {
         texture = material->getTexture("main_texture");
         if (texture->getTarget() != GL_TEXTURE_2D) {
             std::string error =
-                    "UnlitVerticalStereoShader::render : texture with wrong target";
+                    "TextureShader::render : texture with wrong target.";
             throw error;
         }
-        SETBIT(feature_set, AS_DIFFUSE_TEXTURE);
-    } catch (std::string error) {
-        /* No texture */
     }
 
     /* Based on feature set get the shader program */

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
@@ -161,7 +161,7 @@ void AssimpShader::render(const glm::mat4& mv_matrix,
     Texture* texture;
     int feature_set = material->get_shader_feature_set();
 
-    /* Get the texture only diffuese texture is set */
+    /* Get the texture only diffuse texture is set */
     if (ISSET(feature_set, AS_DIFFUSE_TEXTURE)) {
         texture = material->getTexture("main_texture");
         if (texture->getTarget() != GL_TEXTURE_2D) {
@@ -171,8 +171,8 @@ void AssimpShader::render(const glm::mat4& mv_matrix,
         }
     }
 
-    /* Based on feature set get the shader program */
-    program_ = program_list_[feature_set];
+    /* Based on feature set get the shader program, feature set cannot exceed program count */
+    program_ = program_list_[feature_set & (AS_TOTAL_GL_PROGRAM_COUNT - 1)];
 
     a_position_ = glGetAttribLocation(program_->id(), "a_position");
     u_mvp_ = glGetUniformLocation(program_->id(), "u_mvp");

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
@@ -1,0 +1,258 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/***************************************************************************
+ * Shader for model loaded with Assimp
+ ***************************************************************************/
+
+#include "assimp_shader.h"
+
+#include "gl/gl_program.h"
+#include "objects/material.h"
+#include "objects/mesh.h"
+#include "objects/components/render_data.h"
+#include "objects/textures/texture.h"
+#include "util/gvr_gl.h"
+
+#include "util/gvr_log.h"
+
+namespace gvr {
+
+#define AS_TOTAL_SHADER_STRINGS_COUNT    AS_TOTAL_FEATURE_COUNT + 1
+
+static const char DIFFUSE_TEXTURE[] = "#define AS_DIFFUSE_TEXTURE\n";
+static const char NO_DIFFUSE_TEXTURE[] = "#undef AS_DIFFUSE_TEXTURE\n";
+
+static const char SPECULAR_TEXTURE[] = "#define AS_SPECULAR_TEXTURE\n";
+static const char NO_SPECULAR_TEXTURE[] = "#undef AS_SPECULAR_TEXTURE\n";
+
+static const char VERTEX_SHADER[] =
+        "attribute vec4 a_position;\n"
+                "uniform mat4 u_mvp;\n"
+                "\n"
+                "#ifdef AS_DIFFUSE_TEXTURE\n"
+                "attribute vec4 a_tex_coord;\n"
+                "varying vec2 v_tex_coord;\n"
+                "#endif\n"
+                "\n"
+                "void main() {\n"
+                "#ifdef AS_DIFFUSE_TEXTURE\n"
+                "  v_tex_coord = a_tex_coord.xy;\n"
+                "#endif\n"
+                "  gl_Position = u_mvp * a_position;\n"
+                "}\n";
+
+static const char FRAGMENT_SHADER[] =
+        "precision highp float;\n"
+                "\n"
+                "#ifdef AS_DIFFUSE_TEXTURE\n"
+                "varying vec2 v_tex_coord;\n"
+                "uniform sampler2D u_texture;\n"
+                "#else\n"
+                "uniform vec4 u_diffuse_color;\n"
+                "uniform vec4 u_ambient_color;\n"
+                "#endif\n"
+                "\n"
+                "uniform vec3 u_color;\n"
+                "uniform float u_opacity;\n"
+                "\n"
+                "void main()\n"
+                "{\n"
+                "#ifdef AS_DIFFUSE_TEXTURE\n"
+                "  vec4 color;\n"
+                "  color = texture2D(u_texture, v_tex_coord);\n"
+                "  gl_FragColor = vec4(color.r * u_color.r * u_opacity, color.g * u_color.g * u_opacity, color.b * u_color.b * u_opacity, color.a * u_opacity);\n"
+                "#else\n"
+                "  gl_FragColor = (u_diffuse_color * u_opacity) + u_ambient_color;\n"
+                "#endif\n"
+                "}\n";
+
+AssimpShader::AssimpShader() :
+        program_(0), a_position_(0), u_mvp_(0), a_tex_coord_(0), u_diffuse_color_(
+                0), u_ambient_color_(0), u_texture_(0), u_color_(0), u_opacity_(
+                0) {
+    program_list_ = new GLProgram*[AS_TOTAL_GL_PROGRAM_COUNT];
+
+    const char* vertex_shader_strings[AS_TOTAL_SHADER_STRINGS_COUNT];
+    GLint vertex_shader_string_lengths[AS_TOTAL_SHADER_STRINGS_COUNT];
+    const char* fragment_shader_strings[AS_TOTAL_SHADER_STRINGS_COUNT];
+    GLint fragment_shader_string_lengths[AS_TOTAL_SHADER_STRINGS_COUNT];
+
+    for (int i = 0; i < AS_TOTAL_GL_PROGRAM_COUNT; i++) {
+        int counter = 0;
+
+        // TODO: remove duplicate code
+        if (ISSET(i, AS_DIFFUSE_TEXTURE)) {
+            vertex_shader_strings[counter] =  DIFFUSE_TEXTURE;
+            vertex_shader_string_lengths[counter] = (GLint) strlen(DIFFUSE_TEXTURE);
+            fragment_shader_strings[counter] = DIFFUSE_TEXTURE;
+            fragment_shader_string_lengths[counter] = (GLint) strlen(DIFFUSE_TEXTURE);
+            counter++;
+        } else {
+            vertex_shader_strings[counter] =  NO_DIFFUSE_TEXTURE;
+            vertex_shader_string_lengths[counter] = (GLint) strlen(NO_DIFFUSE_TEXTURE);
+            fragment_shader_strings[counter] = NO_DIFFUSE_TEXTURE;
+            fragment_shader_string_lengths[counter] = (GLint) strlen(NO_DIFFUSE_TEXTURE);
+            counter++;
+        }
+
+        if (ISSET(i, AS_SPECULAR_TEXTURE)) {
+            vertex_shader_strings[counter] =  SPECULAR_TEXTURE;
+            vertex_shader_string_lengths[counter] = (GLint) strlen(SPECULAR_TEXTURE);
+            fragment_shader_strings[counter] = SPECULAR_TEXTURE;
+            fragment_shader_string_lengths[counter] = (GLint) strlen(SPECULAR_TEXTURE);
+            counter++;
+        } else {
+            vertex_shader_strings[counter] =  NO_SPECULAR_TEXTURE;
+            vertex_shader_string_lengths[counter] = (GLint) strlen(NO_SPECULAR_TEXTURE);
+            fragment_shader_strings[counter] = NO_SPECULAR_TEXTURE;
+            fragment_shader_string_lengths[counter] = (GLint) strlen(NO_SPECULAR_TEXTURE);
+            counter++;
+        }
+
+        /* Shader should be added in the last */
+        vertex_shader_strings[counter] = VERTEX_SHADER;
+        vertex_shader_string_lengths[counter] = (GLint) strlen(VERTEX_SHADER);
+        fragment_shader_strings[counter] = FRAGMENT_SHADER;
+        fragment_shader_string_lengths[counter] = (GLint) strlen(FRAGMENT_SHADER);
+        counter++;
+
+        program_list_[i] = new GLProgram(vertex_shader_strings,
+                    vertex_shader_string_lengths, fragment_shader_strings,
+                    fragment_shader_string_lengths, counter);
+    }
+}
+
+AssimpShader::~AssimpShader() {
+    if (program_list_ != 0) {
+        recycle();
+    }
+}
+
+void AssimpShader::recycle() {
+    if (program_list_ != 0) {
+        for (int i = 0; i < AS_TOTAL_GL_PROGRAM_COUNT; i++) {
+            if (program_list_[i] != 0) {
+                delete program_list_[i];
+            }
+        }
+        delete program_list_;
+        program_list_ = 0;
+        program_ = 0;
+    }
+}
+
+void AssimpShader::render(const glm::mat4& mv_matrix,
+        const glm::mat4& mv_it_matrix, const glm::mat4& mvp_matrix,
+        RenderData* render_data, Material* material) {
+    Mesh* mesh = render_data->mesh();
+
+    // Which feature are enabled should come from Java material, as an integer
+    // TODO: Get rid of this code and pass from Java, and can get rid of try catch
+    Texture* texture;
+    int feature_set = 0;
+    try {
+        texture = material->getTexture("main_texture");
+        if (texture->getTarget() != GL_TEXTURE_2D) {
+            std::string error =
+                    "UnlitVerticalStereoShader::render : texture with wrong target";
+            throw error;
+        }
+        SETBIT(feature_set, AS_DIFFUSE_TEXTURE);
+    } catch (std::string error) {
+        /* No texture */
+    }
+
+    /* Based on feature set get the shader program */
+    program_ = program_list_[feature_set];
+
+    a_position_ = glGetAttribLocation(program_->id(), "a_position");
+    u_mvp_ = glGetUniformLocation(program_->id(), "u_mvp");
+    a_tex_coord_ = glGetAttribLocation(program_->id(), "a_tex_coord");
+    u_texture_ = glGetUniformLocation(program_->id(), "u_texture");
+    u_diffuse_color_ = glGetUniformLocation(program_->id(), "u_diffuse_color");
+    u_ambient_color_ = glGetUniformLocation(program_->id(), "u_ambient_color");
+    u_color_ = glGetUniformLocation(program_->id(), "u_color");
+    u_opacity_ = glGetUniformLocation(program_->id(), "u_opacity");
+
+    /* Get common attributes and uniforms from material */
+    glm::vec3 color = material->getVec3("color");
+    float opacity = material->getFloat("opacity");
+
+#if _GVRF_USE_GLES3_
+    mesh->setVertexLoc(a_position_);
+    if (ISSET(feature_set, AS_DIFFUSE_TEXTURE)) {
+        mesh->setTexCoordLoc(a_tex_coord_);
+    }
+    mesh->generateVAO(Material::ASSIMP_SHADER);
+
+    glUseProgram(program_->id());
+    glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(mvp_matrix));
+
+    if (ISSET(feature_set, AS_DIFFUSE_TEXTURE)) {
+        glActiveTexture (GL_TEXTURE0);
+        glBindTexture(texture->getTarget(), texture->getId());
+        glUniform1i(u_texture_, 0);
+    } else {
+        glm::vec4 diffuse_color = material->getVec4("diffuse_color");
+        glm::vec4 ambient_color = material->getVec4("ambient_color");
+        glUniform4f(u_diffuse_color_, diffuse_color.r, diffuse_color.g,
+                diffuse_color.b, diffuse_color.a);
+        glUniform4f(u_ambient_color_, ambient_color.r, ambient_color.g,
+                ambient_color.b, ambient_color.a);
+    }
+    glUniform3f(u_color_, color.r, color.g, color.b);
+    glUniform1f(u_opacity_, opacity);
+
+    glBindVertexArray(mesh->getVAOId(Material::ASSIMP_SHADER));
+    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+            0);
+    glBindVertexArray(0);
+#else
+    glUseProgram(program_->id());
+
+    glVertexAttribPointer(a_position_, 3, GL_FLOAT, GL_FALSE, 0,
+            mesh->vertices().data());
+    glEnableVertexAttribArray(a_position_);
+
+    glVertexAttribPointer(a_tex_coord_, 2, GL_FLOAT, GL_FALSE, 0,
+            mesh->tex_coords().data());
+    glEnableVertexAttribArray(a_tex_coord_);
+
+    glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(mvp_matrix));
+
+    if (ISSET(feature_set, AS_DIFFUSE_TEXTURE)) {
+        glActiveTexture (GL_TEXTURE0);
+        glBindTexture(texture->getTarget(), texture->getId());
+        glUniform1i(u_texture_, 0);
+    } else {
+        glm::vec4 diffuse_color = material->getVec4("diffuse_color");
+        glm::vec4 ambient_color = material->getVec4("ambient_color");
+        glUniform4f(u_diffuse_color_, diffuse_color.x, diffuse_color.y, diffuse_color.z, diffuse_color.w);
+        glUniform4f(u_ambient_color_, ambient_color.x, ambient_color.y, ambient_color.z, ambient_color.w);
+    }
+
+    glUniform3f(u_color_, color.r, color.g, color.b);
+    glUniform1f(u_opacity_, opacity);
+
+    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+            mesh->triangles().data());
+#endif
+
+    checkGlError("AssimpShader::render");
+}
+
+}
+;

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.h
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.h
@@ -32,8 +32,8 @@
 #define ISSET(num, i)                    ((num & (1 << i)) != 0)
 #define CLEARBIT(num, i)                 num = (num & ~(1 << i))
 
-#define AS_DIFFUSE_TEXTURE                0x00000001
-#define AS_SPECULAR_TEXTURE               0x00000002
+#define AS_DIFFUSE_TEXTURE                0x00000000
+#define AS_SPECULAR_TEXTURE               0x00000001
 
 /*
  * As the features are incremented, need to increase AS_TOTAL_FEATURE_COUNT

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.h
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.h
@@ -1,0 +1,86 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/***************************************************************************
+ * Shader for model loaded with Assimp
+ ***************************************************************************/
+
+#ifndef ASSIMP_SHADER_H_
+#define ASSIMP_SHADER_H_
+
+#include <memory>
+
+#include "GLES3/gl3.h"
+#include "glm/glm.hpp"
+#include "glm/gtc/type_ptr.hpp"
+
+#include "objects/recyclable_object.h"
+
+#define SETBIT(num, i)                   num = (num | (1 << i))
+#define ISSET(num, i)                    ((num & (1 << i)) != 0)
+#define CLEARBIT(num, i)                 num = (num & ~(1 << i))
+
+#define AS_DIFFUSE_TEXTURE                0x00000001
+#define AS_SPECULAR_TEXTURE               0x00000002
+
+/*
+ * As the features are incremented, need to increase AS_TOTAL_FEATURE_COUNT
+ * as well.
+ *
+ * Also the AS_TOTAL_GL_PROGRAM_COUNT is the total number of combinations
+ * possible with these feature set i.e for AS_TOTAL_FEATURE_COUNT = 3
+ * AS_TOTAL_GL_PROGRAM_COUNT = 8
+ *
+ */
+#define AS_TOTAL_FEATURE_COUNT            2
+#define AS_TOTAL_GL_PROGRAM_COUNT         4
+
+namespace gvr {
+class GLProgram;
+class RenderData;
+class Material;
+
+class AssimpShader: public RecyclableObject {
+public:
+    AssimpShader();
+    ~AssimpShader();
+    void recycle();
+    void render(const glm::mat4& model_matrix, const glm::mat4& model_it_matrix,
+            const glm::mat4& mvp_matrix, RenderData* render_data,
+            Material* material);
+
+private:
+    AssimpShader(const AssimpShader& assimp_shader);
+    AssimpShader(AssimpShader&& assimp_shader);
+    AssimpShader& operator=(const AssimpShader& assimp_shader);
+    AssimpShader& operator=(AssimpShader&& assimp_shader);
+
+private:
+    GLProgram* program_;
+    GLProgram** program_list_;
+
+    GLuint a_position_;
+    GLuint u_mvp_;
+    GLuint a_tex_coord_;
+    GLuint u_texture_;
+    GLuint u_diffuse_color_;
+    GLuint u_ambient_color_;
+    GLuint u_color_;
+    GLuint u_opacity_;
+};
+
+}
+
+#endif

--- a/GVRf/Framework/jni/shaders/material/texture_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/texture_shader.cpp
@@ -129,11 +129,11 @@ TextureShader::TextureShader() :
 
     program_light_ = new GLProgram(vertex_shader_light_strings,
             vertex_shader_light_string_lengths, fragment_shader_light_strings,
-            fragment_shader_light_string_lengths);
+            fragment_shader_light_string_lengths, 2);
     program_no_light_ = new GLProgram(vertex_shader_no_light_strings,
             vertex_shader_no_light_string_lengths,
             fragment_shader_no_light_strings,
-            fragment_shader_no_light_string_lengths);
+            fragment_shader_no_light_string_lengths, 2);
 
     a_position_no_light_ = glGetAttribLocation(program_no_light_->id(),
             "a_position");

--- a/GVRf/Framework/jni/shaders/shader_manager.h
+++ b/GVRf/Framework/jni/shaders/shader_manager.h
@@ -43,7 +43,7 @@ public:
             HybridObject(), bounding_box_shader_(),
             unlit_horizontal_stereo_shader_(), unlit_vertical_stereo_shader_(),
             oes_shader_(), oes_horizontal_stereo_shader_(), oes_vertical_stereo_shader_(),
-            cubemap_shader_(), cubemap_reflection_shader_(), texture_shader_(),
+            cubemap_shader_(), cubemap_reflection_shader_(), texture_shader_(), assimp_shader_(),
             external_renderer_shader_(), error_shader_(), latest_custom_shader_id_(
                     INITIAL_CUSTOM_SHADER_INDEX), custom_shaders_() {
     }

--- a/GVRf/Framework/jni/shaders/shader_manager.h
+++ b/GVRf/Framework/jni/shaders/shader_manager.h
@@ -33,6 +33,7 @@
 #include "shaders/material/cubemap_reflection_shader.h"
 #include "shaders/material/texture_shader.h"
 #include "shaders/material/external_renderer_shader.h"
+#include "shaders/material/assimp_shader.h"
 #include "util/gvr_log.h"
 
 namespace gvr {
@@ -56,6 +57,7 @@ public:
         delete cubemap_reflection_shader_;
         delete texture_shader_;
         delete external_renderer_shader_;
+        delete assimp_shader_;
         delete error_shader_;
         // We don't delete the custom shaders, as their Java owner-objects will do that for us.
     }
@@ -119,6 +121,12 @@ public:
         }
         return external_renderer_shader_;
     }
+    AssimpShader* getAssimpShader() {
+        if (!assimp_shader_) {
+            assimp_shader_ = new AssimpShader();
+        }
+        return assimp_shader_;
+    }
     ErrorShader* getErrorShader() {
         if (!error_shader_) {
             error_shader_ = new ErrorShader();
@@ -161,6 +169,7 @@ private:
     CubemapReflectionShader* cubemap_reflection_shader_;
     TextureShader* texture_shader_;
     ExternalRendererShader* external_renderer_shader_;
+    AssimpShader* assimp_shader_;
     ErrorShader* error_shader_;
     int latest_custom_shader_id_;
     std::map<int, CustomShader*> custom_shaders_;

--- a/GVRf/Framework/src/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRContext.java
@@ -41,7 +41,6 @@ import org.gearvrf.jassimp.AiNode;
 import org.gearvrf.jassimp.AiScene;
 import org.gearvrf.jassimp.AiTextureType;
 import org.gearvrf.jassimp.AiWrapperProvider;
-import org.gearvrf.jassimp.AiMaterial.Property;
 import org.gearvrf.periodic.GVRPeriodicEngine;
 import org.gearvrf.utility.Log;
 import org.gearvrf.utility.ResourceCache;
@@ -746,6 +745,9 @@ public abstract class GVRContext {
         GVRMaterial meshMaterial = new GVRMaterial(this,
                 GVRShaderType.Assimp.ID);
         
+        /* Feature set */
+        int assimpFeatureSet = 0;
+        
         /* Diffuse color */
         AiColor diffuseColor = material.getDiffuseColor(wrapperProvider);
         meshMaterial.setDiffuseColor(diffuseColor.getRed(),
@@ -778,11 +780,16 @@ public abstract class GVRContext {
         String texDiffuseFileName = material.getTextureFile(
                 AiTextureType.DIFFUSE, 0);
         if (texDiffuseFileName != null && !texDiffuseFileName.isEmpty()) {
+            assimpFeatureSet = GVRShaderType.Assimp.setBit(assimpFeatureSet,
+                    GVRShaderType.Assimp.AS_DIFFUSE_TEXTURE);
             Future<GVRTexture> futureDiffuseTexture = this
                     .loadFutureTexture(new GVRAndroidResource(this,
                             texDiffuseFileName));
             meshMaterial.setMainTexture(futureDiffuseTexture);
         }
+
+        /* Apply feature set to the material */
+        meshMaterial.setShaderFeatureSet(assimpFeatureSet);
 
         GVRSceneObject sceneObject = new GVRSceneObject(this);
         GVRRenderData sceneObjectRenderData = new GVRRenderData(this);

--- a/GVRf/Framework/src/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRContext.java
@@ -746,7 +746,7 @@ public abstract class GVRContext {
                 GVRShaderType.Assimp.ID);
         
         /* Feature set */
-        int assimpFeatureSet = 0;
+        int assimpFeatureSet = 0x00000000;
         
         /* Diffuse color */
         AiColor diffuseColor = material.getDiffuseColor(wrapperProvider);

--- a/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
@@ -117,6 +117,11 @@ public class GVRMaterial extends GVRHybridObject implements
             public static final GVRMaterialShaderId ID = new GVRStockMaterialShaderId(
                     8);
         }
+
+        public abstract static class Assimp {
+            public static final GVRMaterialShaderId ID = new GVRStockMaterialShaderId(
+                    9);
+        }
     };
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
@@ -67,6 +67,7 @@ import android.graphics.Color;
 public class GVRMaterial extends GVRHybridObject implements
         GVRShaders<GVRMaterialShaderId> {
 
+    private int mShaderFeatureSet;
     private GVRMaterialShaderId shaderId;
     final private Map<String, GVRTexture> textures = new HashMap<String, GVRTexture>();
 
@@ -121,6 +122,30 @@ public class GVRMaterial extends GVRHybridObject implements
         public abstract static class Assimp {
             public static final GVRMaterialShaderId ID = new GVRStockMaterialShaderId(
                     9);
+
+            /*
+             * Set this feature enum if diffuse texture is present in Assimp
+             * material Diffuse texture maps to main_texture in GearVRf
+             */
+            public static int AS_DIFFUSE_TEXTURE = 0x00000000;
+
+            /*
+             * Set this feature enum if specular texture is present in Assimp
+             * material
+             */
+            public static int AS_SPECULAR_TEXTURE = 0x00000001;
+
+            public static int setBit(int number, int index) {
+                return (number |= 1 << index);
+            }
+
+            public static boolean isSet(int number, int index) {
+                return ((number & (1 << index)) != 0);
+            }
+
+            public static int clearBit(int number, int index) {
+                return (number &= ~(1 << index));
+            }
         }
     };
 
@@ -144,6 +169,7 @@ public class GVRMaterial extends GVRHybridObject implements
             setSpecularColor(0.0f, 0.0f, 0.0f, 1.0f);
             setSpecularExponent(0.0f);
         }
+        this.mShaderFeatureSet = 0;
     }
 
     /**
@@ -509,6 +535,31 @@ public class GVRMaterial extends GVRHybridObject implements
         NativeMaterial.setMat4(getNative(), key, x1, y1, z1, w1, x2, y2, z2,
                 w2, x3, y3, z3, w3, x4, y4, z4, w4);
     }
+    
+    /**
+     * Set the feature set for pre-built shader's. Pre-built shader could be
+     * written to support all the properties of a material system with
+     * preprocessor macro to On/Off features. feature set would determine which
+     * properties are available for current model. Currently only Assimp shader
+     * has support for feature set.
+     * 
+     * @param featureSet
+     *            Feature set for this material.
+     */
+    public void setShaderFeatureSet(int featureSet) {
+        this.mShaderFeatureSet = featureSet;
+        NativeMaterial.setShaderFeatureSet(getNative(), featureSet);
+    }
+    
+    /**
+     * Get the feature set associated with this material.
+     * 
+     * @return An integer representing the feature set.
+     * 
+     */
+    public int getShaderFeatureSet() {
+        return mShaderFeatureSet;
+    }
 
 }
 
@@ -541,4 +592,6 @@ class NativeMaterial {
             float z1, float w1, float x2, float y2, float z2, float w2,
             float x3, float y3, float z3, float w3, float x4, float y4,
             float z4, float w4);
+
+    static native void setShaderFeatureSet(long material, int featureSet);
 }


### PR DESCRIPTION
Added a new shader for 3D models which are imported using jAssimp. Now GearVRf can read all the available material property for 3D models using jAssimp, but lacks shader support. Assimp shader will be one shader for all assimp imported model and will be based on assimp viewer shader:
https://github.com/assimp/assimp/blob/master/tools/assimp_view/Shaders.cpp

This pull request is not complete yet and right now only support diffuse texture and material color constant. Adding new feature would be easy, just adding a new preprocessor and adding support for that feature in shader:
#define AS_DIFFUSE_TEXTURE                0x00000001

I feel the design I followed might look complicated, so any design feedback would be helpful.

EDIT: Basic assimp shader is completed. Right now the shader only support diffuse texture if present and if not present fall back to material color properties. Later on all the material properties supported by assimp can be easily added.

GearVRf-DCO-1.0-Signed-off-by: Deepak Rawat
drawat@usc.edu