### PR TITLE
Minor fixes to gvr-vuforia sample

### DIFF
--- a/GVRf/Sample/gvr-vuforia/src/org/gearvrf/vuforiasample/VuforiaSampleScript.java
+++ b/GVRf/Sample/gvr-vuforia/src/org/gearvrf/vuforiasample/VuforiaSampleScript.java
@@ -111,7 +111,6 @@ public class VuforiaSampleScript extends GVRScript {
         }
 
         teapot.getTransform().setPosition(0f, 0f, -0.5f);
-        mainScene.addSceneObject(teapot);
     }
 
     private float[] convertMatrix = { 1f, 0f, 0f, 0f, 0f, -1f, 0f, 0f, 0f, 0f,
@@ -162,6 +161,7 @@ public class VuforiaSampleScript extends GVRScript {
 
                 float scaleFactor = ((ImageTarget) trackable).getSize()
                         .getData()[0];
+                Matrix.rotateM(convertedMVMatrix, 0, 90, 1, 0, 0);
                 Matrix.scaleM(convertedMVMatrix, 0, scaleFactor, scaleFactor,
                         scaleFactor);
 


### PR DESCRIPTION
1. Avoid showing the teapot unless it is detected by the camera.
2. Change the teapot orientation so that its bottom is parallel to
the flat surface of the vuforia marker.

GearVRf-DCO-1.0-Signed-off-by: Gaurav Srivastava 
gaurav001.s@samsung.com