### PR TITLE
Magnetometer yaw drift correction

### DIFF
--- a/GVRf/Framework/jni/oculus/activity_jni.h
+++ b/GVRf/Framework/jni/oculus/activity_jni.h
@@ -73,24 +73,24 @@ private:
     JNIEnv*             uiJni;            // for use by the Java UI thread
     OVR::Matrix4f       GetEyeView( const int eye, const float fovDegreesX, const float fovDegreesY ) const;
 
-    jclass              activityClass;    // must be looked up from main thread or FindClass() will fail
+    jclass              activityClass = nullptr;    // must be looked up from main thread or FindClass() will fail
 
-    jclass              vrAppSettingsClass;
-    jclass              eyeBufferParmsClass;
+    jclass              vrAppSettingsClass = nullptr;
+    jclass              eyeBufferParmsClass = nullptr;
 
-    jmethodID           getAppSettingsMethodId;
+    jmethodID           getAppSettingsMethodId = nullptr;
 
-    jmethodID           oneTimeInitMethodId;
-    jmethodID           oneTimeShutdownMethodId;
+    jmethodID           oneTimeInitMethodId = nullptr;
+    jmethodID           oneTimeShutdownMethodId = nullptr;
 
-    jmethodID           drawFrameMethodId;
+    jmethodID           drawFrameMethodId = nullptr;
 
-    jmethodID           beforeDrawEyesMethodId;
-    jmethodID           drawEyeViewMethodId;
-    jmethodID           afterDrawEyesMethodId;
+    jmethodID           beforeDrawEyesMethodId = nullptr;
+    jmethodID           drawEyeViewMethodId = nullptr;
+    jmethodID           afterDrawEyesMethodId = nullptr;
 
-    jmethodID           onKeyEventNativeMethodId;
-    jmethodID           updateSensoredSceneMethodId;
+    jmethodID           onKeyEventNativeMethodId = nullptr;
+    jmethodID           updateSensoredSceneMethodId = nullptr;
 
     jclass              GetGlobalClassReference( const char * className ) const;
     jmethodID           GetMethodID( const char * name, const char * signature );

--- a/GVRf/Framework/jni/sensor/ksensor/k_sensor.cpp
+++ b/GVRf/Framework/jni/sensor/ksensor/k_sensor.cpp
@@ -26,16 +26,26 @@
 #include "util/gvr_time.h"
 #include <chrono>
 #include "math/matrix.hpp"
+#include <glm/glm.hpp>
 
 namespace gvr {
 
 #define HIDIOCGFEATURE(len)    _IOC(_IOC_WRITE|_IOC_READ, 'H', 0x07, len)
 //#define LOG_SUMMARY
 //#define LOG_GYRO_FILTER
+//#define LOG_MAGNETOMETER_CORRECTION
+
+const float KVerySmallValue = 0.00001f;
+
+const float KYawDriftCorrection_TiltCorrectionWaitInSeconds = 5.0;
+const float KYawDriftCorrection_MaxTiltDifference = 0.15f;
+const float KYawCorrectionMaxRadians = glm::radians(0.07f);
+const float KYawDriftCorrection_AngularVelocityThreshold = glm::radians(5.0f);
+
+float acosx(const float angle);
 
 void KSensor::readerThreadFunc() {
     LOGV("k_sensor: reader starting up");
-
     readFactoryCalibration();
 
     while (0 > (fd_ = open("/dev/ovr0", O_RDONLY))) {
@@ -73,11 +83,19 @@ void KSensor::readerThreadFunc() {
 }
 
 KSensor::KSensor() :
-        fd_(-1), q_(), first_(true), step_(0), first_real_time_delta_(0.0f), last_timestamp_(
-                0), full_timestamp_(0), last_sample_count_(0), latest_time_(0), last_acceleration_(
-                0.0f, 0.0f, 0.0f), processing_thread_(), gyroFilter_(
+        fd_(-1), q_(), first_(true), step_(0), first_real_time_delta_(0.0f), last_timestamp_(0), full_timestamp_(0), last_sample_count_(
+                0), latest_time_(0), last_acceleration_(0.0f, 0.0f, 0.0f), processing_thread_(), gyroFilter_(
                 KGyroNoiseFilterCapacity), tiltFilter_(25), processing_flag_(
-                true) {
+        true) {
+}
+
+KSensor::~KSensor() {
+    ASensorManager* sensorManager = ASensorManager_getInstance();
+
+    if (nullptr != magneticSensorQueue) {
+        ASensorEventQueue_disableSensor(magneticSensorQueue, magneticSensor);
+        ASensorManager_destroyEventQueue(sensorManager, magneticSensorQueue);
+    }
 }
 
 void KSensor::start() {
@@ -106,39 +124,27 @@ bool KSensor::pollSensor(KTrackerSensorZip* data) {
         }
 
         data->SampleCount = buffer[1];
-        data->Timestamp = (uint16_t) (*(buffer + 3) << 8)
-                | (uint16_t) (*(buffer + 2));
-        data->LastCommandID = (uint16_t) (*(buffer + 5) << 8)
-                | (uint16_t) (*(buffer + 4));
-        data->Temperature = (int16_t) (*(buffer + 7) << 8)
-                | (int16_t) (*(buffer + 6));
+        data->Timestamp = (uint16_t) (*(buffer + 3) << 8) | (uint16_t) (*(buffer + 2));
+        data->LastCommandID = (uint16_t) (*(buffer + 5) << 8) | (uint16_t) (*(buffer + 4));
+        data->Temperature = (int16_t) (*(buffer + 7) << 8) | (int16_t) (*(buffer + 6));
 
-        for (int i = 0; i < (data->SampleCount > 3 ? 3 : data->SampleCount);
-                ++i) {
+        for (int i = 0; i < (data->SampleCount > 3 ? 3 : data->SampleCount); ++i) {
             struct {
                 int32_t x :21;
             } s;
 
-            data->Samples[i].AccelX = s.x = (buffer[0 + 8 + 16 * i] << 13)
-                    | (buffer[1 + 8 + 16 * i] << 5)
+            data->Samples[i].AccelX = s.x = (buffer[0 + 8 + 16 * i] << 13) | (buffer[1 + 8 + 16 * i] << 5)
                     | ((buffer[2 + 8 + 16 * i] & 0xF8) >> 3);
-            data->Samples[i].AccelY = s.x = ((buffer[2 + 8 + 16 * i] & 0x07)
-                    << 18) | (buffer[3 + 8 + 16 * i] << 10)
-                    | (buffer[4 + 8 + 16 * i] << 2)
-                    | ((buffer[5 + 8 + 16 * i] & 0xC0) >> 6);
-            data->Samples[i].AccelZ = s.x = ((buffer[5 + 8 + 16 * i] & 0x3F)
-                    << 15) | (buffer[6 + 8 + 16 * i] << 7)
+            data->Samples[i].AccelY = s.x = ((buffer[2 + 8 + 16 * i] & 0x07) << 18) | (buffer[3 + 8 + 16 * i] << 10)
+                    | (buffer[4 + 8 + 16 * i] << 2) | ((buffer[5 + 8 + 16 * i] & 0xC0) >> 6);
+            data->Samples[i].AccelZ = s.x = ((buffer[5 + 8 + 16 * i] & 0x3F) << 15) | (buffer[6 + 8 + 16 * i] << 7)
                     | (buffer[7 + 8 + 16 * i] >> 1);
 
-            data->Samples[i].GyroX = s.x = (buffer[0 + 16 + 16 * i] << 13)
-                    | (buffer[1 + 16 + 16 * i] << 5)
+            data->Samples[i].GyroX = s.x = (buffer[0 + 16 + 16 * i] << 13) | (buffer[1 + 16 + 16 * i] << 5)
                     | ((buffer[2 + 16 + 16 * i] & 0xF8) >> 3);
-            data->Samples[i].GyroY = s.x = ((buffer[2 + 16 + 16 * i] & 0x07)
-                    << 18) | (buffer[3 + 16 + 16 * i] << 10)
-                    | (buffer[4 + 16 + 16 * i] << 2)
-                    | ((buffer[5 + 16 + 16 * i] & 0xC0) >> 6);
-            data->Samples[i].GyroZ = s.x = ((buffer[5 + 16 + 16 * i] & 0x3F)
-                    << 15) | (buffer[6 + 16 + 16 * i] << 7)
+            data->Samples[i].GyroY = s.x = ((buffer[2 + 16 + 16 * i] & 0x07) << 18) | (buffer[3 + 16 + 16 * i] << 10)
+                    | (buffer[4 + 16 + 16 * i] << 2) | ((buffer[5 + 16 + 16 * i] & 0xC0) >> 6);
+            data->Samples[i].GyroZ = s.x = ((buffer[5 + 16 + 16 * i] & 0x3F) << 15) | (buffer[6 + 16 + 16 * i] << 7)
                     | (buffer[7 + 16 + 16 * i] >> 1);
         }
 
@@ -147,8 +153,7 @@ bool KSensor::pollSensor(KTrackerSensorZip* data) {
     return false;
 }
 
-void KSensor::process(KTrackerSensorZip* data, vec3& corrected_gyro,
-        Quaternion& q) {
+void KSensor::process(KTrackerSensorZip* data, vec3& corrected_gyro, Quaternion& q) {
     const float timeUnit = (1.0f / 1000.f);
 
     struct timespec tp;
@@ -173,8 +178,7 @@ void KSensor::process(KTrackerSensorZip* data, vec3& corrected_gyro,
             // The timestamp rolled around the 16 bit counter, so FullTimeStamp
             // needs a high word increment.
             full_timestamp_ += 0x10000;
-            timestampDelta = ((((int) data->Timestamp) + 0x10000)
-                    - (int) last_timestamp_);
+            timestampDelta = ((((int) data->Timestamp) + 0x10000) - (int) last_timestamp_);
         } else {
             timestampDelta = (data->Timestamp - last_timestamp_);
         }
@@ -195,14 +199,12 @@ void KSensor::process(KTrackerSensorZip* data, vec3& corrected_gyro,
         // This will be considered the absolute time of the last sample in
         // the message.  If we are double or tripple stepping the samples,
         // their absolute times will be adjusted backwards.
-        absoluteTimeSeconds = full_timestamp_ * timeUnit
-                + first_real_time_delta_;
+        absoluteTimeSeconds = full_timestamp_ * timeUnit + first_real_time_delta_;
 
         // If we missed a small number of samples, replicate the last sample.
         if ((timestampDelta > last_sample_count_) && (timestampDelta <= 254)) {
             KTrackerMessage sensors;
-            sensors.TimeDelta = (timestampDelta - last_sample_count_)
-                    * timeUnit;
+            sensors.TimeDelta = (timestampDelta - last_sample_count_) * timeUnit;
             sensors.Acceleration = last_acceleration_;
             sensors.RotationRate = last_rotation_rate_;
 
@@ -223,11 +225,10 @@ void KSensor::process(KTrackerSensorZip* data, vec3& corrected_gyro,
 
     const float scale = 0.0001f;
     for (int i = 0; i < iterations; ++i) {
-        sensors.Acceleration = vec3(data->Samples[i].AccelX * scale,
-                data->Samples[i].AccelY * scale,
+        sensors.Acceleration = vec3(data->Samples[i].AccelX * scale, data->Samples[i].AccelY * scale,
                 data->Samples[i].AccelZ * scale);
-        sensors.RotationRate = vec3(data->Samples[i].GyroX * scale,
-                data->Samples[i].GyroY * scale, data->Samples[i].GyroZ * scale);
+        sensors.RotationRate = vec3(data->Samples[i].GyroX * scale, data->Samples[i].GyroY * scale,
+                data->Samples[i].GyroZ * scale);
 
         updateQ(&sensors, corrected_gyro, q);
 
@@ -241,8 +242,7 @@ void KSensor::process(KTrackerSensorZip* data, vec3& corrected_gyro,
     last_rotation_rate_ = sensors.RotationRate;
 }
 
-void KSensor::updateQ(KTrackerMessage *msg, vec3& corrected_gyro,
-        Quaternion& q) {
+void KSensor::updateQ(KTrackerMessage *msg, vec3& corrected_gyro, Quaternion& q) {
     vec3 filteredGyro = applyGyroFilter(msg->RotationRate, msg->Temperature);
 
     const float deltaT = msg->TimeDelta;
@@ -250,20 +250,18 @@ void KSensor::updateQ(KTrackerMessage *msg, vec3& corrected_gyro,
             deltaT, q);
 
     if (0.0f != axisAndMagnitude.second) {
-        q = q
-                * Quaternion::CreateFromAxisAngle(axisAndMagnitude.first,
-                        axisAndMagnitude.second * deltaT);
+        q = q * Quaternion::CreateFromAxisAngle(axisAndMagnitude.first, axisAndMagnitude.second * deltaT);
     }
 
 #ifdef LOG_SUMMARY
     if (0 == step_ % 1000) {
-        LOGI(
-                "k_sensor: summary: yaw angle %f; gyro offset %f %f %f; temperature %f; gyro filter sizes %d",
-                q.ToEulerAngle().y * KRadiansToDegrees, gyroOffset_.x,
-                gyroOffset_.y, gyroOffset_.z, msg->Temperature,
+        LOGI("k_sensor: summary: yaw angle %f; gyro offset %f %f %f; temperature %f; gyro filter sizes %d",
+                glm::degrees(q.ToEulerAngle().y), gyroOffset_.x, gyroOffset_.y, gyroOffset_.z, msg->Temperature,
                 gyroFilter_.size());
     }
 #endif
+
+    q = applyMagnetometerCorrection(q, msg->Acceleration, filteredGyro, deltaT);
 
     step_++;
     // Normalize error
@@ -276,8 +274,7 @@ void KSensor::updateQ(KTrackerMessage *msg, vec3& corrected_gyro,
  * Tries to determine the gyro noise and subtract it from the actual reading to
  * reduce the amount of yaw drift.
  */
-vec3 KSensor::applyGyroFilter(const vec3& rawGyro,
-        const float currentTemperature) {
+vec3 KSensor::applyGyroFilter(const vec3& rawGyro, const float currentTemperature) {
     const int gyroFilterSize = gyroFilter_.size();
     if (gyroFilterSize > KGyroNoiseFilterCapacity / 2) {
         gyroOffset_ = gyroFilter_.mean();
@@ -285,8 +282,7 @@ vec3 KSensor::applyGyroFilter(const vec3& rawGyro,
     }
 
     if (gyroFilterSize > 0) {
-        if (!isnan(sensorTemperature_)
-                && sensorTemperature_ != currentTemperature) {
+        if (!isnan(sensorTemperature_) && sensorTemperature_ != currentTemperature) {
             gyroFilter_.clear();
             sensorTemperature_ = currentTemperature;
 
@@ -296,8 +292,7 @@ vec3 KSensor::applyGyroFilter(const vec3& rawGyro,
         } else {
             const vec3& mean = gyroFilter_.mean();
             // magic values that happen to work
-            if (rawGyro.Length() > 1.25f * 0.349066f
-                    || (rawGyro - mean).Length() > 0.018f) {
+            if (rawGyro.Length() > 1.25f * 0.349066f || (rawGyro - mean).Length() > 0.018f) {
                 gyroFilter_.clear();
 
 #ifdef LOG_GYRO_FILTER
@@ -308,10 +303,7 @@ vec3 KSensor::applyGyroFilter(const vec3& rawGyro,
     }
 
     const float alpha = 0.4f;
-    const vec3 avg =
-            (0 == gyroFilterSize) ?
-                    rawGyro :
-                    rawGyro * alpha + gyroFilter_.peekBack() * (1 - alpha);
+    const vec3 avg = (0 == gyroFilterSize) ? rawGyro : rawGyro * alpha + gyroFilter_.peekBack() * (1 - alpha);
     gyroFilter_.push(avg);
 
     return factoryGyroMatrix_.Transform(rawGyro - gyroOffset_);
@@ -379,6 +371,161 @@ void KSensor::readFactoryCalibration() {
     }
 }
 
-const double KSensor::KRadiansToDegrees = 180 / M_PI;
+/**
+ * Using the phone magnetometer as it is continuously calibrated.
+ */
+Quaternion KSensor::applyMagnetometerCorrection(Quaternion& orientation, const vec3& accelerometer, const vec3& gyro,
+        float deltaT) {
+    const float gravityThreshold = 0.1f;
+    const float gravity = 9.80665f;
+    if (fabs(accelerometer.Length() / gravity - 1) > gravityThreshold) {
+        //linear acceleration detection
+        yawCorrectionTimer = 0;
+        return orientation;
+    }
+
+    yawCorrectionTimer += deltaT;
+    if (yawCorrectionTimer < KYawDriftCorrection_TiltCorrectionWaitInSeconds
+            || gyro.Length() >= KYawDriftCorrection_AngularVelocityThreshold) {
+#ifdef LOG_MAGNETOMETER_CORRECTION
+        LOGI("ksensor: no yaw correction applied");
+#endif
+        return orientation;
+    }
+
+    getLatestMagneticField();
+    if (0 == magnetic.Length()) {
+        return orientation;
+    }
+
+    bool rememberReferencePoint = true;
+    // get the angle between the remembered orientation and this orientation
+    float angleRadians = 2 * acosx(fabs(orientation.Dot(referencePoint_.second)));
+
+    Quaternion correctedOrientation = orientation;
+    if (angleRadians < glm::radians(5.0f) && 0 != referencePoint_.first.Length()) {
+        //use always the most up-to-date bias for improved calibration
+        vec3 worldFrame = orientation.Rotate(magnetic - magneticBias);
+        if (worldFrame.x * worldFrame.x + worldFrame.z * worldFrame.z < KVerySmallValue) {
+#ifdef LOG_MAGNETOMETER_CORRECTION
+            LOGI("k_sensor: horizontal component too small");
+#endif
+            return orientation;
+        }
+        worldFrame.Normalize();
+
+        vec3 referenceWorldFrame = referencePoint_.second.Rotate(referencePoint_.first - magneticBias);
+        referenceWorldFrame.Normalize();
+
+        if (fabs(referenceWorldFrame.y - worldFrame.y) > KYawDriftCorrection_MaxTiltDifference) {
+#ifdef LOG_MAGNETOMETER_CORRECTION
+            LOGI("k_sensor: too big of a tilt difference");
+#endif
+            return orientation;
+        }
+
+        // compute in the horizontal plane
+        referenceWorldFrame.y = worldFrame.y = 0;
+        float errorAngleInRadians = referenceWorldFrame.Angle(worldFrame);
+        if (isnan(errorAngleInRadians)) {
+            return orientation;
+        }
+        if (worldFrame.Cross(referenceWorldFrame).y < 0.0f) {
+            errorAngleInRadians *= -1.0f;
+        }
+
+        float correction = errorAngleInRadians * KYawCorrectionMaxRadians / 5.0f;
+        correction = std::max(-KYawCorrectionMaxRadians, std::min(KYawCorrectionMaxRadians, correction));
+        correction *= deltaT;
+        correctedOrientation = Quaternion::CreateFromAxisAngle(vec3(0.0f, 1.0f, 0.0f), correction) * orientation;
+
+#ifdef LOG_MAGNETOMETER_CORRECTION
+        if (0 == step_ % 1500) {
+            LOGI("k_sensor: magnetometer correction: %f degrees; angle to reference %f; reference yaw: %f; current yaw: %f; corrected yaw: %f",
+                    glm::degrees(correction), glm::degrees(errorAngleInRadians),
+                    glm::degrees(referencePoint_.second.ToEulerAngle().y),
+                    glm::degrees(orientation.ToEulerAngle().y),
+                    glm::degrees(correctedOrientation.ToEulerAngle().y));
+        }
+#endif
+
+        rememberReferencePoint = false;
+    }
+
+    if (rememberReferencePoint) {
+        referencePoint_ = std::make_pair(magnetic, orientation);
+#ifdef LOG_MAGNETOMETER_CORRECTION
+        LOGI("k_sensor: saving reference point at uncorrected yaw %f", glm::degrees(orientation.ToEulerAngle().y));
+#endif
+    }
+    return correctedOrientation;
+}
+
+const int TYPE_MAGNETIC_FIELD_UNCALIBRATED = 14;
+bool KSensor::getLatestMagneticField() {
+    bool fieldRetrieved = false;
+    if (nullptr == magneticSensorQueue) {
+        // Initialize on same thread as read.
+        ASensorManager* sensorManager = ASensorManager_getInstance();
+
+        ALooper* looper = ALooper_forThread();
+        if (looper == nullptr) {
+            looper = ALooper_prepare(ALOOPER_PREPARE_ALLOW_NON_CALLBACKS);
+        }
+
+        magneticSensor = ASensorManager_getDefaultSensor(sensorManager, TYPE_MAGNETIC_FIELD_UNCALIBRATED);
+        if (nullptr != magneticSensor) {
+            magneticSensorQueue = ASensorManager_createEventQueue(sensorManager, looper, 1, NULL, NULL);
+
+            auto error = ASensorEventQueue_enableSensor(magneticSensorQueue, magneticSensor);
+            if (0 > error) {
+                LOGE("k_sensor: error: enableSensor failed with %d", error);
+            } else {
+                error = ASensorEventQueue_setEventRate(magneticSensorQueue, magneticSensor,
+                        ASensor_getMinDelay(magneticSensor));
+                if (0 > error) {
+                    LOGE("k_sensor: error: setEventRate failed with %d", error);
+                }
+            }
+        } else {
+            LOGE("k_sensor: error: getDefaultSensor failed for sensor type %d", TYPE_MAGNETIC_FIELD_UNCALIBRATED);
+        }
+    }
+
+    int ident;  // Identifier.
+    int events;
+
+    while ((ident = ALooper_pollAll(0, NULL, &events, NULL) >= 0)) {
+        if (ident == 1) {
+            ASensorEvent event;
+            while (ASensorEventQueue_getEvents(magneticSensorQueue, &event, 1) > 0) {
+                if (event.type == TYPE_MAGNETIC_FIELD_UNCALIBRATED) {
+                    magnetic.x = event.uncalibrated_magnetic.x_uncalib;
+                    magnetic.y = event.uncalibrated_magnetic.y_uncalib;
+                    magnetic.z = event.uncalibrated_magnetic.z_uncalib;
+                    magneticBias.x = event.uncalibrated_magnetic.x_bias;
+                    magneticBias.y = event.uncalibrated_magnetic.y_bias;
+                    magneticBias.z = event.uncalibrated_magnetic.z_bias;
+                    fieldRetrieved = true;
+                }
+            }
+        }
+    }
+
+    return fieldRetrieved;
+}
+
+/**
+ * @param angle in radians
+ */
+float acosx(const float angle) {
+    if (angle > 1) {
+        return 0;
+    } else if (angle < -1) {
+        return M_PI;
+    } else {
+        return acos(angle);
+    }
+}
 
 }


### PR DESCRIPTION
It helps a little bit, most of the times. I think not accounting for the temperature changes is currently the biggest source of drift, relatively speaking. Have observed numerous times that most of drift happens during the phase where the headset warms up. Once the temperature stabilizes there is virtually no drift. With or without these change the drift on S6 is a fraction of a degree over 40+ minutes (starting from cold headset&device).

Can be turned off by commenting out the FEATURE_MAGNETOMETER_YAW_CORRECTION flag in k_sensor.cpp. To actually use KSensor uncomment the USE_FEATURE_KSENSOR in activity_jni.h.