### PR TITLE
Reduce the visibility of GVRComponent.getOwnerObject() to protected

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -329,6 +329,14 @@ public class GVRCameraRig extends GVRComponent {
         NativeCameraRig.attachCenterCamera(getNative(), camera.getNative());
     }
 
+    public void attachToParent(GVRSceneObject parentObject) {
+        parentObject.addChildObject(getOwnerObject());
+    }
+
+    public void detachFromParent(GVRSceneObject parentObject) {
+       parentObject.removeChildObject(getOwnerObject());
+    }
+
     /**
      * Resets the rotation of the camera rig by multiplying further rotations by
      * the inverse of the current rotation.

--- a/GVRf/Framework/src/org/gearvrf/GVRComponent.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRComponent.java
@@ -70,7 +70,7 @@ class GVRComponent extends GVRHybridObject {
     /**
      * @return The {@link GVRSceneObject} this object is currently attached to.
      */
-    public GVRSceneObject getOwnerObject() {
+    protected GVRSceneObject getOwnerObject() {
         if (owner != null) {
             return owner;
         }

--- a/GVRf/Framework/src/org/gearvrf/GVREyePointeeHolder.java
+++ b/GVRf/Framework/src/org/gearvrf/GVREyePointeeHolder.java
@@ -119,6 +119,10 @@ public class GVREyePointeeHolder extends GVRComponent {
         sConcatenations = new CleanupHandlerListManager(sCleanup);
     }
 
+    public GVRSceneObject getOwnerObject() {
+        return super.getOwnerObject();
+    }
+
     /**
      * Is this holder enabled?
      * 

--- a/GVRf/Sample/collision/src/org/gearvrf/collisiondetection/CollisionViewManager.java
+++ b/GVRf/Sample/collision/src/org/gearvrf/collisiondetection/CollisionViewManager.java
@@ -72,7 +72,7 @@ public class CollisionViewManager extends GVRScript {
         mMainScene.getMainCameraRig().getRightCamera()
                 .setBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
 
-        mMainScene.getMainCameraRig().getOwnerObject().getTransform()
+        mMainScene.getMainCameraRig().getTransform()
                 .setPosition(0.0f, 0.0f, 0.0f);
 
         GVRSceneObject solarSystemObject = new GVRSceneObject(gvrContext);
@@ -103,8 +103,7 @@ public class CollisionViewManager extends GVRScript {
         GVRSceneObject moonRevolutionObject = new GVRSceneObject(gvrContext);
         moonRevolutionObject.getTransform().setPosition(4.0f, 0.0f, 0.0f);
         earthRevolutionObject.addChildObject(moonRevolutionObject);
-        moonRevolutionObject.addChildObject(mMainScene.getMainCameraRig()
-                .getOwnerObject());
+        mMainScene.getMainCameraRig().attachToParent(moonRevolutionObject);
 
         counterClockwise(venusRevolutionObject, 400f);
         clockwise(venusRotationObject, 400f);
@@ -113,7 +112,7 @@ public class CollisionViewManager extends GVRScript {
         counterClockwise(earthRotationObject, 1.5f);
 
         clockwise(
-                mMainScene.getMainCameraRig().getOwnerObject().getTransform(),
+                mMainScene.getMainCameraRig().getTransform(),
                 60f);
     }
 

--- a/GVRf/Sample/gvrjassimpmodelloader/src/org/gearvrf/jassimpmodelloader/JassimpModelLoaderViewManager.java
+++ b/GVRf/Sample/gvrjassimpmodelloader/src/org/gearvrf/jassimpmodelloader/JassimpModelLoaderViewManager.java
@@ -63,8 +63,7 @@ public class JassimpModelLoaderViewManager extends GVRScript {
         GVRCameraRig mainCameraRig = mMainScene.getMainCameraRig();
         mainCameraRig.getLeftCamera().setBackgroundColor(Color.BLACK);
         mainCameraRig.getRightCamera().setBackgroundColor(Color.BLACK);
-        mainCameraRig.getOwnerObject().getTransform()
-                .setPosition(0.0f, 0.0f, 0.0f);
+        mainCameraRig.getTransform().setPosition(0.0f, 0.0f, 0.0f);
 
         // Model with texture
         GVRSceneObject astroBoyModel = gvrContext

--- a/GVRf/VRHackathons/VRBasketBalls/VRBasketBallsAndroid/src/com/cesarandres/vr/vrbbals/android/BallSpinnerScript.java
+++ b/GVRf/VRHackathons/VRBasketBalls/VRBasketBallsAndroid/src/com/cesarandres/vr/vrbbals/android/BallSpinnerScript.java
@@ -140,11 +140,11 @@ public class BallSpinnerScript extends GVRScript {
 		headTracker.getRenderData().setDepthTest(false);
 		headTracker.getRenderData().setRenderingOrder(100000);
 		mainCamera = scene.getMainCameraRig();
-		mainCamera.getOwnerObject().addChildObject(headTracker);
+		mainCamera.addChildObject(headTracker);
 
 		mainCamera.getLeftCamera().setBackgroundColor(r, g, b, 1.0f);
 		mainCamera.getRightCamera().setBackgroundColor(r, g, b, 1.0f);
-		mainCamera.getOwnerObject().getTransform().setPosition(0f, 0f, 0f);
+		mainCamera.getTransform().setPosition(0f, 0f, 0f);
 
 		root = new GVRSceneObject(ctx);
 		scene.addSceneObject(root);


### PR DESCRIPTION
getOwnerObject() was used to set CameraRig transform, adding camera-frame objects (pickers,
head trackers, moved objects, etc.), and set orientation data from sensors. Because
implementations of these functionalities are subject to change, it is risky to expose the
owner object to users.

Recently, new APIs have been added to CameraRig to directly perform these functions, such as
getTransform(), addChildObject, removeChildObject, etc. So it is less needed to keep getOwnerObject()
public; further, when is is public, there are multiple ways to do common things and can lead to
confusion and maintainability issues.

The proposed solution is to
   1) Make GVRComponent.getOwnerObject() protected.
   2) Add explicit API to perform things for CameraRig, such as attachToParent() and
      detachFromParent().
   3) An exception is to make GVREyePointeeHolder.getOwnerObject() public to support current functionalites.
      Refactoring of this class is left for others if seen appropriate.