### PR TITLE
Fix bug in removeChildObject().

### DIFF
--- a/GVRf/Framework/jni/objects/scene_object.cpp
+++ b/GVRf/Framework/jni/objects/scene_object.cpp
@@ -166,6 +166,7 @@ void SceneObject::removeChildObject(SceneObject* child) {
                 children_.end());
         child->parent_ = NULL;
     }
+    child->transform()->invalidate(false);
     dirtyBoundingVolume();
 }
 


### PR DESCRIPTION
Fix bug in removeChildObject(). If child is removed, the child's
transform has to be invalidated. Otherwise it will still hold the
complete transformation from root.

Invalidaing the transform forces a re-evaluation in the next
getModelMatrix() call.