### PR TITLE
Fix crash in loading complex models. The issue was we were not freeing

### DIFF
--- a/GVRf/Framework/jni/engine/importer/jassimp.cpp
+++ b/GVRf/Framework/jni/engine/importer/jassimp.cpp
@@ -260,6 +260,8 @@ bool load_scene_node(JNIEnv *env, const aiNode *assimp_node, jobject parent,
     if (NULL != loaded_node) {
         *loaded_node = jassimp_node;
     }
+    else
+    	DeleteLocalRef jassimp_node_ref(env, jassimp_node);
 
     return true;
 }


### PR DESCRIPTION
one local refrence in load_scene_node() (for the jassimp_node). We need
to hold the local reference for the root node only.

Due to this we exhaust the limit of 512 local references and there is a
crash. Fix is to release local references except for the root node.