### PR TITLE
gvr-cubemap: Add a new sample to show efficient cube mapping

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCubeSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCubeSceneObject.java
@@ -249,9 +249,15 @@ public class GVRCubeSceneObject extends GVRSceneObject {
     /**
      * Constructs a cube scene object with each side of length 1.
      * 
-     * The cube's triangles and normals are facing either in or out and the same
-     * texture will be applied to each side of the cube. All six faces share the
-     * same material (i.e. same texture and same shader).
+     * The cube's triangles and normals are facing either in or out and the material
+     * is applied to the cube.
+     *
+     * To use the same texture on the six faces, use a material with the shader type
+     * {@code GVRMaterial.GVRShaderType.Texture} and a {@code GVRTexture}.
+     *
+     * To use different textures on different faces, use a material
+     * with the shader type {@code GVRMaterial.GVRShaderType.Cubemap}, and a
+     * cubemap texture loaded by {@code GVRContext.loadFutureCubemapTexture}.
      * 
      * @param gvrContext
      *            current {@link GVRContext}

--- a/GVRf/Sample/gvr-cubemap/src/org/gearvrf/cubemap/CubemapScript.java
+++ b/GVRf/Sample/gvr-cubemap/src/org/gearvrf/cubemap/CubemapScript.java
@@ -42,10 +42,13 @@ public class CubemapScript extends GVRScript {
 
     // Type of object for the environment
     // 0: surrounding sphere using GVRSphereSceneObject
-    // 1: surrounding cube using GVRCubeSceneObject
-    // 2: surrounding cylinder using GVRCylinderSceneObject
-    // 2: surrounding cube using six GVRSceneOjbects (quads)
-    private static final int mEnvironmentType = 0;
+    // 1: surrounding cube using GVRCubeSceneObject and 1 GVRCubemapTexture
+    //    (method A, recommended)
+    // 2: surrounding cube using GVRCubeSceneObject and 6 GVRTexture's
+    //    (method B)
+    // 3: surrounding cylinder using GVRCylinderSceneObject
+    // 4: surrounding cube using six GVRSceneOjbects (quads)
+    private static final int mEnvironmentType = 1;
 
     // Type of object for the reflective object
     // 0: reflective sphere using GVRSphereSceneObject
@@ -101,17 +104,28 @@ public class CubemapScript extends GVRScript {
             break;
 
         case 1:
-            // ////////////////////////////////////////////////////
-            // create surrounding cube using GVRCubeSceneObject //
-            // ////////////////////////////////////////////////////
+            // ////////////////////////////////////////////////////////////
+            // create surrounding cube using GVRCubeSceneObject method A //
+            // ////////////////////////////////////////////////////////////
             GVRCubeSceneObject mCubeEvironment = new GVRCubeSceneObject(
-                    gvrContext, false, futureTextureList, 2);
+                    gvrContext, false, cubemapMaterial);
             mCubeEvironment.getTransform().setScale(CUBE_WIDTH, CUBE_WIDTH,
                     CUBE_WIDTH);
             scene.addSceneObject(mCubeEvironment);
             break;
 
         case 2:
+            // ////////////////////////////////////////////////////////////
+            // create surrounding cube using GVRCubeSceneObject method B //
+            // ////////////////////////////////////////////////////////////
+            mCubeEvironment = new GVRCubeSceneObject(
+                    gvrContext, false, futureTextureList, 2);
+            mCubeEvironment.getTransform().setScale(CUBE_WIDTH, CUBE_WIDTH,
+                    CUBE_WIDTH);
+            scene.addSceneObject(mCubeEvironment);
+            break;
+
+        case 3:
             // ///////////////////////////////////////////////////////////
             // create surrounding cylinder using GVRCylinderSceneObject //
             // ///////////////////////////////////////////////////////////
@@ -122,7 +136,7 @@ public class CubemapScript extends GVRScript {
             scene.addSceneObject(mCylinderEvironment);
             break;
 
-        case 3:
+        case 4:
             // /////////////////////////////////////////////////////////////
             // create surrounding cube using six GVRSceneOjbects (quads) //
             // /////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currenty, the samples show how to construct a cube scene object using a list of
textures.

A sample is added to use a GVRCubemapTexture which can be loaded from a .zip file.

Using the cubemap, each frame only requires 1 draw and 12 triangles. It is also more
convnient than using a list of textures.