### PR TITLE
Improve robustness of mesh.cpp

### DIFF
--- a/GVRf/Framework/jni/engine/memory/gl_delete.cpp
+++ b/GVRf/Framework/jni/engine/memory/gl_delete.cpp
@@ -13,14 +13,25 @@
  * limitations under the License.
  */
 
-//#include "util/gvr_log.h"
+#include "util/gvr_log.h"
 #include "gl_delete.h"
+#include "util/gvr_cpp_stack_trace.h"
 
 namespace gvr {
 
 GlDelete gl_delete;
 
+void GlDelete::logInvalidParameter(const char *funcName) {
+    LOGW("GlDelete::%s is called with an invalid parameter", funcName);
+    printStackTrace();
+}
+
 void GlDelete::queueBuffer(GLuint buffer) {
+    if (buffer == GVR_INVALID) {
+        logInvalidParameter(__func__);
+        return;
+    }
+
     lock();
     buffers_.push_back(buffer);
 //    LOGD("queueBuffer(%d) buffers_.size() = %d", buffer, buffers_.size());
@@ -29,6 +40,11 @@ void GlDelete::queueBuffer(GLuint buffer) {
 }
 
 void GlDelete::queueFrameBuffer(GLuint buffer) {
+    if (buffer == GVR_INVALID) {
+        logInvalidParameter(__func__);
+        return;
+    }
+
     lock();
     frame_buffers_.push_back(buffer);
 //    LOGD("queueFrameBuffer(%d) frame_buffers_.size() = %d", buffer,
@@ -38,6 +54,11 @@ void GlDelete::queueFrameBuffer(GLuint buffer) {
 }
 
 void GlDelete::queueProgram(GLuint program) {
+    if (program == GVR_INVALID) {
+        logInvalidParameter(__func__);
+        return;
+    }
+
     lock();
     programs_.push_back(program);
 //    LOGD("queueProgram(%d) programs_.size() = %d", program, programs_.size());
@@ -46,6 +67,11 @@ void GlDelete::queueProgram(GLuint program) {
 }
 
 void GlDelete::queueRenderBuffer(GLuint buffer) {
+    if (buffer == GVR_INVALID) {
+        logInvalidParameter(__func__);
+        return;
+    }
+
     lock();
     render_buffers_.push_back(buffer);
 //    LOGD("queueRenderBuffer(%d) render_buffers_.size() = %d", buffer,
@@ -55,6 +81,11 @@ void GlDelete::queueRenderBuffer(GLuint buffer) {
 }
 
 void GlDelete::queueShader(GLuint shader) {
+    if (shader == GVR_INVALID) {
+        logInvalidParameter(__func__);
+        return;
+    }
+
     lock();
     shaders_.push_back(shader);
 //    LOGD("queueShader(%d) shaders_.size() = %d", shader, shaders_.size());
@@ -63,6 +94,11 @@ void GlDelete::queueShader(GLuint shader) {
 }
 
 void GlDelete::queueTexture(GLuint texture) {
+    if (texture == GVR_INVALID) {
+        logInvalidParameter(__func__);
+        return;
+    }
+
     lock();
     textures_.push_back(texture);
 //    LOGD("queueTexture(%d) textures_.size() = %d", texture, textures_.size());
@@ -71,6 +107,11 @@ void GlDelete::queueTexture(GLuint texture) {
 }
 
 void GlDelete::queueVertexArray(GLuint vertex_array) {
+    if (vertex_array == GVR_INVALID) {
+        logInvalidParameter(__func__);
+        return;
+    }
+
     lock();
     vertex_arrays_.push_back(vertex_array);
 //    LOGD("queueVertexArray(%d) vertex_arrays_.size() = %d", vertex_array,

--- a/GVRf/Framework/jni/engine/memory/gl_delete.h
+++ b/GVRf/Framework/jni/engine/memory/gl_delete.h
@@ -20,6 +20,8 @@
 #include <pthread.h>
 #include "GLES3/gl3.h"
 
+#define GVR_INVALID 0
+
 namespace gvr {
 class GlDelete {
 
@@ -53,6 +55,8 @@ private:
     void unlock() {
         pthread_mutex_unlock(&mutex);
     }
+
+    void logInvalidParameter(const char *msg);
 
     std::vector<GLuint> buffers_;
     std::vector<GLuint> frame_buffers_;

--- a/GVRf/Framework/jni/objects/mesh.h
+++ b/GVRf/Framework/jni/objects/mesh.h
@@ -41,7 +41,10 @@ class Mesh: public HybridObject {
 public:
     Mesh() :
             vertices_(), normals_(), tex_coords_(), triangles_(), float_vectors_(), vec2_vectors_(), vec3_vectors_(), vec4_vectors_(),
-                    have_bounding_volume_(false), vaoInitiliased_(false) {
+                    have_bounding_volume_(false), vaoInitiliased_(false),
+                    vaoID_(GVR_INVALID), triangle_vboID_(GVR_INVALID), vert_vboID_(GVR_INVALID),
+                    norm_vboID_(GVR_INVALID), tex_vboID_(GVR_INVALID)
+    {
     }
 
     ~Mesh() {
@@ -62,11 +65,16 @@ public:
     }
 
     void deleteVaos() {
-        gl_delete.queueVertexArray(vaoID_);
-        gl_delete.queueBuffer(triangle_vboID_);
-        gl_delete.queueBuffer(vert_vboID_);
-        gl_delete.queueBuffer(norm_vboID_);
-        gl_delete.queueBuffer(tex_vboID_);
+        if (vaoID_ != GVR_INVALID)
+            gl_delete.queueVertexArray(vaoID_);
+        if (triangle_vboID_ != GVR_INVALID)
+            gl_delete.queueBuffer(triangle_vboID_);
+        if (vert_vboID_ != GVR_INVALID)
+            gl_delete.queueBuffer(vert_vboID_);
+        if (norm_vboID_ != GVR_INVALID)
+            gl_delete.queueBuffer(norm_vboID_);
+        if (tex_vboID_ != GVR_INVALID)
+            gl_delete.queueBuffer(tex_vboID_);
         have_bounding_volume_ = false;
     }
 

--- a/GVRf/Framework/jni/util/gvr_cpp_stack_trace.cpp
+++ b/GVRf/Framework/jni/util/gvr_cpp_stack_trace.cpp
@@ -1,0 +1,83 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "android/log.h"
+#include "gvr_cpp_stack_trace.h"
+
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+
+#include <unwind.h>
+#include <dlfcn.h>
+
+#define TAG "gvrf"
+
+namespace {
+
+    struct BacktraceState
+    {
+        void** current;
+        void** end;
+    };
+
+    static _Unwind_Reason_Code unwindCallback(struct _Unwind_Context* context, void* arg)
+    {
+        BacktraceState* state = static_cast<BacktraceState*>(arg);
+        uintptr_t pc = _Unwind_GetIP(context);
+        if (pc) {
+            if (state->current == state->end) {
+                return _URC_END_OF_STACK;
+            } else {
+                *state->current++ = reinterpret_cast<void*>(pc);
+            }
+        }
+        return _URC_NO_REASON;
+    }
+
+    size_t captureBacktrace(void** buffer, size_t max)
+    {
+        BacktraceState state = {buffer, buffer + max};
+        _Unwind_Backtrace(unwindCallback, &state);
+
+        return state.current - buffer;
+    }
+
+    void dumpBacktrace(std::ostream& os, void** addrs, size_t count)
+    {
+        for (size_t idx = 0; idx < count; ++idx) {
+            const void* addr = addrs[idx];
+            const char* symbol = "";
+
+            Dl_info info;
+            if (dladdr(addr, &info) && info.dli_sname) {
+                symbol = info.dli_sname;
+            }
+
+            os << "  #" << std::setw(2) << idx << ": " << addr << "  " << symbol << "\n";
+        }
+    }
+
+} // namespace
+
+void printStackTrace(unsigned int max_frames)
+{
+    void* buffer[max_frames];
+    std::ostringstream oss;
+
+    dumpBacktrace(oss, buffer, captureBacktrace(buffer, max_frames));
+
+    __android_log_print(ANDROID_LOG_DEBUG, TAG, "%s", oss.str().c_str());
+}

--- a/GVRf/Framework/jni/util/gvr_cpp_stack_trace.cpp
+++ b/GVRf/Framework/jni/util/gvr_cpp_stack_trace.cpp
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include "android/log.h"
+#include "util/gvr_log.h"
 #include "gvr_cpp_stack_trace.h"
 
 #include <iostream>
@@ -22,8 +22,6 @@
 
 #include <unwind.h>
 #include <dlfcn.h>
-
-#define TAG "gvrf"
 
 namespace {
 
@@ -79,5 +77,5 @@ void printStackTrace(unsigned int max_frames)
 
     dumpBacktrace(oss, buffer, captureBacktrace(buffer, max_frames));
 
-    __android_log_print(ANDROID_LOG_DEBUG, TAG, "%s", oss.str().c_str());
+    LOGD("%s", oss.str().c_str());
 }

--- a/GVRf/Framework/jni/util/gvr_cpp_stack_trace.h
+++ b/GVRf/Framework/jni/util/gvr_cpp_stack_trace.h
@@ -1,0 +1,25 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/***************************************************************************
+ * Printing C++ stacktrace when native crash happens. Using tag gvrf
+ ***************************************************************************/
+
+#ifndef GVR_CPP_STACK_TRACE_H_
+#define GVR_CPP_STACK_TRACE_H_
+
+void printStackTrace(unsigned int max_frames = 10);
+
+#endif // GVR_CPP_STACK_TRACE_H_


### PR DESCRIPTION
Currently, some variables in mesh.cpp are not initialized, but
might be passed to glDelete* functions. This causes some glErrors
and might accidentally delete GL objects used by other meshes.

This patch initializes these variables to GL_INVALID (-1), and
added sanity checks in gl_delete.cpp. Stack trace is logged with
the tag "gvrf" to help debugging if invalid values are detected
by gl_delete.

GearVRf-DCO-1.0-Signed-off-by: Danke Xie
d.xie@samsung.com