### PR TITLE
Fix a memory leak in renderer.cpp

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -327,6 +327,7 @@ void Renderer::frustum_cull(Scene* scene, Camera *camera,
 
             //Delete the generated bounding box mesh
             bounding_box_mesh->cleanUp();
+            delete bounding_box_render_data;
         }
 #endif
     }


### PR DESCRIPTION
A RenderData object is allocated every time Renderer::frustum_cull()
is called but is not deallocated.