### PR TITLE
Moveculling

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/jni/engine/renderer/renderer.h
@@ -77,6 +77,8 @@ public:
             RenderTexture* post_effect_render_texture_a,
             RenderTexture* post_effect_render_texture_b);
 
+    static void cull(Scene *scene, Camera *camera, ShaderManager* shader_manager);
+
     static void initializeStats();
     static void resetStats();
     static int getNumberDrawCalls();

--- a/GVRf/Framework/jni/monoscopic/monoscopic_renderer_jni.cpp
+++ b/GVRf/Framework/jni/monoscopic/monoscopic_renderer_jni.cpp
@@ -26,6 +26,8 @@ void Java_org_gearvrf_NativeMonoscopicRenderer_renderCamera(JNIEnv * env,
         jlong jpost_effect_render_texture_a,
         jlong jpost_effect_render_texture_b);
 
+void Java_org_gearvrf_NativeMonoscopicRenderer_cull(JNIEnv * env,
+        jobject obj, jlong jscene, jlong jcamera, jlong shader_manager);
 }
 
 void Java_org_gearvrf_NativeMonoscopicRenderer_renderCamera(JNIEnv * env,
@@ -49,5 +51,15 @@ void Java_org_gearvrf_NativeMonoscopicRenderer_renderCamera(JNIEnv * env,
             post_effect_render_texture_a, post_effect_render_texture_b);
 
 }
+
+void Java_org_gearvrf_NativeMonoscopicRenderer_cull(JNIEnv * env,
+        jobject obj, jlong jscene, jlong jcamera, jlong jshader_manager) {
+    Scene* scene = reinterpret_cast<Scene*>(jscene);
+    Camera* camera = reinterpret_cast<Camera*>(jcamera);
+    ShaderManager* shader_manager = reinterpret_cast<ShaderManager*>(jshader_manager);
+
+    Renderer::cull(scene, camera, shader_manager);
+}
+
 
 }

--- a/GVRf/Framework/jni/oculus/view_manager.cpp
+++ b/GVRf/Framework/jni/oculus/view_manager.cpp
@@ -23,6 +23,14 @@ namespace gvr {
 
 extern "C" {
 
+void Java_org_gearvrf_GVRViewManager_cull(JNIEnv * jni, jclass clazz,
+        jlong jscene, jlong jcamera, jlong jshader_manager) {
+    Scene* scene = reinterpret_cast<Scene*>(jscene);
+    Camera* camera = reinterpret_cast<Camera*>(jcamera);
+    ShaderManager* shader_manager = reinterpret_cast<ShaderManager*>(jshader_manager);
+    Renderer::cull(scene, camera, shader_manager);
+}
+
 void Java_org_gearvrf_GVRViewManager_renderCamera(JNIEnv * jni, jclass clazz,
         jlong appPtr, jlong jscene, jlong jcamera, jlong jshader_manager,
         jlong jpost_effect_shader_manager, jlong jpost_effect_render_texture_a,

--- a/GVRf/Framework/src/org/gearvrf/GVRMonoscopicRenderer.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMonoscopicRenderer.java
@@ -50,9 +50,14 @@ abstract class GVRMonoscopicRenderer {
                         .getPostEffectRenderTextureA().getNative(),
                 renderBundle.getPostEffectRenderTextureB().getNative());
     }
+
+    static void cull(GVRScene scene, GVRCamera camera, GVRRenderBundle renderBundle) {
+        NativeMonoscopicRenderer.cull(scene.getNative(), camera.getNative(), renderBundle.getMaterialShaderManager().getNative());
+    }
 }
 
 class NativeMonoscopicRenderer {
+    static native void cull(long scene, long camera, long shader_manager);
     static native void renderCamera(long scene, long camera, int viewportX,
             int viewportY, int viewportWidth, int viewportHeight,
             long shaderManager, long postEffectShaderManager,

--- a/GVRf/Framework/src/org/gearvrf/GVRMonoscopicViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMonoscopicViewManager.java
@@ -141,6 +141,7 @@ class GVRMonoscopicViewManager extends GVRViewManager {
     protected void drawEyes() {
         // Log.d(TAG, "drawEyes()");
         mMainScene.getMainCameraRig().predictAndSetRotation(3.5f / 60.0f);
+        GVRMonoscopicRenderer.cull(mMainScene, mMainScene.getMainCameraRig().getCenterCamera(), mRenderBundle);
         GVRMonoscopicRenderer.renderCamera(mMainScene, mMainScene
                 .getMainCameraRig().getLeftCamera(), mViewportX, mViewportY,
                 mViewportWidth, mViewportHeight, mRenderBundle);

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -463,6 +463,11 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
         if (!(mSensoredScene == null || !mMainScene.equals(mSensoredScene))) {
             GVRCameraRig mainCameraRig = mMainScene.getMainCameraRig();
 
+            if(eye == 0) {
+                GVRPerspectiveCamera centerCamera = mainCameraRig.getCenterCamera();
+                cull(mMainScene.getNative(), centerCamera.getNative(), mRenderBundle.getMaterialShaderManager().getNative());
+            }
+
             if (eye == 1) {
                 GVRCamera rightCamera = mainCameraRig.getRightCamera();
                 renderCamera(mActivity.getAppPtr(), mMainScene, rightCamera,
@@ -639,7 +644,6 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                     mSplashScreen = null;
                 }
             }
-            cull(mMainScene.getNative(), mMainScene.getMainCameraRig().getCenterCamera().getNative(), mRenderBundle.getMaterialShaderManager().getNative());
         }
 
         public void onDrawFrame() {
@@ -663,8 +667,6 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
             doMemoryManagementAndPerFrameCallbacks();
 
             mScript.onStep();
-
-            cull(mMainScene.getNative(), mMainScene.getMainCameraRig().getCenterCamera().getNative(), mRenderBundle.getMaterialShaderManager().getNative());
         }
 
         public void onDrawFrame() {

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -107,6 +107,7 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
     ByteBuffer mReadbackBuffer = null;
     int mReadbackBufferWidth = 0, mReadbackBufferHeight = 0;
 
+    private native void cull(long scene, long camera, long shader_manager);
     private native void renderCamera(long appPtr, long scene, long camera,
             long shaderManager, long postEffectShaderManager,
             long postEffectRenderTextureA, long postEffectRenderTextureB);
@@ -638,6 +639,7 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                     mSplashScreen = null;
                 }
             }
+            cull(mMainScene.getNative(), mMainScene.getMainCameraRig().getCenterCamera().getNative(), mRenderBundle.getMaterialShaderManager().getNative());
         }
 
         public void onDrawFrame() {
@@ -661,6 +663,8 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
             doMemoryManagementAndPerFrameCallbacks();
 
             mScript.onStep();
+
+            cull(mMainScene.getNative(), mMainScene.getMainCameraRig().getCenterCamera().getNative(), mRenderBundle.getMaterialShaderManager().getNative());
         }
 
         public void onDrawFrame() {

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -463,11 +463,6 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
         if (!(mSensoredScene == null || !mMainScene.equals(mSensoredScene))) {
             GVRCameraRig mainCameraRig = mMainScene.getMainCameraRig();
 
-            if(eye == 0) {
-                GVRPerspectiveCamera centerCamera = mainCameraRig.getCenterCamera();
-                cull(mMainScene.getNative(), centerCamera.getNative(), mRenderBundle.getMaterialShaderManager().getNative());
-            }
-
             if (eye == 1) {
                 GVRCamera rightCamera = mainCameraRig.getRightCamera();
                 renderCamera(mActivity.getAppPtr(), mMainScene, rightCamera,
@@ -535,6 +530,10 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
 
     /** Called once per frame, before {@link #onDrawEyeView(int, float)}. */
     void onDrawFrame() {
+
+        GVRPerspectiveCamera centerCamera = mMainScene.getMainCameraRig().getCenterCamera();
+        cull(mMainScene.getNative(), centerCamera.getNative(), mRenderBundle.getMaterialShaderManager().getNative());
+
         if (mCurrentEye == 1) {
             mActivity.setCamera(mMainScene.getMainCameraRig().getLeftCamera());
         } else {


### PR DESCRIPTION
Moved culling outside of renderCamera().  Culling will now happen before the left eye is drawn.  Culling will only happen once per frame now.  Yay :).  Culling also now uses the center camera of the camera rig.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn 
tom.flynn@samsung.com