### PR TITLE
Add Texture Capturer for reading back rendered textures

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -581,6 +581,7 @@ void Renderer::renderRenderData(RenderData* render_data,
                             break;
                         case Material::ShaderType::EXTERNAL_RENDERER_SHADER:
                             shader_manager->getExternalRendererShader()->render(
+                                    mv_matrix, glm::inverseTranspose(mv_matrix),
                                     mvp_matrix, render_data);
                             break;
                         case Material::ShaderType::ASSIMP_SHADER:

--- a/GVRf/Framework/jni/objects/components/render_data.h
+++ b/GVRf/Framework/jni/objects/components/render_data.h
@@ -28,6 +28,7 @@
 
 #include "objects/components/component.h"
 #include "objects/render_pass.h"
+#include "objects/components/texture_capturer.h"
 
 namespace gvr {
 class Mesh;
@@ -53,7 +54,7 @@ public:
                     DEFAULT_RENDER_MASK), rendering_order_(
                     DEFAULT_RENDERING_ORDER), offset_(false), offset_factor_(
                     0.0f), offset_units_(0.0f), depth_test_(true), alpha_blend_(
-                    true), draw_mode_(GL_TRIANGLES) {
+                    true), draw_mode_(GL_TRIANGLES), texture_capturer(0) {
     }
 
     ~RenderData() {
@@ -201,9 +202,16 @@ public:
         return camera_distance_;
     }
 
-
     void set_draw_mode(GLenum draw_mode) {
         draw_mode_ = draw_mode;
+    }
+
+    void set_texture_capturer(TextureCapturer *capturer) {
+        texture_capturer = capturer;
+    }
+
+    TextureCapturer *get_texture_capturer() {
+        return texture_capturer;
     }
 
 private:
@@ -228,6 +236,7 @@ private:
     bool alpha_blend_;
     GLenum draw_mode_;
     float camera_distance_;
+    TextureCapturer *texture_capturer;
 };
 
 inline bool compareRenderData(RenderData* i, RenderData* j) {

--- a/GVRf/Framework/jni/objects/components/render_data_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/render_data_jni.cpp
@@ -23,6 +23,7 @@
 
 #include "objects/mesh.h"
 #include "objects/material.h"
+#include "objects/components/texture_capturer.h"
 
 namespace gvr {
 
@@ -109,6 +110,10 @@ Java_org_gearvrf_NativeRenderData_getDrawMode(
 JNIEXPORT void JNICALL
 Java_org_gearvrf_NativeRenderData_setDrawMode(
         JNIEnv * env, jobject obj, jlong jrender_data, jint draw_mode);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeRenderData_setTextureCapturer(JNIEnv * env, jobject obj,
+        jlong jrender_data, jlong jtexture_capturer);
 }
 ;
 
@@ -266,6 +271,14 @@ Java_org_gearvrf_NativeRenderData_getDrawMode(
     JNIEnv * env, jobject obj, jlong jrender_data) {
 RenderData* render_data = reinterpret_cast<RenderData*>(jrender_data);
 return render_data->draw_mode();
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeRenderData_setTextureCapturer(JNIEnv * env, jobject obj,
+        jlong jrender_data, jlong jtexture_capturer) {
+    RenderData* render_data = reinterpret_cast<RenderData*>(jrender_data);
+    render_data->set_texture_capturer(
+            reinterpret_cast<TextureCapturer*>(jtexture_capturer));
 }
 
 }

--- a/GVRf/Framework/jni/objects/components/texture_capturer.cpp
+++ b/GVRf/Framework/jni/objects/components/texture_capturer.cpp
@@ -1,0 +1,171 @@
+/***************************************************************************
+ * Captures a rendered texture to a buffer.
+ ***************************************************************************/
+
+#include "glm/glm.hpp"
+#include "glm/gtc/constants.hpp"
+#include "glm/gtc/type_ptr.hpp"
+#include "glm/gtc/matrix_inverse.hpp"
+#include "glm/gtc/matrix_transform.hpp"
+#include "objects/components/render_data.h"
+#include "objects/components/texture_capturer.h"
+#include "objects/material.h"
+#include "objects/mesh.h"
+#include "util/gvr_log.h"
+#include "util/gvr_time.h"
+
+#define TOL 1e-8
+
+namespace gvr {
+
+extern "C" {
+void Java_org_gearvrf_NativeTextureCapturer_callbackFromNative(
+        JNIEnv *env, jobject obj, jint index, char *info);
+}
+
+TextureCapturer::TextureCapturer(ShaderManager *shaderManager)
+        : Component()
+        , mShaderManager(shaderManager)
+        , mRenderTexture(0)
+        , mPendingCapture(false)
+        , mHasNewCapture(false)
+        , mCaptureIntervalNS(0)
+        , mLastCaptureTimeNS(0)
+        , mJNIEnv(0)
+        , mCapturerObject(0)
+{
+}
+
+TextureCapturer::~TextureCapturer() {
+    if (mJNIEnv && mCapturerObject) {
+        mJNIEnv->DeleteGlobalRef(mCapturerObject);
+    }
+}
+
+void TextureCapturer::setCapturerObject(JNIEnv *env, jobject capturer) {
+    mJNIEnv = env;
+
+    if (mCapturerObject) {
+        mJNIEnv->DeleteGlobalRef(mCapturerObject);
+    }
+
+    mCapturerObject = env->NewGlobalRef(capturer);
+}
+
+void TextureCapturer::setRenderTexture(RenderTexture *renderTexture) {
+    mRenderTexture = renderTexture;
+}
+
+void TextureCapturer::setCapture(bool capture, float fps) {
+    mPendingCapture = capture;
+    if (fabs(fps) > TOL) {
+        mCaptureIntervalNS = (long long)(1000000000.f / fps);
+    } else {
+        mCaptureIntervalNS = 0;
+    }
+}
+
+bool TextureCapturer::getAndClearPendingCapture() {
+    // periodic capture
+    if (mCaptureIntervalNS) {
+        long long now = getNanoTime();
+        if (now - mLastCaptureTimeNS >= mCaptureIntervalNS) {
+            mPendingCapture = true;
+        }
+    }
+
+    bool rv = mPendingCapture;
+    mPendingCapture = false;
+    return rv;
+}
+
+void TextureCapturer::beginCapture() {
+    // Save states
+    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &mSavedFBO);
+    glGetIntegerv(GL_VIEWPORT, mSavedViewport);
+    glGetIntegerv(GL_SCISSOR_BOX, mSavedScissor);
+    mIsCullFace = glIsEnabled(GL_CULL_FACE);
+
+    // Setup FBO
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mRenderTexture->getFrameBufferId());
+
+    glDisable(GL_CULL_FACE);
+    glEnable (GL_BLEND);
+    glBlendEquation (GL_FUNC_ADD);
+    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+    glDisable (GL_POLYGON_OFFSET_FILL);
+
+    // Setup viewport
+    glViewport(0, 0, mRenderTexture->width(), mRenderTexture->height());
+    glClearColor(0, 0, 0, 0); // transparency is needed
+    glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+
+    mLastCaptureTimeNS = getNanoTime();
+}
+
+void TextureCapturer::startReadBack() {
+    mRenderTexture->startReadBack();
+}
+
+void TextureCapturer::endCapture() {
+    // Restore GL settings
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mSavedFBO);
+    glViewport(mSavedViewport[0], mSavedViewport[1],
+               mSavedViewport[2], mSavedViewport[3]);
+    glScissor(mSavedScissor[0], mSavedScissor[1],
+              mSavedScissor[2], mSavedScissor[3]);
+
+    if (mIsCullFace)
+        glEnable(GL_CULL_FACE);
+    else
+        glDisable(GL_CULL_FACE);
+}
+
+void TextureCapturer::render(
+        const glm::mat4& mv_matrix, const glm::mat4& mv_it_matrix,
+        const glm::mat4& mvp_matrix, RenderData* render_data) {
+
+    Material* material = render_data->pass(0)->material();
+    if (material == NULL) {
+        LOGE("No material");
+        return;
+    }
+
+    // Create the texture material
+    Material textureMaterial(Material::TEXTURE_SHADER);
+    textureMaterial.setTexture("main_texture", mRenderTexture);
+    textureMaterial.setFloat("opacity", material->getFloat("opacity"));
+
+    // OpenGL default
+    textureMaterial.setVec4("ambient_color", glm::vec4(0.2f, 0.2f, 0.2f, 1.0f));
+    textureMaterial.setVec4("diffuse_color", glm::vec4(0.8f, 0.8f, 0.8f, 1.0f));
+    textureMaterial.setVec4("specular_color", glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+    textureMaterial.setFloat("specular_exponent", 0.0f);
+
+    TextureShader *textureShader = mShaderManager->getTextureShader();
+
+    textureShader->render(mv_matrix, mv_it_matrix, mvp_matrix, render_data,
+                          &textureMaterial);
+}
+
+glm::mat4 TextureCapturer::getModelViewMatrix() {
+    // Apply rotation
+    glm::quat rot_quat = glm::angleAxis(180.f, glm::vec3(1.f, 0.f, 0.f));
+    glm::mat4 mv = glm::mat4_cast(rot_quat);
+    return mv;
+}
+
+glm::mat4 TextureCapturer::getMvpMatrix(float half_width, float half_height) {
+    // Orthographic projection
+    glm::mat4 proj = glm::ortho(-half_width, half_width,
+                                -half_height, half_height,
+                                -1.f, 1.f);
+    return glm::mat4(proj * getModelViewMatrix());
+}
+
+void TextureCapturer::callback(int msg, char *info) {
+    Java_org_gearvrf_NativeTextureCapturer_callbackFromNative(
+            mJNIEnv, mCapturerObject, msg, info);
+}
+
+}

--- a/GVRf/Framework/jni/objects/components/texture_capturer.h
+++ b/GVRf/Framework/jni/objects/components/texture_capturer.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+ * Captures a rendered texture to a buffer.
+ ***************************************************************************/
+
+#ifndef TEXTURE_CAPTURER_H_
+#define TEXTURE_CAPTURER_H_
+
+#include <chrono>
+#include <memory>
+
+#include "glm/glm.hpp"
+#include "objects/lazy.h"
+#include "objects/components/component.h"
+#include "objects/textures/render_texture.h"
+#include "shaders/shader_manager.h"
+
+#define TCCB_NEW_CAPTURE   1
+
+namespace gvr {
+class RenderData;
+
+class TextureCapturer : public Component {
+public:
+    TextureCapturer(ShaderManager *shaderManager);
+    virtual ~TextureCapturer();
+
+    void setCapturerObject(JNIEnv *env, jobject capturer);
+
+    void setRenderTexture(RenderTexture *renderTexture);
+    void setCapture(bool capture, float fps);
+    bool getAndClearPendingCapture();
+
+    void beginCapture();
+    void endCapture();
+
+    void startReadBack();
+
+    void render(const glm::mat4& mv_matrix, const glm::mat4& mv_it_matrix,
+                const glm::mat4& mvp_matrix, RenderData* render_data);
+
+    glm::mat4 getModelViewMatrix();
+    glm::mat4 getMvpMatrix(float width, float height);
+
+    void callback(int msg, char *info);
+
+private:
+    TextureCapturer(const TextureCapturer& capturer);
+    TextureCapturer(TextureCapturer&& capturer);
+    TextureCapturer& operator=(const TextureCapturer& capturer);
+    TextureCapturer& operator=(TextureCapturer&& capturer);
+
+private:
+    ShaderManager *mShaderManager;
+    RenderTexture *mRenderTexture;
+    bool mPendingCapture;
+    bool mHasNewCapture;
+    long long mCaptureIntervalNS;
+    long long mLastCaptureTimeNS;
+
+    // Saved GL settings
+    GLint mSavedFBO;
+    GLint mSavedViewport[4];
+    GLint mSavedScissor[4];
+    bool  mIsCullFace;
+
+    // Data for callback
+    JNIEnv  *mJNIEnv;
+    jobject mCapturerObject;
+};
+
+}
+#endif

--- a/GVRf/Framework/jni/objects/components/texture_capturer_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/texture_capturer_jni.cpp
@@ -1,0 +1,81 @@
+/***************************************************************************
+ * JNI
+ ***************************************************************************/
+
+#include "objects/components/texture_capturer.h"
+
+#include "util/gvr_jni.h"
+#include "util/gvr_log.h"
+#include "glm/gtc/type_ptr.hpp"
+
+namespace gvr {
+extern "C" {
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeTextureCapturer_ctor(JNIEnv * env,
+        jobject obj, jlong shaderManagerPtr);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeTextureCapturer_setCapturerObject(JNIEnv * env, jobject obj,
+        jlong ptr, jobject capturerObject);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeTextureCapturer_setRenderTexture(JNIEnv * env, jobject obj,
+        jlong ptr, jlong ptrRenderTexture);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeTextureCapturer_setCapture(JNIEnv * env, jobject obj,
+        jlong ptr, jboolean capture, jfloat fps);
+
+void
+Java_org_gearvrf_NativeTextureCapturer_callbackFromNative(
+        JNIEnv * env, jobject obj, jint index, char *info);
+}
+;
+
+static jmethodID sCallbackMethod;
+
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeTextureCapturer_ctor(JNIEnv * env,
+        jobject obj, jlong shaderManagerPtr) {
+
+    return reinterpret_cast<jlong>(new TextureCapturer(
+            reinterpret_cast<ShaderManager*>(shaderManagerPtr)));
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeTextureCapturer_setCapturerObject(JNIEnv * env, jobject obj,
+        jlong ptr, jobject capturerObject) {
+    TextureCapturer *capturer = reinterpret_cast<TextureCapturer*>(ptr);
+    capturer->setCapturerObject(env, capturerObject);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeTextureCapturer_setRenderTexture(JNIEnv * env, jobject obj,
+        jlong ptr, jlong ptrRenderTexture) {
+    TextureCapturer *capturer = reinterpret_cast<TextureCapturer*>(ptr);
+    capturer->setRenderTexture(reinterpret_cast<RenderTexture*>(ptrRenderTexture));
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeTextureCapturer_setCapture(JNIEnv * env, jobject obj,
+        jlong ptr, jboolean capture, jfloat fps) {
+    TextureCapturer *capturer = reinterpret_cast<TextureCapturer*>(ptr);
+    capturer->setCapture(capture, fps);
+}
+
+void
+Java_org_gearvrf_NativeTextureCapturer_callbackFromNative(JNIEnv * env,
+        jobject obj, jint msg, char *info) {
+
+    // Initialize method id
+    if (!sCallbackMethod) {
+        jclass clz = env->GetObjectClass(obj);
+        sCallbackMethod = env->GetMethodID(clz,
+                "callbackFromNative", "(ILjava/lang/String;)V");
+    }
+
+    jstring strInfo = info ? env->NewStringUTF(info) : 0;
+    env->CallVoidMethod(obj, sCallbackMethod, msg, strInfo);
+}
+
+}

--- a/GVRf/Framework/jni/objects/textures/external_renderer_texture.h
+++ b/GVRf/Framework/jni/objects/textures/external_renderer_texture.h
@@ -7,6 +7,7 @@
 #include <GLES2/gl2ext.h>
 
 #include "objects/textures/base_texture.h"
+#include "objects/components/texture_capturer.h"
 
 // this is the texture to be used with an external renderer
 // the data field can be used to pass data between the gvrf application

--- a/GVRf/Framework/jni/objects/textures/render_texture_jni.cpp
+++ b/GVRf/Framework/jni/objects/textures/render_texture_jni.cpp
@@ -30,6 +30,9 @@ Java_org_gearvrf_NativeRenderTexture_ctor(JNIEnv * env,
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeRenderTexture_ctorMSAA(JNIEnv * env,
         jobject obj, jint width, jint height, jint sample_count);
+JNIEXPORT bool JNICALL
+Java_org_gearvrf_NativeRenderTexture_readRenderResult(JNIEnv * env, jobject obj,
+        jlong ptr, jintArray jreadback_buffer);
 }
 ;
 
@@ -43,6 +46,20 @@ JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeRenderTexture_ctorMSAA(JNIEnv * env,
         jobject obj, jint width, jint height, jint sample_count) {
     return reinterpret_cast<jlong>(new RenderTexture(width, height, sample_count));
+}
+
+JNIEXPORT bool JNICALL
+Java_org_gearvrf_NativeRenderTexture_readRenderResult(JNIEnv * env, jobject obj,
+        jlong ptr, jintArray jreadback_buffer) {
+    RenderTexture *render_texture = reinterpret_cast<RenderTexture*>(ptr);
+    jint *readback_buffer = env->GetIntArrayElements(jreadback_buffer, JNI_FALSE);
+    jlong buffer_capacity = env->GetArrayLength(jreadback_buffer);
+
+    bool rv = render_texture->readRenderResult((uint32_t*)readback_buffer, buffer_capacity);
+
+    env->ReleaseIntArrayElements(jreadback_buffer, readback_buffer, 0);
+
+    return rv;
 }
 
 }

--- a/GVRf/Framework/jni/shaders/material/external_renderer_shader.h
+++ b/GVRf/Framework/jni/shaders/material/external_renderer_shader.h
@@ -23,7 +23,8 @@ class RenderData;
 class ExternalRendererShader : public RecyclableObject {
 public:
     ExternalRendererShader() {}
-    void render(const glm::mat4& mvp_matrix, RenderData* render_data);
+    void render(const glm::mat4& mv_matrix, const glm::mat4& mv_it_matrix,
+                const glm::mat4& mvp_matrix, RenderData* render_data);
 
 private:
     ExternalRendererShader(

--- a/GVRf/Framework/jni/util/gvr_time.h
+++ b/GVRf/Framework/jni/util/gvr_time.h
@@ -22,12 +22,23 @@
 #define GVR_TIME_H_
 
 #include "time.h"
+#include "util/gvr_log.h"
 
 namespace gvr {
 
 static long long getCurrentTime() {
     timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts); // Works on Linux
+    long long time = static_cast<long long>(ts.tv_sec)
+            * static_cast<long long>(1000000000)
+            + static_cast<long long>(ts.tv_nsec);
+    return time;
+}
+
+static long long getNanoTime() {
+    timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
     long long time = static_cast<long long>(ts.tv_sec)
             * static_cast<long long>(1000000000)
             + static_cast<long long>(ts.tv_nsec);

--- a/GVRf/Framework/src/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRContext.java
@@ -2162,6 +2162,22 @@ public abstract class GVRContext {
     public abstract void runOnGlThread(Runnable runnable);
 
     /**
+     * Enqueues a callback to be run in the GL thread after rendering a frame.
+     *
+     * This is how you take data generated on a background thread (or the main
+     * (GUI) thread) and pass it to the coprocessor, using calls that must be
+     * made from the GL thread (aka the "GL context"). The callback queue is
+     * processed after a frame has been rendered.
+     *
+     * @param delayFrames
+     *            Number of frames to delay the task. 0 means current frame.
+     * @param runnable
+     *            A bit of code that must run on the GL thread after rendering
+     *            a frame.
+     */
+    public abstract void runOnGlThreadPostRender(int delayFrames, Runnable runnable);
+
+    /**
      * Subscribes a {@link GVRDrawFrameListener}.
      * 
      * Each frame listener is called, once per frame, after any pending

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
@@ -678,9 +678,12 @@ public class GVRRenderData extends GVRComponent {
 
     /**
      * Set the capturer for this texture. If capturer is null, the existing capturer
-     * is removed.
+     * is removed. Whether the capturer takes effect depends on the shader associated
+     * with {@code GVRMaterial}. In order to support the texture capturer, a native
+     * shader should check {@code RenderData::get_texture_capturer}. See {@code
+     * ExternalRendererShader} as an example.
      *
-     * @param capturer
+     * @param capturer The capturer.
      */
     public void setTextureCapturer(GVRTextureCapturer capturer) {
         if (capturer != null)

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
@@ -686,10 +686,11 @@ public class GVRRenderData extends GVRComponent {
      * @param capturer The capturer.
      */
     public void setTextureCapturer(GVRTextureCapturer capturer) {
-        if (capturer != null)
+        if (capturer != null) {
             NativeRenderData.setTextureCapturer(getNative(), capturer.getNative());
-        else
+        } else {
             NativeRenderData.setTextureCapturer(getNative(), 0);
+        }
     }
 
     private boolean isLightEnabled;

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
@@ -676,6 +676,19 @@ public class GVRRenderData extends GVRComponent {
         NativeRenderData.setDrawMode(getNative(), drawMode);
     }
 
+    /**
+     * Set the capturer for this texture. If capturer is null, the existing capturer
+     * is removed.
+     *
+     * @param capturer
+     */
+    public void setTextureCapturer(GVRTextureCapturer capturer) {
+        if (capturer != null)
+            NativeRenderData.setTextureCapturer(getNative(), capturer.getNative());
+        else
+            NativeRenderData.setTextureCapturer(getNative(), 0);
+    }
+
     private boolean isLightEnabled;
 }
 
@@ -724,4 +737,5 @@ class NativeRenderData {
 
     public static native void setDrawMode(long renderData, int draw_mode);
 
+    public static native void setTextureCapturer(long renderData, long texture_capturer);
 }

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderTexture.java
@@ -15,6 +15,8 @@
 
 package org.gearvrf;
 
+import java.nio.IntBuffer;
+
 /** Frame Buffer object. */
 public class GVRRenderTexture extends GVRTexture {
     /**
@@ -37,7 +39,7 @@ public class GVRRenderTexture extends GVRTexture {
     /**
      * Constructs a GVRRenderTexture for a frame buffer of the specified size,
      * with MSAA enabled at the specified sample count.
-     * 
+     *
      * @param gvrContext
      *            Current gvrContext
      * @param width
@@ -51,7 +53,6 @@ public class GVRRenderTexture extends GVRTexture {
             int sampleCount) {
         super(gvrContext, NativeRenderTexture.ctorMSAA(width, height,
                 sampleCount));
-
         mWidth = width;
         mHeight = height;
     }
@@ -74,6 +75,20 @@ public class GVRRenderTexture extends GVRTexture {
         return mHeight;
     }
 
+    /**
+     * Return the render texture.
+     *
+     * @param readbackBuffer
+     *        A preallocated IntBuffer to receive the data from the texture. Its capacity should
+     *        be width * height. The output pixel format is GPU format GL_RGBA packed as an 32-bit
+     *        integer.
+     *
+     * @return true if successful.
+     */
+    boolean readRenderResult(int[] readbackBuffer) {
+      return NativeRenderTexture.readRenderResult(getNative(), readbackBuffer);
+    }
+
     private int mWidth, mHeight;
 }
 
@@ -81,4 +96,6 @@ class NativeRenderTexture {
     static native long ctor(int width, int height);
 
     static native long ctorMSAA(int width, int height, int sampleCount);
+
+    static native boolean readRenderResult(long ptr, int[] readbackBuffer);
 }

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderTexture.java
@@ -15,13 +15,11 @@
 
 package org.gearvrf;
 
-import java.nio.IntBuffer;
-
 /** Frame Buffer object. */
 public class GVRRenderTexture extends GVRTexture {
     /**
      * Constructs a GVRRenderTexture for a frame buffer of the specified size.
-     * 
+     *
      * @param gvrContext
      *            Current gvrContext
      * @param width
@@ -86,7 +84,7 @@ public class GVRRenderTexture extends GVRTexture {
      * @return true if successful.
      */
     boolean readRenderResult(int[] readbackBuffer) {
-      return NativeRenderTexture.readRenderResult(getNative(), readbackBuffer);
+        return NativeRenderTexture.readRenderResult(getNative(), readbackBuffer);
     }
 
     private int mWidth, mHeight;

--- a/GVRf/Framework/src/org/gearvrf/GVRTextureCapturer.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRTextureCapturer.java
@@ -1,0 +1,124 @@
+package org.gearvrf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gearvrf.utility.ImageUtils;
+import org.gearvrf.utility.Log;
+
+import android.graphics.Bitmap;
+
+public class GVRTextureCapturer extends GVRHybridObject {
+    private static final String TAG = GVRTextureCapturer.class.getSimpleName();
+    private static final int TCCB_NEW_CAPTURE = 1;
+
+    public static interface TextureCapturerListener {
+        void onTextureCaptured(Bitmap capturedTexture);
+    }
+
+    protected int width;
+    protected int height;
+    protected GVRRenderTexture captureTexture;
+    protected int[] readBackBuffer;
+    protected boolean processingCapturedTexture;
+
+    protected List<TextureCapturerListener> mListeners;
+
+    public GVRTextureCapturer(GVRContext gvrContext, int width, int height) {
+        this(gvrContext, width, height, 0);
+    }
+
+    public GVRTextureCapturer(GVRContext gvrContext, int width, int height, int sampleCount) {
+        super(gvrContext, NativeTextureCapturer.ctor(
+                gvrContext.getRenderBundle().getMaterialShaderManager().getNative()));
+        NativeTextureCapturer.setCapturerObject(getNative(), this);
+
+        mListeners = new ArrayList<TextureCapturerListener>();
+
+        if (sampleCount > 1) {
+            int maxSampleCount = GVRMSAA.getMaxSampleCount();
+            if (sampleCount > maxSampleCount) {
+                sampleCount = maxSampleCount;
+            }
+        }
+
+        update(width, height, sampleCount);
+    }
+
+    public void update(int width, int height, int sampleCount) {
+        this.width = width;
+        this.height = height;
+
+        if (sampleCount == 0)
+            captureTexture = new GVRRenderTexture(getGVRContext(), width, height);
+        else
+            captureTexture = new GVRRenderTexture(getGVRContext(), width, height, sampleCount);
+
+        setRenderTexture(captureTexture);
+        readBackBuffer = new int[width * height];
+    }
+
+    public void setRenderTexture(GVRRenderTexture screenshot) {
+        NativeTextureCapturer.setRenderTexture(getNative(), screenshot.getNative());
+    }
+
+    public void setCapture(boolean capture, float fps) {
+        NativeTextureCapturer.setCapture(getNative(), capture, fps);
+    }
+
+    public void addListener(TextureCapturerListener l) {
+        synchronized (mListeners) {
+            mListeners.add(l);
+        }
+    }
+
+    public void removeListener(TextureCapturerListener l) {
+        synchronized (mListeners) {
+            mListeners.remove(l);
+        }
+    }
+
+    public void callbackFromNative(int index, String info) {
+        switch (index) {
+            case TCCB_NEW_CAPTURE:
+                getGVRContext().runOnGlThread(new Runnable() {
+                    @Override
+                    public void run()
+                    {
+                        Bitmap capturedBitmap = null;
+
+                        synchronized (readBackBuffer) {
+                            if (processingCapturedTexture) {
+                                Log.w(TAG, "Busy processing a captured frame. Reduce capture FPS?");
+                                return;
+                            }
+
+                            try {
+                                processingCapturedTexture = true;
+                                boolean readOk = captureTexture.readRenderResult(readBackBuffer);
+                                if (!readOk)
+                                    return;
+
+                                capturedBitmap = ImageUtils.generateBitmap(readBackBuffer,
+                                                                           width, height);
+                            } finally {
+                                processingCapturedTexture = false;
+                            }
+
+                            for (TextureCapturerListener l : mListeners) {
+                                l.onTextureCaptured(capturedBitmap);
+                            }
+                        }
+                    }
+                });
+                break;
+        }
+    }
+}
+
+class NativeTextureCapturer {
+    static native long ctor(long shaderManagerPtr);
+    static native void setCapturerObject(long capturer, GVRTextureCapturer capturerObject);
+    static native void setRenderTexture(long capturer, long ptr);
+    static native void setCapture(long capturer, boolean capture, float fps);
+}

--- a/GVRf/Framework/src/org/gearvrf/GVRTextureCapturer.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRTextureCapturer.java
@@ -153,7 +153,7 @@ public class GVRTextureCapturer extends GVRHybridObject {
                     processingCapturedTexture = true;
                 }
 
-                getGVRContext().runOnGlThread(new Runnable() {
+                getGVRContext().runOnGlThreadPostRender(1 /* delay 1 frame */, new Runnable() {
                     @Override
                     public void run()
                     {

--- a/GVRf/Framework/src/org/gearvrf/GVRTextureCapturer.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRTextureCapturer.java
@@ -8,10 +8,25 @@ import org.gearvrf.utility.Log;
 
 import android.graphics.Bitmap;
 
+/**
+ * Captures rendered contents from a shader into a {@code GVRRenderTexture} while
+ * normal rendering is in progress.
+ *
+ * A {@code GVRTextureCapturer} object can be set into a {@code GVRRenderData}, which
+ * is passed to the corresponding shader that renders a scene object. The shader's native
+ * class can check if capturing is requested, and perform a capture while rendering to
+ * screen.
+ *
+ * Automatic capturing can be set up with a specified FPS value, and after rendering
+ * the callback function is called with the captured {@code Bitmap}.
+ */
 public class GVRTextureCapturer extends GVRHybridObject {
     private static final String TAG = GVRTextureCapturer.class.getSimpleName();
     private static final int TCCB_NEW_CAPTURE = 1;
 
+    /**
+     * An interface to receive captured {@code Bitmap}s.
+     */
     public static interface TextureCapturerListener {
         void onTextureCaptured(Bitmap capturedTexture);
     }
@@ -20,14 +35,32 @@ public class GVRTextureCapturer extends GVRHybridObject {
     protected int height;
     protected GVRRenderTexture captureTexture;
     protected int[] readBackBuffer;
+    protected Object processingLock = new Object();
     protected boolean processingCapturedTexture;
+    protected boolean capturing;
 
     protected List<TextureCapturerListener> mListeners;
 
+    /**
+     * Constructs a texture capturer with a backing texture with width * height pixels.
+     *
+     * @param gvrContext The {@code GVRContext}.
+     * @param width The width of the backing texture in pixels.
+     * @param height The height of the backing texture in pixels.
+     */
     public GVRTextureCapturer(GVRContext gvrContext, int width, int height) {
         this(gvrContext, width, height, 0);
     }
 
+    /**
+     * Constructs a texture capturer with a backing texture with width * height pixels,
+     * a specified MSAA sample count.
+     *
+     * @param gvrContext The {@code GVRContext}.
+     * @param width The width of the backing texture in pixels.
+     * @param height The height of the backing texture in pixels.
+     * @param sampleCount The MSAA sample count.
+     */
     public GVRTextureCapturer(GVRContext gvrContext, int width, int height, int sampleCount) {
         super(gvrContext, NativeTextureCapturer.ctor(
                 gvrContext.getRenderBundle().getMaterialShaderManager().getNative()));
@@ -45,7 +78,19 @@ public class GVRTextureCapturer extends GVRHybridObject {
         update(width, height, sampleCount);
     }
 
+    /**
+     * Updates the backing render texture. This method should not
+     * be called when capturing is in progress.
+     *
+     * @param width The width of the backing texture in pixels.
+     * @param height The height of the backing texture in pixels.
+     * @param sampleCount The MSAA sample count.
+     */
     public void update(int width, int height, int sampleCount) {
+        if (capturing) {
+            throw new IllegalStateException("Cannot update backing texture while capturing");
+        }
+
         this.width = width;
         this.height = height;
 
@@ -58,55 +103,75 @@ public class GVRTextureCapturer extends GVRHybridObject {
         readBackBuffer = new int[width * height];
     }
 
-    public void setRenderTexture(GVRRenderTexture screenshot) {
+    private void setRenderTexture(GVRRenderTexture screenshot) {
         NativeTextureCapturer.setRenderTexture(getNative(), screenshot.getNative());
     }
 
+    /**
+     * Starts or stops capturing.
+     *
+     * @param capture If true, capturing is started. If false, it is stopped.
+     * @param fps Capturing FPS (frames per second).
+     */
     public void setCapture(boolean capture, float fps) {
+        capturing = capture;
         NativeTextureCapturer.setCapture(getNative(), capture, fps);
     }
 
+    /**
+     * Adds a listener of the capturer.
+     *
+     * @param l The listener.
+     */
     public void addListener(TextureCapturerListener l) {
         synchronized (mListeners) {
             mListeners.add(l);
         }
     }
 
+    /**
+     * Removes a listener of the capturer.
+     *
+     * @param l The listener.
+     */
     public void removeListener(TextureCapturerListener l) {
         synchronized (mListeners) {
             mListeners.remove(l);
         }
     }
 
-    public void callbackFromNative(int index, String info) {
+    protected void callbackFromNative(int index, String info) {
         switch (index) {
             case TCCB_NEW_CAPTURE:
+                synchronized (processingLock) {
+                    // Busy processing, drop frame without queuing
+                    if (processingCapturedTexture) {
+                        Log.w(TAG, "Busy processing a captured frame. Reduce capture FPS?");
+                        return;
+                    }
+                    processingCapturedTexture = true;
+                }
+
                 getGVRContext().runOnGlThread(new Runnable() {
                     @Override
                     public void run()
                     {
                         Bitmap capturedBitmap = null;
-
-                        synchronized (readBackBuffer) {
-                            if (processingCapturedTexture) {
-                                Log.w(TAG, "Busy processing a captured frame. Reduce capture FPS?");
+                        try {
+                            boolean readOk = captureTexture.readRenderResult(readBackBuffer);
+                            if (!readOk)
                                 return;
-                            }
 
-                            try {
-                                processingCapturedTexture = true;
-                                boolean readOk = captureTexture.readRenderResult(readBackBuffer);
-                                if (!readOk)
-                                    return;
+                            capturedBitmap = ImageUtils.generateBitmap(readBackBuffer,
+                                                                       width, height);
 
-                                capturedBitmap = ImageUtils.generateBitmap(readBackBuffer,
-                                                                           width, height);
-                            } finally {
-                                processingCapturedTexture = false;
-                            }
-
+                            // Wait for all listeners before processing another frame
                             for (TextureCapturerListener l : mListeners) {
                                 l.onTextureCaptured(capturedBitmap);
+                            }
+                        } finally {
+                            synchronized (processingLock) {
+                                processingCapturedTexture = false;
                             }
                         }
                     }

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -30,12 +30,12 @@ import org.gearvrf.animation.GVRAnimation;
 import org.gearvrf.animation.GVROnFinish;
 import org.gearvrf.animation.GVROpacityAnimation;
 import org.gearvrf.asynchronous.GVRAsynchronousResourceLoader;
+import org.gearvrf.utility.ImageUtils;
 import org.gearvrf.utility.Log;
 import org.gearvrf.utility.Threads;
 
 import android.app.Activity;
 import android.graphics.Bitmap;
-import android.graphics.Color;
 import android.opengl.GLES20;
 import android.util.DisplayMetrics;
 import android.view.KeyEvent;
@@ -314,25 +314,6 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                 .getNative(), mReadbackBuffer);
     }
 
-    private Bitmap generateBitmap(final byte[] byteArray, final int width,
-            final int height) {
-        int[] pixels = new int[width * height];
-        for (int row = 0; row < height; row++) {
-            int start_position = row * width;
-            int reverse_start_position = (height - 1 - row) * width;
-            for (int col = 0; col < width; col++) {
-                int position = (start_position + col) * 4;
-                int r = byteArray[position++] & 0xff;
-                int g = byteArray[position++] & 0xff;
-                int b = byteArray[position] & 0xff;
-                // flip the image vertically
-                pixels[reverse_start_position + col] = Color.rgb(r, g, b);
-            }
-        }
-        return Bitmap.createBitmap(pixels, width, height,
-                Bitmap.Config.ARGB_8888);
-    }
-
     private void returnScreenshotToCaller(final GVRScreenshotCallback callback,
             final int width, final int height) {
         // run the callback function in a background thread
@@ -340,8 +321,8 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                 mReadbackBuffer.array().length);
         Threads.spawn(new Runnable() {
             public void run() {
-                final Bitmap capturedBitmap = generateBitmap(byteArray, width,
-                        height);
+                final Bitmap capturedBitmap = ImageUtils.generateBitmapFlipV(
+                        byteArray, width, height);
                 callback.onScreenCaptured(capturedBitmap);
             }
         });
@@ -426,8 +407,8 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                             public void run() {
                                 byte[] bytearray = byteArrays[index];
                                 byteArrays[index] = null;
-                                Bitmap bitmap = generateBitmap(bytearray,
-                                        width, height);
+                                Bitmap bitmap = ImageUtils.generateBitmapFlipV(
+                                        bytearray, width, height);
                                 synchronized (this) {
                                     bitmapArray[index] = bitmap;
                                     notify();

--- a/GVRf/Framework/src/org/gearvrf/utility/ImageUtils.java
+++ b/GVRf/Framework/src/org/gearvrf/utility/ImageUtils.java
@@ -2,14 +2,26 @@ package org.gearvrf.utility;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.IntBuffer;
 
 import android.graphics.Bitmap;
 import android.graphics.Color;
 
+/**
+ * Utilities for basic image I/O and manipulation.
+ */
 public class ImageUtils
 {
+    /**
+     * Generates a {@code Bitmap} from a byte array containing {@code width} *
+     * {@code height} pixels. The pixel format is RGBA in little endian. The
+     * alpha value is not used in the result bitmap. The bitmap is also
+     * vertically flipped.
+     *
+     * @param byteArray The input byte array.
+     * @param width The width of the image.
+     * @param height The height of the image.
+     * @return The generated {@code Bitmap} object.
+     */
     public static Bitmap generateBitmapFlipV(final byte[] byteArray, final int width,
             final int height) {
         int[] pixels = new int[width * height];
@@ -29,12 +41,29 @@ public class ImageUtils
                 Bitmap.Config.ARGB_8888);
     }
 
+    /**
+     * Generates a {@code Bitmap} from a int array containing {@code width} *
+     * {@code height} pixels. The pixel format is in ARGB_8888 format for
+     * Android.
+     *
+     * @param argbIntBuffer The int array containing pixels values.
+     * @param width The width of the image.
+     * @param height The height of the image.
+     * @return The generated {@code Bitmap} object.
+     */
     public static Bitmap generateBitmap(final int[] argbIntBuffer,
             final int width, final int height) {
         return Bitmap.createBitmap(argbIntBuffer,
                                    width, height, Bitmap.Config.ARGB_8888);
     }
 
+    /**
+     * Saves a {@code Bitmap} as a PNG file.
+     *
+     * @param filename The file path on the file system.
+     * @param bitmap The input {@code Bitmap} object.
+     * @return {@code true} if successful.
+     */
     public static boolean saveBitmapAsPNG(String filename, Bitmap bitmap) {
         FileOutputStream outStream = null;
         try {

--- a/GVRf/Framework/src/org/gearvrf/utility/ImageUtils.java
+++ b/GVRf/Framework/src/org/gearvrf/utility/ImageUtils.java
@@ -1,0 +1,59 @@
+package org.gearvrf.utility;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+import android.graphics.Bitmap;
+import android.graphics.Color;
+
+public class ImageUtils
+{
+    public static Bitmap generateBitmapFlipV(final byte[] byteArray, final int width,
+            final int height) {
+        int[] pixels = new int[width * height];
+        for (int row = 0; row < height; row++) {
+            int start_position = row * width;
+            int reverse_start_position = (height - 1 - row) * width;
+            for (int col = 0; col < width; col++) {
+                int position = (start_position + col) * 4;
+                int r = byteArray[position++] & 0xff;
+                int g = byteArray[position++] & 0xff;
+                int b = byteArray[position] & 0xff;
+                // flip the image vertically
+                pixels[reverse_start_position + col] = Color.rgb(r, g, b);
+            }
+        }
+        return Bitmap.createBitmap(pixels, width, height,
+                Bitmap.Config.ARGB_8888);
+    }
+
+    public static Bitmap generateBitmap(final int[] argbIntBuffer,
+            final int width, final int height) {
+        return Bitmap.createBitmap(argbIntBuffer,
+                                   width, height, Bitmap.Config.ARGB_8888);
+    }
+
+    public static boolean saveBitmapAsPNG(String filename, Bitmap bitmap) {
+        FileOutputStream outStream = null;
+        try {
+            outStream = new FileOutputStream(filename);
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, outStream);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        } finally {
+            try {
+                if (outStream != null) {
+                    outStream.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
- A GVRTextureCapturer can be added to the RenderData for capturing
  the rendered texture
- Currently, it is applied to the external renderer texture
- Added utilities to convert generate Bitmaps from captured data
  and to save it as PNG file

Performance of the capture is high, allowing 60 FPS capturing
without affecting rendering performance. It may be further improved
by using multiple pixel buffers. This feature can be used for
capturing screen at high FPS.