### PR TITLE
Fix for bug 19478, "Crash while launching an app"

### DIFF
--- a/GVRf/Framework/jni/objects/components/eye_pointee_holder.cpp
+++ b/GVRf/Framework/jni/objects/components/eye_pointee_holder.cpp
@@ -42,15 +42,21 @@ void EyePointeeHolder::removePointee(EyePointee* pointee) {
 
 EyePointData EyePointeeHolder::isPointed(const glm::mat4& view_matrix, float ox,
         float oy, float oz, float dx, float dy, float dz) {
-    glm::mat4 mv_matrix = view_matrix
-            * owner_object()->transform()->getModelMatrix();
     EyePointData holder_data;
-    for (auto it = pointees_.begin(); it != pointees_.end(); ++it) {
-        EyePointData data = (*it)->isPointed(mv_matrix, ox, oy, oz, dx, dy, dz);
-        if (data.distance() < holder_data.distance()) {
-            holder_data = data;
+    const SceneObject* ownerObject = owner_object();
+    if (nullptr != ownerObject) {
+        Transform* transform = ownerObject->transform();
+        if (nullptr != transform) {
+            glm::mat4 mv_matrix = view_matrix * transform->getModelMatrix();
+            for (auto it = pointees_.begin(); it != pointees_.end(); ++it) {
+                EyePointData data = (*it)->isPointed(mv_matrix, ox, oy, oz, dx, dy, dz);
+                if (data.distance() < holder_data.distance()) {
+                    holder_data = data;
+                }
+            }
         }
     }
+
     return holder_data;
 }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
@@ -419,10 +419,16 @@ public class GVRSceneObject extends GVRHybridObject {
      *            New {@link GVREyePointeeHolder}.
      */
     public void attachEyePointeeHolder(GVREyePointeeHolder eyePointeeHolder) {
-        mEyePointeeHolder = eyePointeeHolder;
-        eyePointeeHolder.setOwnerObject(this);
-        NativeSceneObject.attachEyePointeeHolder(getNative(),
+        // see GVRPicker.findObjects
+        GVRPicker.sFindObjectsLock.lock();
+        try {
+            mEyePointeeHolder = eyePointeeHolder;
+            eyePointeeHolder.setOwnerObject(this);
+            NativeSceneObject.attachEyePointeeHolder(getNative(),
                 eyePointeeHolder.getNative());
+        } finally {
+            GVRPicker.sFindObjectsLock.unlock();
+        }
     }
 
     /**


### PR DESCRIPTION
Didn't reproduce it thus far; this is my best guess.

The thread-safety guarantee on the Java side is enough but the changes to the C++ are nice-to-have  - if ever that code is used without relying on the Java side for locking, these checks are necessary as nullptr is valid return value.