### PR TITLE
Mark all samples's activities "singleTask" to prevent a crash

### DIFF
--- a/GVRf/Sample/collision/AndroidManifest.xml
+++ b/GVRf/Sample/collision/AndroidManifest.xml
@@ -38,6 +38,7 @@
         <activity
             android:name="org.gearvrf.collisiondetection.CollisionActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/eye-picking/AndroidManifest.xml
+++ b/GVRf/Sample/eye-picking/AndroidManifest.xml
@@ -37,6 +37,7 @@
         <activity
             android:name="org.gearvrf.eyepickingsample.SampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gamepad/AndroidManifest.xml
+++ b/GVRf/Sample/gamepad/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <activity
             android:name="org.gearvrf.gamepad.SampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvr-cubemap/AndroidManifest.xml
+++ b/GVRf/Sample/gvr-cubemap/AndroidManifest.xml
@@ -40,6 +40,7 @@
         <activity
             android:name="org.gearvrf.cubemap.CubemapActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvr-litshader/AndroidManifest.xml
+++ b/GVRf/Sample/gvr-litshader/AndroidManifest.xml
@@ -39,6 +39,7 @@
         <activity
             android:name="org.gearvrf.litshader.LitshaderActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvr-outlinesample/AndroidManifest.xml
+++ b/GVRf/Sample/gvr-outlinesample/AndroidManifest.xml
@@ -34,6 +34,7 @@
         <activity
             android:name="org.gearvrf.gvroutlinesample.OutlineActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvr-pickandmove/AndroidManifest.xml
+++ b/GVRf/Sample/gvr-pickandmove/AndroidManifest.xml
@@ -38,6 +38,7 @@
         <activity
             android:name="org.gearvrf.pickandmove.PickandmoveActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvr-sample/AndroidManifest.xml
+++ b/GVRf/Sample/gvr-sample/AndroidManifest.xml
@@ -40,6 +40,7 @@
         <activity
             android:name="org.gearvrf.sample.SampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvr-test-screenshot3Dresult/AndroidManifest.xml
+++ b/GVRf/Sample/gvr-test-screenshot3Dresult/AndroidManifest.xml
@@ -40,6 +40,7 @@
         <activity
             android:name="org.gearvrf.testscreenshot3Dresult.TestScreenshot3DResultActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvr-testcube/AndroidManifest.xml
+++ b/GVRf/Sample/gvr-testcube/AndroidManifest.xml
@@ -40,6 +40,7 @@
         <activity
             android:name="org.gearvrf.testcube.SampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvr-video/AndroidManifest.xml
+++ b/GVRf/Sample/gvr-video/AndroidManifest.xml
@@ -39,6 +39,7 @@
         <activity
             android:name="org.gearvrf.video.VideoActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvr-vuforia/AndroidManifest.xml
+++ b/GVRf/Sample/gvr-vuforia/AndroidManifest.xml
@@ -43,6 +43,7 @@
         <activity
             android:name="org.gearvrf.vuforiasample.VuforiaSampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvrbulletsample/AndroidManifest.xml
+++ b/GVRf/Sample/gvrbulletsample/AndroidManifest.xml
@@ -35,6 +35,7 @@
         <activity
             android:name="org.gearvrf.bulletsample.BulletSampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvrcockpit_v1_5_0/AndroidManifest.xml
+++ b/GVRf/Sample/gvrcockpit_v1_5_0/AndroidManifest.xml
@@ -38,6 +38,7 @@
             android:name="org.gearvrf.cockpit.CockpitActivity"
             android:label="@string/app_name"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvrexposeapisample/AndroidManifest.xml
+++ b/GVRf/Sample/gvrexposeapisample/AndroidManifest.xml
@@ -40,6 +40,7 @@
         <activity
             android:name="org.gearvrf.gvrexposeapisample.SampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvrf_controls_sample/AndroidManifest.xml
+++ b/GVRf/Sample/gvrf_controls_sample/AndroidManifest.xml
@@ -37,7 +37,8 @@
         <activity
             android:name="org.gearvrf.controls.MainActivity"
             android:label="@string/app_name"
-            android:screenOrientation="landscape" >
+            android:screenOrientation="landscape"
+            android:launchMode="singleTask" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/GVRf/Sample/gvrf_immersivepedia/AndroidManifest.xml
+++ b/GVRf/Sample/gvrf_immersivepedia/AndroidManifest.xml
@@ -25,7 +25,8 @@
         <activity
             android:name="org.gearvrf.immersivepedia.MainActivity"
             android:label="@string/app_name"
-            android:screenOrientation="landscape" >
+            android:screenOrientation="landscape"
+            android:launchMode="singleTask" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/GVRf/Sample/gvrf_keyboard_sample/AndroidManifest.xml
+++ b/GVRf/Sample/gvrf_keyboard_sample/AndroidManifest.xml
@@ -22,7 +22,8 @@
         <activity
             android:name="org.gearvrf.keyboard.main.MainActivity"
             android:label="@string/app_name"
-            android:screenOrientation="landscape" >
+            android:screenOrientation="landscape"
+            android:launchMode="singleTask" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/GVRf/Sample/gvrjassimpmodelloader/AndroidManifest.xml
+++ b/GVRf/Sample/gvrjassimpmodelloader/AndroidManifest.xml
@@ -38,6 +38,7 @@
         <activity
             android:name="org.gearvrf.jassimpmodelloader.JassimpModelLoaderActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvropacityanigallery/AndroidManifest.xml
+++ b/GVRf/Sample/gvropacityanigallery/AndroidManifest.xml
@@ -36,6 +36,7 @@
         <activity
             android:name="org.gearvrf.opacityanigallery.GalleryActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvrpanoramasstereoimagesample_v1_5_0/AndroidManifest.xml
+++ b/GVRf/Sample/gvrpanoramasstereoimagesample_v1_5_0/AndroidManifest.xml
@@ -38,6 +38,7 @@
             android:name="org.gearvrf.panoramasstereoimagesample.SampleActivity"
             android:label="@string/app_name"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvrperformancetest_v1_5_0/AndroidManifest.xml
+++ b/GVRf/Sample/gvrperformancetest_v1_5_0/AndroidManifest.xml
@@ -38,6 +38,7 @@
             android:name="org.gearvrf.performancetest.TestActivity"
             android:label="@string/app_name"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvrsixaxissensortest_v1_5_0/AndroidManifest.xml
+++ b/GVRf/Sample/gvrsixaxissensortest_v1_5_0/AndroidManifest.xml
@@ -37,6 +37,7 @@
             android:name="org.gearvrf.sixaxissensortest.TestActivity"
             android:label="@string/app_name"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/gvrtextviewsample/AndroidManifest.xml
+++ b/GVRf/Sample/gvrtextviewsample/AndroidManifest.xml
@@ -34,6 +34,7 @@
         <activity
             android:name="org.gearvrf.gvrtextviewsample.SampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/lod-test/AndroidManifest.xml
+++ b/GVRf/Sample/lod-test/AndroidManifest.xml
@@ -15,6 +15,7 @@
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
         <activity android:name="LODTestActivity"
                   android:screenOrientation="landscape"
+                  android:launchMode="singleTask"
                   android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/model-viewer/AndroidManifest.xml
+++ b/GVRf/Sample/model-viewer/AndroidManifest.xml
@@ -38,6 +38,7 @@
         <activity
             android:name="org.gearvrf.modelviewer.ViewerActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/nonglthreadupdate/AndroidManifest.xml
+++ b/GVRf/Sample/nonglthreadupdate/AndroidManifest.xml
@@ -34,6 +34,7 @@
         <activity
             android:name="org.gearvrf.nonglthreadupdate.SampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/scene-objects/AndroidManifest.xml
+++ b/GVRf/Sample/scene-objects/AndroidManifest.xml
@@ -33,6 +33,7 @@
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
         <activity android:name="SceneObjectActivity"
                   android:screenOrientation="landscape"
+                  android:launchMode="singleTask"
                   android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/simple-gallery/AndroidManifest.xml
+++ b/GVRf/Sample/simple-gallery/AndroidManifest.xml
@@ -38,6 +38,7 @@
         <activity
             android:name="org.gearvrf.simplegallery.GalleryActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/simple-sample/AndroidManifest.xml
+++ b/GVRf/Sample/simple-sample/AndroidManifest.xml
@@ -34,6 +34,7 @@
         <activity
             android:name="org.gearvrf.simplesample.SampleActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/solar-system/AndroidManifest.xml
+++ b/GVRf/Sample/solar-system/AndroidManifest.xml
@@ -36,6 +36,7 @@
         <activity
             android:name="org.gearvrf.solarsystem.SolarActivity"
             android:screenOrientation="landscape"
+            android:launchMode="singleTask"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/GVRf/Sample/transparency-test/AndroidManifest.xml
+++ b/GVRf/Sample/transparency-test/AndroidManifest.xml
@@ -18,6 +18,7 @@
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
         <activity android:name="TransparencyTest"
                   android:screenOrientation="landscape"
+                  android:launchMode="singleTask"
                   android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
If you hit back and hit back again to return to the app there is a
crash since the move to 1.0.0.0. Oculus requires singleTask
activity.

Oculus apps crash the same way if singleTask is taken out from
their manifest.