### PR TITLE
Fix JNI crash due to using a JNI environment attached to the UI thread ...

### DIFF
--- a/GVRf/Framework/jni/oculus/activity_jni.h
+++ b/GVRf/Framework/jni/oculus/activity_jni.h
@@ -35,8 +35,7 @@ class KSensorHeadRotation;
 template <class R> class GVRActivityT : public OVR::VrAppInterface
 {
 public:
-    GVRActivityT( JNIEnv & jni_, jobject activityObject_);
-    ~GVRActivityT();
+    GVRActivityT(JNIEnv& jni);
 
     virtual void        Configure( OVR::ovrSettings & settings );
     virtual void        OneTimeInit( const char * fromPackage, const char * launchIntentJSON, const char * launchIntentURI );
@@ -46,6 +45,7 @@ public:
     virtual bool        OnKeyEvent( const int keyCode, const int repeatCount, const OVR::KeyEventType eventType );
     bool                updateSensoredScene();
     void                setCameraRig(jlong cameraRig);
+    void                initJni();
 
     // When launched by an intent, we may be viewing a partial
     // scene for debugging, so always clear the screen to grey
@@ -68,10 +68,9 @@ private:
         viewManager->mvp_matrix = mvp;
     }
 
-    JNIEnv*             UiJni;            // for use by the Java UI thread
+    JNIEnv*             uiJni;            // for use by the Java UI thread
     OVR::Matrix4f       GetEyeView( const int eye, const float fovDegrees ) const;
 
-    jobject             javaObject;
     jclass              activityClass;    // must be looked up from main thread or FindClass() will fail
 
     jclass              vrAppSettingsClass;


### PR DESCRIPTION
... from the Oculus native VR thread on shutdown. Plus small cleanup.

Unfortunately there is another crash, this time in Oculus so this
does't help. Not sure I will be able to do something about the Oculus
crash (in vrapi_Shutdown there seems to be use of an invalid JNI
object). The Oculus VrCubeWorld_Framework sample exhibits the same
behavior..

So this is it for now. Will try few more things but we might have to
hope that the new Oculus SDK remedies the problem.