### PR TITLE
Upgrade to Oculus SDK 1.0.0.0 (#294)

### DIFF
--- a/GVRf/Framework/jni/Android.mk
+++ b/GVRf/Framework/jni/Android.mk
@@ -111,9 +111,10 @@ LOCAL_SRC_FILES += $(FILE_LIST:$(LOCAL_PATH)/%=%)
 #LOCAL_STATIC_LIBRARIES += staticAssimp
 LOCAL_SHARED_LIBRARIES += assimp
 LOCAL_SHARED_LIBRARIES += vrapi
+LOCAL_STATIC_LIBRARIES += systemutils
+LOCAL_STATIC_LIBRARIES += vrmodel
 LOCAL_STATIC_LIBRARIES += vrappframework
-LOCAL_STATIC_LIBRARIES += libovr
-LOCAL_STATIC_LIBRARIES += libvrmodel
+LOCAL_STATIC_LIBRARIES += libovrkernel
 
 LOCAL_ARM_NEON := true
 
@@ -134,4 +135,5 @@ include $(BUILD_SHARED_LIBRARY)
 $(call import-module,LibOVRKernel/Projects/AndroidPrebuilt/jni)
 $(call import-module,VrApi/Projects/AndroidPrebuilt/jni)
 $(call import-module,VrAppFramework/Projects/AndroidPrebuilt/jni)
-$(call import-module,VrAppSupport/VrModel/Projects/Android/jni)
+$(call import-module,VrAppSupport/SystemUtils/Projects/AndroidPrebuilt/jni)
+$(call import-module,VrAppSupport/VrModel/Projects/AndroidPrebuilt/jni)

--- a/GVRf/Framework/jni/Android.mk
+++ b/GVRf/Framework/jni/Android.mk
@@ -28,7 +28,7 @@ include $(PREBUILT_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 
 ifndef OVR_MOBILE_SDK
-	OVR_MOBILE_SDK=../../ovr_mobile_sdk
+	OVR_MOBILE_SDK=../../ovr_sdk_mobile
 endif
 
 #include $(OVR_MOBILE_SDK)/VRLib/import_vrlib.mk

--- a/GVRf/Framework/jni/Application.mk
+++ b/GVRf/Framework/jni/Application.mk
@@ -21,7 +21,7 @@ APP_PLATFORM := android-19
 APP_STL := gnustl_static
 NDK_TOOLCHAIN_VERSION := 4.8
 ifndef OVR_MOBILE_SDK
-	OVR_MOBILE_SDK=../../ovr_mobile_sdk
+	OVR_MOBILE_SDK=../../ovr_sdk_mobile
 endif
 
 NDK_MODULE_PATH := $(OVR_MOBILE_SDK)

--- a/GVRf/Framework/jni/oculus/activity_jni.cpp
+++ b/GVRf/Framework/jni/oculus/activity_jni.cpp
@@ -134,13 +134,13 @@ template <class PredictionTrait> jclass GVRActivityT<PredictionTrait>::GetGlobal
 template <class R> void GVRActivityT<R>::Configure(OVR::ovrSettings & settings)
 {
     //General settings.
-    JNIEnv *env = app->GetVrJni();
+    JNIEnv *env = app->GetJava()->Env;
     jobject vrSettings = env->CallObjectMethod(app->GetJava()->ActivityObject,
             getAppSettingsMethodId);
     jint framebufferPixelsWide = env->GetIntField(vrSettings,
             env->GetFieldID(vrAppSettingsClass, "framebufferPixelsWide", "I"));
     if (framebufferPixelsWide == -1) {
-        app->GetVrJni()->SetIntField(vrSettings,
+        app->GetJava()->Env->SetIntField(vrSettings,
                 env->GetFieldID(vrAppSettingsClass, "framebufferPixelsWide",
                         "I"), settings.FramebufferPixelsWide);
     } else {
@@ -354,12 +354,12 @@ template <class R> void GVRActivityT<R>::Configure(OVR::ovrSettings & settings)
 
 template <class R> void GVRActivityT<R>::OneTimeInit(const char * fromPackage, const char * launchIntentJSON, const char * launchIntentURI)
 {
-    app->GetVrJni()->CallVoidMethod(app->GetJava()->ActivityObject, oneTimeInitMethodId );
+    app->GetJava()->Env->CallVoidMethod(app->GetJava()->ActivityObject, oneTimeInitMethodId );
 }
 
 template <class R> void GVRActivityT<R>::OneTimeShutdown()
 {
-    app->GetVrJni()->CallVoidMethod(app->GetJava()->ActivityObject, oneTimeShutdownMethodId);
+    app->GetJava()->Env->CallVoidMethod(app->GetJava()->ActivityObject, oneTimeShutdownMethodId);
 
     // Free GL resources
 }
@@ -389,7 +389,7 @@ template <class R> OVR::Matrix4f GVRActivityT<R>::DrawEyeView(const int eye, con
     glm::quat headRotation = headRotationProvider_.getPrediction(*this, frameParms, (1 == eye ? 4.0f : 3.5f) / 60.0f);
     cameraRig_->getHeadTransform()->set_rotation(headRotation);
 
-    JNIEnv* jni = app->GetVrJni();
+    JNIEnv* jni = app->GetJava()->Env;
     jni->CallVoidMethod(app->GetJava()->ActivityObject, drawEyeViewMethodId, eye, fovDegreesY);
 
     if (eye == 1) {
@@ -412,7 +412,7 @@ template <class R> OVR::Matrix4f GVRActivityT<R>::DrawEyeView(const int eye, con
 
 template <class R> OVR::Matrix4f GVRActivityT<R>::Frame( const OVR::VrFrame & vrFrame )
 {
-    JNIEnv* jni = app->GetVrJni();
+    JNIEnv* jni = app->GetJava()->Env;
     jni->CallVoidMethod(app->GetJava()->ActivityObject, beforeDrawEyesMethodId);
     jni->CallVoidMethod(app->GetJava()->ActivityObject, drawFrameMethodId);
 
@@ -446,7 +446,7 @@ template <class R> OVR::Matrix4f GVRActivityT<R>::Frame( const OVR::VrFrame & vr
 template <class R> bool GVRActivityT<R>::OnKeyEvent(const int keyCode, const int repeatCode,
         const OVR::KeyEventType eventType) {
 
-    bool handled = app->GetVrJni()->CallBooleanMethod(app->GetJava()->ActivityObject,
+    bool handled = app->GetJava()->Env->CallBooleanMethod(app->GetJava()->ActivityObject,
             onKeyEventNativeMethodId, keyCode, (int)eventType);
 
     // if not handled back key long press, show global menu
@@ -458,7 +458,7 @@ template <class R> bool GVRActivityT<R>::OnKeyEvent(const int keyCode, const int
 }
 
 template <class R> bool GVRActivityT<R>::updateSensoredScene() {
-    return app->GetVrJni()->CallBooleanMethod(app->GetJava()->ActivityObject, updateSensoredSceneMethodId);
+    return app->GetJava()->Env->CallBooleanMethod(app->GetJava()->ActivityObject, updateSensoredSceneMethodId);
 }
 
 template <class R> void GVRActivityT<R>::setCameraRig(jlong cameraRig) {


### PR DESCRIPTION
Need to make sure to copy VrApi.jar, VrAppFramework.jar and SystemUtils.jar into Framework/libs/ before building.  

Also, we'll follow Oculus' convention for the naming of their sdk directory.  Previously they were using 'ovr_mobile_sdk'.  now they are using 'ovr_sdk_mobile'.

We'll need to update the build instructions before merging this.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com