### PR TITLE
Prediction tweaks

### DIFF
--- a/GVRf/Framework/jni/objects/components/camera_rig.cpp
+++ b/GVRf/Framework/jni/objects/components/camera_rig.cpp
@@ -136,19 +136,15 @@ glm::quat CameraRig::predict(float time, const RotationSensorData& rotationSenso
             / 1000000000.0f;
 
     glm::vec3 axis = rotationSensorData.gyro();
+    //the magnitude of the gyro vector should be the angular velocity, rad/sec
     float angle = glm::length(axis);
 
+    //normalize the axis
     if (angle != 0.0f) {
         axis /= angle;
     }
-    angle *= (time + time_diff) * 180.0f / M_PI;
 
-    glm::quat rotation = rotationSensorData.quaternion()
-            * glm::angleAxis(angle, axis);
-
-    glm::quat transform_rotation = complementary_rotation_ * rotation;
-
-    return transform_rotation;
+    return complementary_rotation_*rotationSensorData.quaternion();
 }
 
 void CameraRig::setRotation(const glm::quat& transform_rotation) {

--- a/GVRf/Framework/jni/oculus/activity_jni.h
+++ b/GVRf/Framework/jni/oculus/activity_jni.h
@@ -98,6 +98,7 @@ private:
 
 
 typedef GVRActivityT<OculusHeadRotation> GVRActivity;
+//typedef GVRActivityT<KSensorHeadRotation> GVRActivity;
 
 class KSensorHeadRotation {
 public:
@@ -127,7 +128,7 @@ public:
         }
     }
 
-private:
+public:
     std::unique_ptr<KSensor> sensor_;
     RotationSensorData rotationSensorData_;
 };


### PR DESCRIPTION
This is not meant for merging; it shows the effect of the ::predict tweak I am planning to eliminate the shimmering. It doesn't improve the actual prediction but as far as I can tell doesn't degrade it while the shimmering is eliminated.

Still researching the motion blur - causes and effects are not clear to me. My impression is that it is not just a function of the prediction.

Exposed is a significant gyro drift problem with ksensor which causes at least some of the aliasing once the shimmering is removed.

By default the old KSensor is activated; long-pressing the back key switches modes:
0 - old KSensor
1 - the calculation leading to the shimmering is eliminated
2 - additional rotation (that doesn't do anything noticeable) eliminated also
3 - switches to Oculus

My plan is to use mode 2.