### PR TITLE
Obey draw_mode and introduce set/getIndices (fix #293)

### DIFF
--- a/GVRf/Framework/jni/objects/mesh.cpp
+++ b/GVRf/Framework/jni/objects/mesh.cpp
@@ -55,47 +55,47 @@ Mesh* Mesh::getBoundingBox() {
     mesh->vertices_.push_back(glm::vec3(min_x, max_y, max_z));
     mesh->vertices_.push_back(glm::vec3(max_x, max_y, max_z));
 
-    mesh->triangles_.push_back(0);
-    mesh->triangles_.push_back(2);
-    mesh->triangles_.push_back(1);
-    mesh->triangles_.push_back(1);
-    mesh->triangles_.push_back(2);
-    mesh->triangles_.push_back(3);
+    mesh->indices_.push_back(0);
+    mesh->indices_.push_back(2);
+    mesh->indices_.push_back(1);
+    mesh->indices_.push_back(1);
+    mesh->indices_.push_back(2);
+    mesh->indices_.push_back(3);
 
-    mesh->triangles_.push_back(1);
-    mesh->triangles_.push_back(3);
-    mesh->triangles_.push_back(7);
-    mesh->triangles_.push_back(1);
-    mesh->triangles_.push_back(7);
-    mesh->triangles_.push_back(5);
+    mesh->indices_.push_back(1);
+    mesh->indices_.push_back(3);
+    mesh->indices_.push_back(7);
+    mesh->indices_.push_back(1);
+    mesh->indices_.push_back(7);
+    mesh->indices_.push_back(5);
 
-    mesh->triangles_.push_back(4);
-    mesh->triangles_.push_back(5);
-    mesh->triangles_.push_back(6);
-    mesh->triangles_.push_back(5);
-    mesh->triangles_.push_back(7);
-    mesh->triangles_.push_back(6);
+    mesh->indices_.push_back(4);
+    mesh->indices_.push_back(5);
+    mesh->indices_.push_back(6);
+    mesh->indices_.push_back(5);
+    mesh->indices_.push_back(7);
+    mesh->indices_.push_back(6);
 
-    mesh->triangles_.push_back(0);
-    mesh->triangles_.push_back(6);
-    mesh->triangles_.push_back(2);
-    mesh->triangles_.push_back(0);
-    mesh->triangles_.push_back(4);
-    mesh->triangles_.push_back(6);
+    mesh->indices_.push_back(0);
+    mesh->indices_.push_back(6);
+    mesh->indices_.push_back(2);
+    mesh->indices_.push_back(0);
+    mesh->indices_.push_back(4);
+    mesh->indices_.push_back(6);
 
-    mesh->triangles_.push_back(0);
-    mesh->triangles_.push_back(1);
-    mesh->triangles_.push_back(5);
-    mesh->triangles_.push_back(0);
-    mesh->triangles_.push_back(5);
-    mesh->triangles_.push_back(4);
+    mesh->indices_.push_back(0);
+    mesh->indices_.push_back(1);
+    mesh->indices_.push_back(5);
+    mesh->indices_.push_back(0);
+    mesh->indices_.push_back(5);
+    mesh->indices_.push_back(4);
 
-    mesh->triangles_.push_back(2);
-    mesh->triangles_.push_back(7);
-    mesh->triangles_.push_back(3);
-    mesh->triangles_.push_back(2);
-    mesh->triangles_.push_back(6);
-    mesh->triangles_.push_back(7);
+    mesh->indices_.push_back(2);
+    mesh->indices_.push_back(7);
+    mesh->indices_.push_back(3);
+    mesh->indices_.push_back(2);
+    mesh->indices_.push_back(6);
+    mesh->indices_.push_back(7);
 
     return mesh;
 }
@@ -202,9 +202,9 @@ void Mesh::generateVAO() {
     glGenBuffers(1, &triangle_vboID_);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, triangle_vboID_);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-            sizeof(unsigned short) * triangles_.size(), &triangles_[0],
+            sizeof(unsigned short) * indices_.size(), &indices_[0],
             GL_STATIC_DRAW);
-    numTriangles_ = triangles_.size() / 3;
+    numTriangles_ = indices_.size() / 3;
 
     if (vertices_.size()) {
         glGenBuffers(1, &vert_vboID_);

--- a/GVRf/Framework/jni/objects/mesh.h
+++ b/GVRf/Framework/jni/objects/mesh.h
@@ -43,7 +43,7 @@ namespace gvr {
 class Mesh: public HybridObject {
 public:
     Mesh() :
-            vertices_(), normals_(), tex_coords_(), triangles_(), float_vectors_(), vec2_vectors_(), vec3_vectors_(), vec4_vectors_(),
+            vertices_(), normals_(), tex_coords_(), indices_(), float_vectors_(), vec2_vectors_(), vec3_vectors_(), vec4_vectors_(),
                     have_bounding_volume_(false), vao_dirty_(true),
                     vaoID_(GVR_INVALID), triangle_vboID_(GVR_INVALID), vert_vboID_(GVR_INVALID),
                     norm_vboID_(GVR_INVALID), tex_vboID_(GVR_INVALID)
@@ -61,8 +61,8 @@ public:
         normals.swap(normals_);
         std::vector<glm::vec2> tex_coords;
         tex_coords.swap(tex_coords_);
-        std::vector<unsigned short> triangles;
-        triangles.swap(triangles_);
+        std::vector<unsigned short> indices;
+        indices.swap(indices_);
 
         deleteVaos();
     }
@@ -130,16 +130,30 @@ public:
     }
 
     const std::vector<unsigned short>& triangles() const {
-        return triangles_;
+        return indices_;
     }
 
     void set_triangles(const std::vector<unsigned short>& triangles) {
-        triangles_ = triangles;
+        indices_ = triangles;
         vao_dirty_ = true;
     }
 
     void set_triangles(std::vector<unsigned short>&& triangles) {
-        triangles_ = std::move(triangles);
+        indices_ = std::move(triangles);
+        vao_dirty_ = true;
+    }
+
+    const std::vector<unsigned short>& indices() const {
+        return indices_;
+    }
+
+    void set_indices(const std::vector<unsigned short>& indices) {
+        indices_ = indices;
+        vao_dirty_ = true;
+    }
+
+    void set_indices(std::vector<unsigned short>&& indices) {
+        indices_ = std::move(indices);
         vao_dirty_ = true;
     }
 
@@ -258,7 +272,7 @@ private:
     std::map<std::string, std::vector<glm::vec2>> vec2_vectors_;
     std::map<std::string, std::vector<glm::vec3>> vec3_vectors_;
     std::map<std::string, std::vector<glm::vec4>> vec4_vectors_;
-    std::vector<unsigned short> triangles_;
+    std::vector<unsigned short> indices_;
 
     // add location slot map
     std::map<int, std::string> attribute_float_keys_;

--- a/GVRf/Framework/jni/objects/mesh_jni.cpp
+++ b/GVRf/Framework/jni/objects/mesh_jni.cpp
@@ -60,6 +60,13 @@ JNIEXPORT jfloatArray JNICALL
 Java_org_gearvrf_NativeMesh_getFloatVector(JNIEnv * env,
         jobject obj, jlong jmesh, jstring key);
 
+JNIEXPORT jcharArray JNICALL
+Java_org_gearvrf_NativeMesh_getIndices(JNIEnv * env,
+        jobject obj, jlong jmesh);
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeMesh_setIndices(JNIEnv * env,
+        jobject obj, jlong jmesh, jcharArray indices);
+
 JNIEXPORT void JNICALL
 Java_org_gearvrf_NativeMesh_setFloatVector(JNIEnv * env,
         jobject obj, jlong jmesh, jstring key, jfloatArray float_vector);
@@ -202,6 +209,32 @@ Java_org_gearvrf_NativeMesh_setTriangles(JNIEnv * env,
     }
     mesh->set_triangles(native_triangles);
     env->ReleaseCharArrayElements(triangles, jtriangles_pointer, 0);
+}
+
+JNIEXPORT jcharArray JNICALL
+Java_org_gearvrf_NativeMesh_getIndices(JNIEnv * env,
+        jobject obj, jlong jmesh) {
+    Mesh* mesh = reinterpret_cast<Mesh*>(jmesh);
+    const std::vector<unsigned short>& indices = mesh->indices();
+    jcharArray jindices = env->NewCharArray(indices.size());
+    env->SetCharArrayRegion(jindices, 0, indices.size(), indices.data());
+    return jindices;
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeMesh_setIndices(JNIEnv * env,
+        jobject obj, jlong jmesh, jcharArray indices) {
+    Mesh* mesh = reinterpret_cast<Mesh*>(jmesh);
+    jchar* jindices_pointer = env->GetCharArrayElements(indices, 0);
+    unsigned short* indices_pointer =
+            static_cast<unsigned short*>(jindices_pointer);
+    int indices_length = env->GetArrayLength(indices);
+    std::vector<unsigned short> native_indices;
+    for (int i = 0; i < indices_length; ++i) {
+        native_indices.push_back(indices_pointer[i]);
+    }
+    mesh->set_indices(native_indices);
+    env->ReleaseCharArrayElements(indices, jindices_pointer, 0);
 }
 
 JNIEXPORT jfloatArray JNICALL

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
@@ -207,7 +207,7 @@ void AssimpShader::render(const glm::mat4& mv_matrix,
     glUniform1f(u_opacity_, opacity);
 
     glBindVertexArray(mesh->getVAOId(Material::ASSIMP_SHADER));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -237,8 +237,8 @@ void AssimpShader::render(const glm::mat4& mv_matrix,
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
 
     checkGlError("AssimpShader::render");

--- a/GVRf/Framework/jni/shaders/material/bounding_box_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/bounding_box_shader.cpp
@@ -69,7 +69,7 @@ void BoundingBoxShader::render(const glm::mat4& mvp_matrix,
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(mvp_matrix));
 
     glBindVertexArray(mesh->getVAOId(material->shader_type()));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 
@@ -80,8 +80,8 @@ void BoundingBoxShader::render(const glm::mat4& mvp_matrix,
     glEnableVertexAttribArray(a_position_);
 
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(mvp_matrix));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
 
     checkGlError("BoundingBoxShader::render");

--- a/GVRf/Framework/jni/shaders/material/cubemap_reflection_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/cubemap_reflection_shader.cpp
@@ -149,7 +149,7 @@ void CubemapReflectionShader::render(const glm::mat4& mv_matrix,
     glUniform1f(u_opacity_, opacity);
 
     glBindVertexArray(mesh->getVAOId(Material::CUBEMAP_REFLECTION_SHADER));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -176,8 +176,8 @@ void CubemapReflectionShader::render(const glm::mat4& mv_matrix,
 
     glUniform1f(u_opacity_, opacity);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
 
     checkGlError("CubemapReflectionShader::render");

--- a/GVRf/Framework/jni/shaders/material/cubemap_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/cubemap_shader.cpp
@@ -132,7 +132,7 @@ void CubemapShader::render(const glm::mat4& model_matrix,
     glUniform1f(u_opacity_, opacity);
 
     glBindVertexArray(mesh->getVAOId(Material::CUBEMAP_SHADER));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -153,8 +153,8 @@ void CubemapShader::render(const glm::mat4& model_matrix,
 
     glUniform1f(u_opacity_, opacity);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
 
     checkGlError("CubemapShader::render");

--- a/GVRf/Framework/jni/shaders/material/custom_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/custom_shader.cpp
@@ -181,7 +181,7 @@ void CustomShader::render(const glm::mat4& mvp_matrix, RenderData* render_data, 
     }
 
     glBindVertexArray(mesh->getVAOId(material->shader_type()));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -280,8 +280,8 @@ void CustomShader::render(const glm::mat4& mvp_matrix, RenderData* render_data, 
         glUniformMatrix4fv(it->first, 1, GL_FALSE, glm::value_ptr(m));
     }
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
 
     checkGlError("CustomShader::render");

--- a/GVRf/Framework/jni/shaders/material/error_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/error_shader.cpp
@@ -74,7 +74,7 @@ void ErrorShader::render(const glm::mat4& mvp_matrix, RenderData* render_data) {
     glUniform4f(u_color_, r, g, b, a);
 
     glBindVertexArray(mesh->getVAOId(material->shader_type()));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -88,8 +88,8 @@ void ErrorShader::render(const glm::mat4& mvp_matrix, RenderData* render_data) {
 
     glUniform4f(u_color_, r, g, b, a);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
     checkGlError("ErrorShader::render");
 }

--- a/GVRf/Framework/jni/shaders/material/oes_horizontal_stereo_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/oes_horizontal_stereo_shader.cpp
@@ -107,7 +107,7 @@ void OESHorizontalStereoShader::render(const glm::mat4& mvp_matrix,
     glUniform1i(u_right_, mono_rendering || right ? 1 : 0);
 
     glBindVertexArray(mesh->getVAOId(Material::UNLIT_HORIZONTAL_STEREO_SHADER));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -133,8 +133,8 @@ void OESHorizontalStereoShader::render(const glm::mat4& mvp_matrix,
 
     glUniform1i(u_right_, mono_rendering || right ? 1 : 0);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
 
     checkGlError("OESHorizontalStereoShader::render");

--- a/GVRf/Framework/jni/shaders/material/oes_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/oes_shader.cpp
@@ -93,7 +93,7 @@ void OESShader::render(const glm::mat4& mvp_matrix, RenderData* render_data, Mat
     glUniform1f(u_opacity_, opacity);
 
     glBindVertexArray(mesh->getVAOId(Material::OES_SHADER));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -118,8 +118,8 @@ void OESShader::render(const glm::mat4& mvp_matrix, RenderData* render_data, Mat
 
     glUniform1f(u_opacity_, opacity);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
     checkGlError("OESShader::render");
 }

--- a/GVRf/Framework/jni/shaders/material/oes_vertical_stereo_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/oes_vertical_stereo_shader.cpp
@@ -107,7 +107,7 @@ void OESVerticalStereoShader::render(const glm::mat4& mvp_matrix,
     glUniform1i(u_right_, mono_rendering || right ? 1 : 0);
 
     glBindVertexArray(mesh->getVAOId(Material::OES_VERTICAL_STEREO_SHADER));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -133,8 +133,8 @@ void OESVerticalStereoShader::render(const glm::mat4& mvp_matrix,
 
     glUniform1i(u_right_, mono_rendering || right ? 1 : 0);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
     checkGlError("OESVerticalStereoShader::render");
 }

--- a/GVRf/Framework/jni/shaders/material/texture_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/texture_shader.cpp
@@ -271,7 +271,7 @@ void TextureShader::render(const glm::mat4& mv_matrix,
         glBindVertexArray(mesh->getVAOId(Material::TEXTURE_SHADER_NOLIGHT));
     }
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 
@@ -294,8 +294,8 @@ void TextureShader::render(const glm::mat4& mv_matrix,
 
     glUniform1f(u_opacity_, opacity);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
 
     checkGlError("TextureShader::render");

--- a/GVRf/Framework/jni/shaders/material/unlit_horizontal_stereo_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/unlit_horizontal_stereo_shader.cpp
@@ -106,7 +106,7 @@ void UnlitHorizontalStereoShader::render(const glm::mat4& mvp_matrix,
     glUniform1i(u_right_, mono_rendering || right ? 1 : 0);
 
     glBindVertexArray(mesh->getVAOId(Material::UNLIT_HORIZONTAL_STEREO_SHADER));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -132,8 +132,8 @@ void UnlitHorizontalStereoShader::render(const glm::mat4& mvp_matrix,
 
     glUniform1i(u_right_, mono_rendering || right ? 1 : 0);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
     checkGlError("HorizontalStereoUnlitShader::render");
 }

--- a/GVRf/Framework/jni/shaders/material/unlit_vertical_stereo_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/unlit_vertical_stereo_shader.cpp
@@ -106,7 +106,7 @@ void UnlitVerticalStereoShader::render(const glm::mat4& mvp_matrix,
     glUniform1i(u_right_, mono_rendering || right ? 1 : 0);
 
     glBindVertexArray(mesh->getVAOId(Material::UNLIT_VERTICAL_STEREO_SHADER));
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
             0);
     glBindVertexArray(0);
 #else
@@ -132,8 +132,8 @@ void UnlitVerticalStereoShader::render(const glm::mat4& mvp_matrix,
 
     glUniform1i(u_right_, mono_rendering || right ? 1 : 0);
 
-    glDrawElements(GL_TRIANGLES, mesh->triangles().size(), GL_UNSIGNED_SHORT,
-            mesh->triangles().data());
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
+            mesh->indices().data());
 #endif
 
     checkGlError("UnlitShader::render");

--- a/GVRf/Framework/src/org/gearvrf/GVRMesh.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMesh.java
@@ -123,6 +123,8 @@ public class GVRMesh extends GVRHybridObject {
      * </code>
      * 
      * @return Array with the packed triangle index data.
+     *
+     * @deprecated use {@link #getIndices()} instead.
      */
     public char[] getTriangles() {
         return NativeMesh.getTriangles(getNative());
@@ -139,10 +141,32 @@ public class GVRMesh extends GVRHybridObject {
      * 
      * @param triangles
      *            Array containing the packed triangle index data.
+     * @deprecated use {@link #setIndices()} instead.
      */
     public void setTriangles(char[] triangles) {
         checkDivisibleDataLength("triangles", triangles, 3);
         NativeMesh.setTriangles(getNative(), triangles);
+    }
+
+    /**
+     * Get the vertex indices of the mesh. The indices for each
+     * vertex to be referenced.
+     * 
+     * @return Array with the packed index data.
+     */
+    public char[] getIndices() {
+        return NativeMesh.getIndices(getNative());
+    }
+
+    /**
+     * Sets the vertex indices of the mesh. The indices for each
+     * vertex.
+     * 
+     * @param indices
+     *            Array containing the packed index data.
+     */
+    public void setIndices(char[] indices) {
+        NativeMesh.setIndices(getNative(), indices);
     }
 
     /**
@@ -316,6 +340,10 @@ class NativeMesh {
     static native char[] getTriangles(long mesh);
 
     static native void setTriangles(long mesh, char[] triangles);
+
+    static native char[] getIndices(long mesh);
+
+    static native void setIndices(long mesh, char[] indices);
 
     static native float[] getFloatVector(long mesh, String key);
 


### PR DESCRIPTION
Somehow, we weren't obeying the draw_mode.  That should be fixed now.
Also, deprecated get/setTriangles() in GVRMesh.  Replaced with
get/setIndices() which is a less confusing and more general name.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com