### PR TITLE
Add setters/getters for near/far clipping planes to GVRCameraRig

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCamera.java
@@ -297,6 +297,37 @@ public abstract class GVRCamera extends GVRComponent {
         }
         return 0;
     }
+
+    /**
+     * @return Distance from the origin to the near clipping plane for this
+     *         camera.
+     */
+    public abstract float getNearClippingDistance();
+
+    /**
+     * Sets the distance from the origin to the near clipping plane for this
+     * camera.
+     * 
+     * @param near
+     *            Distance to the near clipping plane.
+     */
+    public abstract void setNearClippingDistance(float near);
+
+    /**
+     * @return Distance from the origin to the far clipping plane for this
+     *         camera.
+     */
+    public abstract float getFarClippingDistance();
+
+    /**
+     * Sets the distance from the origin to the far clipping plane for this
+     * camera.
+     * 
+     * @param far
+     *            Distance to the far clipping plane.
+     */
+    public abstract void setFarClippingDistance(float far);
+
 }
 
 class NativeCamera {

--- a/GVRf/Framework/src/org/gearvrf/GVRCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCamera.java
@@ -297,37 +297,6 @@ public abstract class GVRCamera extends GVRComponent {
         }
         return 0;
     }
-
-    /**
-     * @return Distance from the origin to the near clipping plane for this
-     *         camera.
-     */
-    public abstract float getNearClippingDistance();
-
-    /**
-     * Sets the distance from the origin to the near clipping plane for this
-     * camera.
-     * 
-     * @param near
-     *            Distance to the near clipping plane.
-     */
-    public abstract void setNearClippingDistance(float near);
-
-    /**
-     * @return Distance from the origin to the far clipping plane for this
-     *         camera.
-     */
-    public abstract float getFarClippingDistance();
-
-    /**
-     * Sets the distance from the origin to the far clipping plane for this
-     * camera.
-     * 
-     * @param far
-     *            Distance to the far clipping plane.
-     */
-    public abstract void setFarClippingDistance(float far);
-
 }
 
 class NativeCamera {

--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -512,7 +512,10 @@ public class GVRCameraRig extends GVRComponent {
      *         camera rig.
      */
     public float getNearClippingDistance() {
-        return leftCamera.getNearClippingDistance();
+        if(leftCamera instanceof GVRCameraClippingDistanceInterface) {
+            return ((GVRCameraClippingDistanceInterface)leftCamera).getNearClippingDistance();
+        }
+        return 0.0f;
     }
 
     /**
@@ -523,9 +526,13 @@ public class GVRCameraRig extends GVRComponent {
      *            Distance to the near clipping plane.
      */
     public void setNearClippingDistance(float near) {
-        leftCamera.setNearClippingDistance(near);
-        centerCamera.setNearClippingDistance(near);
-        rightCamera.setNearClippingDistance(near);
+        if(leftCamera instanceof GVRCameraClippingDistanceInterface &&
+           centerCamera instanceof GVRCameraClippingDistanceInterface &&
+           rightCamera instanceof GVRCameraClippingDistanceInterface) {
+            ((GVRCameraClippingDistanceInterface)leftCamera).setNearClippingDistance(near);
+            centerCamera.setNearClippingDistance(near);
+            ((GVRCameraClippingDistanceInterface)rightCamera).setNearClippingDistance(near);
+        }
     }
 
     /**
@@ -533,7 +540,10 @@ public class GVRCameraRig extends GVRComponent {
      *         camera rig.
      */
     public float getFarClippingDistance() {
-        return leftCamera.getFarClippingDistance();
+        if(leftCamera instanceof GVRCameraClippingDistanceInterface) {
+            return ((GVRCameraClippingDistanceInterface)leftCamera).getFarClippingDistance();
+        }
+        return 0.0f;
     }
 
     /**
@@ -544,9 +554,13 @@ public class GVRCameraRig extends GVRComponent {
      *            Distance to the far clipping plane.
      */
     public void setFarClippingDistance(float far) {
-        leftCamera.setFarClippingDistance(far);
-        centerCamera.setFarClippingDistance(far);
-        rightCamera.setFarClippingDistance(far);
+        if(leftCamera instanceof GVRCameraClippingDistanceInterface &&
+           centerCamera instanceof GVRCameraClippingDistanceInterface &&
+           rightCamera instanceof GVRCameraClippingDistanceInterface) {
+            ((GVRCameraClippingDistanceInterface)leftCamera).setFarClippingDistance(far);
+            centerCamera.setFarClippingDistance(far);
+            ((GVRCameraClippingDistanceInterface)rightCamera).setFarClippingDistance(far);
+        }
     }
 
 }

--- a/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCameraRig.java
@@ -506,6 +506,49 @@ public class GVRCameraRig extends GVRComponent {
     public GVRTransform getHeadTransform() {
         return headTransformObject.getTransform();
     }
+
+    /**
+     * @return Distance from the origin to the near clipping plane for the
+     *         camera rig.
+     */
+    public float getNearClippingDistance() {
+        return leftCamera.getNearClippingDistance();
+    }
+
+    /**
+     * Sets the distance from the origin to the near clipping plane for the
+     * whole camera rig.
+     * 
+     * @param near
+     *            Distance to the near clipping plane.
+     */
+    public void setNearClippingDistance(float near) {
+        leftCamera.setNearClippingDistance(near);
+        centerCamera.setNearClippingDistance(near);
+        rightCamera.setNearClippingDistance(near);
+    }
+
+    /**
+     * @return Distance from the origin to the far clipping plane for the
+     *         camera rig.
+     */
+    public float getFarClippingDistance() {
+        return leftCamera.getFarClippingDistance();
+    }
+
+    /**
+     * Sets the distance from the origin to the far clipping plane for the
+     * whole camera rig.
+     * 
+     * @param far
+     *            Distance to the far clipping plane.
+     */
+    public void setFarClippingDistance(float far) {
+        leftCamera.setFarClippingDistance(far);
+        centerCamera.setFarClippingDistance(far);
+        rightCamera.setFarClippingDistance(far);
+    }
+
 }
 
 class NativeCameraRig {

--- a/GVRf/Framework/src/org/gearvrf/GVRCustomCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCustomCamera.java
@@ -30,6 +30,48 @@ public class GVRCustomCamera extends GVRCamera {
         NativeCustomCamera.setProjectionMatrix(getNative(), x1, y1, z1, w1, x2,
                 y2, z2, w2, x3, y3, z3, w3, x4, y4, z4, w4);
     }
+
+    /**
+     * @return Distance from the origin to the near clipping plane.
+     * Note: this is a no-op for this class and will return 0.0f.
+     */
+    @Override
+    public float getNearClippingDistance() {
+        return 0.0f;
+    }
+
+    /**
+     * Sets the distance from the origin to the near clipping plane.
+     * Note: this is a no-op for this class.
+     * 
+     * @param near
+     *            Distance to the near clipping plane.
+     */
+    @Override
+    public void setNearClippingDistance(float near) {
+        return;
+    }
+
+    /**
+     * @return Distance from the origin to the far clipping plane.
+     * Note: this is a no-op for this class and will return 0.0f.
+     */
+    @Override
+    public float getFarClippingDistance() {
+        return 0.0f;
+    }
+
+    /**
+     * Sets the distance from the origin to the far clipping plane.
+     * Note: this is a no-op for this class.
+     * 
+     * @param far
+     *            Distance to the far clipping plane.
+     */
+    @Override
+    public void setFarClippingDistance(float far) {
+        return;
+    }
 }
 
 class NativeCustomCamera {

--- a/GVRf/Framework/src/org/gearvrf/GVRCustomCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCustomCamera.java
@@ -31,47 +31,6 @@ public class GVRCustomCamera extends GVRCamera {
                 y2, z2, w2, x3, y3, z3, w3, x4, y4, z4, w4);
     }
 
-    /**
-     * @return Distance from the origin to the near clipping plane.
-     * Note: this is a no-op for this class and will return 0.0f.
-     */
-    @Override
-    public float getNearClippingDistance() {
-        return 0.0f;
-    }
-
-    /**
-     * Sets the distance from the origin to the near clipping plane.
-     * Note: this is a no-op for this class.
-     * 
-     * @param near
-     *            Distance to the near clipping plane.
-     */
-    @Override
-    public void setNearClippingDistance(float near) {
-        return;
-    }
-
-    /**
-     * @return Distance from the origin to the far clipping plane.
-     * Note: this is a no-op for this class and will return 0.0f.
-     */
-    @Override
-    public float getFarClippingDistance() {
-        return 0.0f;
-    }
-
-    /**
-     * Sets the distance from the origin to the far clipping plane.
-     * Note: this is a no-op for this class.
-     * 
-     * @param far
-     *            Distance to the far clipping plane.
-     */
-    @Override
-    public void setFarClippingDistance(float far) {
-        return;
-    }
 }
 
 class NativeCustomCamera {

--- a/GVRf/Framework/src/org/gearvrf/GVROrthogonalCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVROrthogonalCamera.java
@@ -98,6 +98,7 @@ public class GVROrthogonalCamera extends GVRCamera {
     /**
      * @return Distance from the origin to the near clipping plane.
      */
+    @Override
     public float getNearClippingDistance() {
         return NativeOrthogonalCamera.getNearClippingDistance(getNative());
     }
@@ -108,6 +109,7 @@ public class GVROrthogonalCamera extends GVRCamera {
      * @param near
      *            Distance to the near clipping plane.
      */
+    @Override
     public void setNearClippingDistance(float near) {
         NativeOrthogonalCamera.setNearClippingDistance(getNative(), near);
     }
@@ -115,6 +117,7 @@ public class GVROrthogonalCamera extends GVRCamera {
     /**
      * @return Distance from the origin to the far clipping plane.
      */
+    @Override
     public float getFarClippingDistance() {
         return NativeOrthogonalCamera.getFarClippingDistance(getNative());
     }
@@ -125,6 +128,7 @@ public class GVROrthogonalCamera extends GVRCamera {
      * @param far
      *            Distance to the far clipping plane.
      */
+    @Override
     public void setFarClippingDistance(float far) {
         NativeOrthogonalCamera.setFarClippingDistance(getNative(), far);
     }

--- a/GVRf/Framework/src/org/gearvrf/GVROrthogonalCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVROrthogonalCamera.java
@@ -16,7 +16,7 @@
 package org.gearvrf;
 
 /** A {@link GVRCamera camera} with an orthogonal projection. */
-public class GVROrthogonalCamera extends GVRCamera {
+public class GVROrthogonalCamera extends GVRCamera implements GVRCameraClippingDistanceInterface {
     /**
      * Constructor.
      * 

--- a/GVRf/Framework/src/org/gearvrf/GVRPerspectiveCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRPerspectiveCamera.java
@@ -65,6 +65,7 @@ public class GVRPerspectiveCamera extends GVRCamera {
      * @return Distance from the origin to the near clipping plane for this
      *         camera.
      */
+    @Override
     public float getNearClippingDistance() {
         return NativePerspectiveCamera.getNearClippingDistance(getNative());
     }
@@ -76,6 +77,7 @@ public class GVRPerspectiveCamera extends GVRCamera {
      * @param near
      *            Distance to the near clipping plane.
      */
+    @Override
     public void setNearClippingDistance(float near) {
         NativePerspectiveCamera.setNearClippingDistance(getNative(), near);
     }
@@ -84,6 +86,7 @@ public class GVRPerspectiveCamera extends GVRCamera {
      * @return Distance from the origin to the far clipping plane for this
      *         camera.
      */
+    @Override
     public float getFarClippingDistance() {
         return NativePerspectiveCamera.getFarClippingDistance(getNative());
     }
@@ -95,6 +98,7 @@ public class GVRPerspectiveCamera extends GVRCamera {
      * @param far
      *            Distance to the far clipping plane.
      */
+    @Override
     public void setFarClippingDistance(float far) {
         NativePerspectiveCamera.setFarClippingDistance(getNative(), far);
     }

--- a/GVRf/Framework/src/org/gearvrf/GVRPerspectiveCamera.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRPerspectiveCamera.java
@@ -16,7 +16,7 @@
 package org.gearvrf;
 
 /** A {@link GVRCamera camera} with a perspective projection. */
-public class GVRPerspectiveCamera extends GVRCamera {
+public class GVRPerspectiveCamera extends GVRCamera implements GVRCameraClippingDistanceInterface {
     /**
      * Constructor.
      * 


### PR DESCRIPTION
We keep hitting this on one of our internal projects, so I'm creating a convenience function.  It'd be nice to set the near/far clipping planes for all the cameras attached to the camera rig from the camera rig itself.  So that's what this does.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn 
tom.flynn@samsung.com