### PR TITLE
Fix JNI memory leak from texture parameters.

### DIFF
--- a/GVRf/Framework/jni/objects/textures/base_texture_jni.cpp
+++ b/GVRf/Framework/jni/objects/textures/base_texture_jni.cpp
@@ -71,14 +71,18 @@ Java_org_gearvrf_NativeBaseTexture_fileConstructor(JNIEnv * env,
     int imgW = loader.pOutImage.width;
     int imgH = loader.pOutImage.height;
     unsigned char *pixels = loader.pOutImage.bits;
-    return reinterpret_cast<jlong>(new BaseTexture(imgW, imgH, pixels, texture_parameters));
+    jlong result = reinterpret_cast<jlong>(new BaseTexture(imgW, imgH, pixels, texture_parameters));
+    env->ReleaseIntArrayElements(jtexture_parameters, texture_parameters, 0);
+    return result;
 }
 
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeBaseTexture_bareConstructor(JNIEnv * env, jobject obj, jintArray jtexture_parameters) {
 
     jint* texture_parameters = env->GetIntArrayElements(jtexture_parameters,0);
-    return reinterpret_cast<jlong>(new BaseTexture(texture_parameters));
+    jlong result =  reinterpret_cast<jlong>(new BaseTexture(texture_parameters));
+    env->ReleaseIntArrayElements(jtexture_parameters, texture_parameters, 0);
+    return result;
 }
 
 JNIEXPORT jboolean JNICALL

--- a/GVRf/Framework/jni/objects/textures/compressed_texture_jni.cpp
+++ b/GVRf/Framework/jni/objects/textures/compressed_texture_jni.cpp
@@ -48,6 +48,8 @@ Java_org_gearvrf_asynchronous_NativeCompressedTexture_normalConstructor(JNIEnv *
 
     env->ReleaseByteArrayElements(bytes, data, 0);
 
+    env->ReleaseIntArrayElements(jtexture_parameters, texture_parameters, 0);
+
     return reinterpret_cast<jlong>(texture);
 }
 

--- a/GVRf/Framework/jni/objects/textures/cubemap_texture_jni.cpp
+++ b/GVRf/Framework/jni/objects/textures/cubemap_texture_jni.cpp
@@ -41,13 +41,16 @@ Java_org_gearvrf_NativeCubemapTexture_bitmapArrayConstructor(JNIEnv * env,
         "new CubemapTexture() failed! Input bitmapList's length is not 6.";
         throw error;
     }
+    jlong result = NULL;
     try {
         jint* texture_parameters = env->GetIntArrayElements(jtexture_parameters,0);
-        return reinterpret_cast<jlong>(new CubemapTexture(env, bitmapArray, texture_parameters));
+        result = reinterpret_cast<jlong>(new CubemapTexture(env, bitmapArray, texture_parameters));
+        env->ReleaseIntArrayElements(jtexture_parameters, texture_parameters, 0);
     } catch (const std::string &err) {
         printJavaCallStack(env, err);
         throw err;
     }
+    return result;
 }
 
 }

--- a/GVRf/Framework/jni/objects/textures/texture_jni.cpp
+++ b/GVRf/Framework/jni/objects/textures/texture_jni.cpp
@@ -47,6 +47,8 @@ Java_org_gearvrf_NativeTexture_updateTextureParameters(JNIEnv * env, jobject obj
 
     jint* texture_parameters = env->GetIntArrayElements(jtexture_parameters, 0);
     texture->updateTextureParameters(texture_parameters);
+    env->ReleaseIntArrayElements(jtexture_parameters, texture_parameters, 0);
+
 }
 
 }


### PR DESCRIPTION
Just found it while I was working on other issues.

All parameter int array in JNI weren't released after they had been used.

GearVRf-DCO-1.0-Signed-off-by: Chao Chen