### PR TITLE
Avoid overdrawing except for transparent objects and overlays

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -89,8 +89,13 @@ void Renderer::renderCamera(Scene* scene, Camera* camera, int framebufferId,
                 vp_matrix, shader_manager);
 
         // do sorting based on render order
-        std::sort(render_data_vector.begin(), render_data_vector.end(),
-                compareRenderData);
+        if (!scene->get_frustum_culling()) {
+            std::sort(render_data_vector.begin(), render_data_vector.end(),
+                    compareRenderData);
+        } else {
+            std::sort(render_data_vector.begin(), render_data_vector.end(),
+                    compareRenderDataWithFrustumCulling);
+        }
 
         std::vector<PostEffectData*> post_effects = camera->post_effect_data();
 

--- a/GVRf/Framework/jni/objects/components/render_data.h
+++ b/GVRf/Framework/jni/objects/components/render_data.h
@@ -241,5 +241,23 @@ inline bool compareRenderData(RenderData* i, RenderData* j) {
     return i->rendering_order() < j->rendering_order();
 }
 
+inline bool compareRenderDataWithFrustumCulling(RenderData* i, RenderData* j) {
+    // if either i or j is a transparent object or an overlay object
+    if (i->rendering_order() >= RenderData::Transparent
+            || j->rendering_order() >= RenderData::Transparent) {
+        if (i->rendering_order() == j->rendering_order()) {
+            // if both are either transparent or both are overlays
+            // place them in reverse camera order from back to front
+            return i->camera_distance() < j->camera_distance();
+        } else {
+            // if one of them is a transparent or an overlay draw by rendering order
+            return i->rendering_order() < j->rendering_order();
+        }
+    }
+
+    // if both are neither transparent nor overlays, place them in camera order front to back
+    return i->camera_distance() > j->camera_distance();
+}
+
 }
 #endif


### PR DESCRIPTION
To avoid over drawing, draw objects front to back based on camera distance (continue to draw transparent objects and overlays in reverse order back to front)

GearVRf-DCO-1.0-Signed-off-by: Srinivasa Algubelli
s.algubelli@samsung.com