### PR TITLE
Camera2 Sample: force finish the activity on pause as a workaround;

### DIFF
--- a/GVRf/Sample/gvrcamera2renderscript/src/org/gearvrf/sample/gvrcamera2renderscript/Camera2RenderscriptActivity.java
+++ b/GVRf/Sample/gvrcamera2renderscript/src/org/gearvrf/sample/gvrcamera2renderscript/Camera2RenderscriptActivity.java
@@ -19,5 +19,6 @@ public class Camera2RenderscriptActivity extends GVRActivity
     protected void onPause() {
         super.onPause();
         mManger.onPause();
+        finish();
     }
 }


### PR DESCRIPTION
otherwise the sample doesn't work properly on resume.