### PR TITLE
Skeletal animation (skinning) development work for review

### DIFF
--- a/GVRf/Framework/jni/objects/components/bone.cpp
+++ b/GVRf/Framework/jni/objects/components/bone.cpp
@@ -1,0 +1,35 @@
+/***************************************************************************
+ * Bone for skeletal animation.
+ ***************************************************************************/
+
+#include <algorithm>
+
+#include "objects/components/component.h"
+#include "objects/components/bone.h"
+
+#include "glm/gtc/matrix_inverse.hpp"
+
+#include "util/gvr_log.h"
+
+namespace gvr {
+Bone::Bone()
+  : Component()
+  , name_()
+  , boneWeights_()
+  , offsetMatrix_()
+  , finalTransformMatrixPtr_()
+{
+}
+
+Bone::~Bone() {
+}
+
+void Bone::setName(const char *name) {
+	name_ = std::string(name);
+}
+
+void Bone::setBoneWeights(std::vector<BoneWeight*>&& boneWeights) {
+    boneWeights_ = std::move(boneWeights);
+}
+
+}

--- a/GVRf/Framework/jni/objects/components/bone.h
+++ b/GVRf/Framework/jni/objects/components/bone.h
@@ -1,0 +1,62 @@
+/***************************************************************************
+ * Bone for skeletal animation.
+ ***************************************************************************/
+
+#ifndef BONE_H_
+#define BONE_H_
+
+#include <string>
+#include <vector>
+
+#include "glm/glm.hpp"
+#include "glm/gtc/matrix_transform.hpp"
+
+#include "objects/components/component.h"
+#include "objects/components/bone_weight.h"
+
+#include "util/gvr_log.h"
+
+namespace gvr {
+class Bone: public Component {
+public:
+    Bone();
+    virtual ~Bone();
+
+    void setName(const char *name);
+    void setBoneWeights(std::vector<BoneWeight*> &&boneWeights);
+
+    void setOffsetMatrix(glm::mat4 &mat) {
+        offsetMatrix_ = mat;
+    }
+
+    glm::mat4 getOffsetMatrix() {
+        return offsetMatrix_;
+    }
+
+    void setFinalTransformMatrixPtr(glm::mat4 *ptr) {
+        finalTransformMatrixPtr_ = ptr;
+    }
+
+    void setFinalTransformMatrix(glm::mat4 &mat) {
+        *finalTransformMatrixPtr_ = mat;
+    }
+
+    glm::mat4 &getFinalTransformMatrix() {
+        return *finalTransformMatrixPtr_;
+    }
+
+private:
+    Bone(const Bone& bone);
+    Bone(Bone&& bone);
+    Bone& operator=(const Bone& bone);
+    Bone& operator=(Bone&& bone);
+
+private:
+    std::string name_;
+    std::vector<BoneWeight*> boneWeights_;
+    glm::mat4 offsetMatrix_;
+    glm::mat4 *finalTransformMatrixPtr_;
+};
+
+}
+#endif

--- a/GVRf/Framework/jni/objects/components/bone_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/bone_jni.cpp
@@ -1,0 +1,138 @@
+/***************************************************************************
+ * JNI
+ ***************************************************************************/
+
+#include "glm/glm.hpp"
+#include "glm/gtc/type_ptr.hpp"
+
+#include "objects/components/bone.h"
+
+#include "util/gvr_jni.h"
+
+namespace gvr {
+extern "C" {
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeBone_ctor(JNIEnv * env, jobject obj);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBone_setName(JNIEnv * env, jobject clz, jlong ptr,
+        jstring name);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBone_setBoneWeights(JNIEnv * env, jobject clz, jlong ptr,
+        jlongArray jArrayBoneWeights);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBone_setOffsetMatrix(JNIEnv * env, jobject clz, jlong ptr,
+        jfloatArray jOffsetMatrix);
+
+JNIEXPORT jfloatArray JNICALL
+Java_org_gearvrf_NativeBone_getOffsetMatrix(JNIEnv * env, jobject clz, jlong ptr);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBone_setFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr,
+        jfloatArray jOffsetMatrix);
+
+JNIEXPORT jfloatArray JNICALL
+Java_org_gearvrf_NativeBone_getFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr);
+
+} // extern "C"
+;
+
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeBone_ctor(JNIEnv * env, jobject clz) {
+    return reinterpret_cast<jlong>(new Bone());
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBone_setName(JNIEnv * env, jobject clz, jlong ptr,
+        jstring name) {
+    Bone* bone = reinterpret_cast<Bone*>(ptr);
+    if (!name || !env->GetStringLength(name)) {
+        bone->setName("");
+        return;
+    }
+
+    const char* charName = env->GetStringUTFChars(name, NULL);
+    bone->setName(charName);
+    env->ReleaseStringUTFChars(name, charName);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBone_setBoneWeights(JNIEnv * env, jobject clz, jlong ptr,
+        jlongArray jArrayBoneWeights) {
+    Bone* bone = reinterpret_cast<Bone*>(ptr);
+    int arrlen;
+    if (!jArrayBoneWeights && !(arrlen = env->GetArrayLength(jArrayBoneWeights))) {
+        bone->setBoneWeights(std::vector<BoneWeight*>());
+        return;
+    }
+
+    jlong* ptr_arr = env->GetLongArrayElements(jArrayBoneWeights, JNI_FALSE);
+    std::vector<BoneWeight*> ptr_vec(arrlen);
+    for (int i = 0; i < arrlen; ++i)
+        ptr_vec[i] = reinterpret_cast<BoneWeight*>(ptr_arr[i]);
+    bone->setBoneWeights(std::move(ptr_vec));
+    env->ReleaseLongArrayElements(jArrayBoneWeights, ptr_arr, JNI_ABORT);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBone_setOffsetMatrix(JNIEnv * env, jobject clz, jlong ptr,
+        jfloatArray jOffsetMatrix) {
+    Bone* bone = reinterpret_cast<Bone*>(ptr);
+    if (!jOffsetMatrix)
+        return;
+
+    jfloat* mat_arr = env->GetFloatArrayElements(jOffsetMatrix, JNI_FALSE);
+    glm::mat4 matrix = glm::make_mat4x4(mat_arr);
+    bone->setOffsetMatrix(matrix);
+    env->ReleaseFloatArrayElements(jOffsetMatrix, mat_arr, JNI_ABORT);
+}
+
+JNIEXPORT jfloatArray JNICALL
+Java_org_gearvrf_NativeBone_getOffsetMatrix(JNIEnv * env, jobject clz, jlong ptr) {
+    Bone* bone = reinterpret_cast<Bone*>(ptr);
+
+    glm::mat4 matrix = bone->getOffsetMatrix();
+    jsize size = sizeof(matrix) / sizeof(jfloat);
+    if (size != 16) {
+        LOGE("sizeof(matrix) / sizeof(jfloat) != 16");
+        throw "sizeof(matrix) / sizeof(jfloat) != 16";
+    }
+    jfloatArray jmatrix = env->NewFloatArray(size);
+    env->SetFloatArrayRegion(jmatrix, 0, size, glm::value_ptr(matrix));
+
+    return jmatrix;
+}
+
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBone_setFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr,
+        jfloatArray jTransform) {
+    Bone* bone = reinterpret_cast<Bone*>(ptr);
+    if (!jTransform)
+        return;
+
+    jfloat* mat_arr = env->GetFloatArrayElements(jTransform, JNI_FALSE);
+    glm::mat4 matrix(glm::make_mat4x4(mat_arr));
+    bone->setFinalTransformMatrix(matrix);
+    env->ReleaseFloatArrayElements(jTransform, mat_arr, JNI_ABORT);
+}
+
+JNIEXPORT jfloatArray JNICALL
+Java_org_gearvrf_NativeBone_getFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr) {
+    Bone* bone = reinterpret_cast<Bone*>(ptr);
+
+    glm::mat4 matrix = bone->getFinalTransformMatrix();
+    jsize size = sizeof(matrix) / sizeof(jfloat);
+    if (size != 16) {
+        LOGE("sizeof(matrix) / sizeof(jfloat) != 16");
+        throw "sizeof(matrix) / sizeof(jfloat) != 16";
+    }
+    jfloatArray jmatrix = env->NewFloatArray(size);
+    env->SetFloatArrayRegion(jmatrix, 0, size, glm::value_ptr(matrix));
+
+    return jmatrix;
+}
+
+} // namespace gvr

--- a/GVRf/Framework/jni/objects/components/bone_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/bone_jni.cpp
@@ -63,7 +63,7 @@ Java_org_gearvrf_NativeBone_setBoneWeights(JNIEnv * env, jobject clz, jlong ptr,
         jlongArray jArrayBoneWeights) {
     Bone* bone = reinterpret_cast<Bone*>(ptr);
     int arrlen;
-    if (!jArrayBoneWeights && !(arrlen = env->GetArrayLength(jArrayBoneWeights))) {
+    if (!jArrayBoneWeights || !(arrlen = env->GetArrayLength(jArrayBoneWeights))) {
         bone->setBoneWeights(std::vector<BoneWeight*>());
         return;
     }

--- a/GVRf/Framework/jni/objects/components/bone_weight.cpp
+++ b/GVRf/Framework/jni/objects/components/bone_weight.cpp
@@ -1,0 +1,38 @@
+/***************************************************************************
+ * Bone for skeletal animation.
+ ***************************************************************************/
+
+#include "bone_weight.h"
+
+#include "glm/gtc/matrix_inverse.hpp"
+
+#include "util/gvr_log.h"
+
+namespace gvr {
+BoneWeight::BoneWeight()
+: Component()
+, vertexId_(0)
+, weight_(0)
+{
+}
+
+BoneWeight::~BoneWeight() {
+}
+
+void BoneWeight::setVertexId(int vertexId) {
+    vertexId_ = vertexId;
+}
+
+void BoneWeight::setWeight(float weight) {
+    weight_ = weight;
+}
+
+int BoneWeight::getVertexId() {
+    return vertexId_;
+}
+
+float BoneWeight::getWeight() {
+    return weight_;
+}
+
+}

--- a/GVRf/Framework/jni/objects/components/bone_weight.h
+++ b/GVRf/Framework/jni/objects/components/bone_weight.h
@@ -1,0 +1,33 @@
+/***************************************************************************
+ * Bone for skeletal animation.
+ ***************************************************************************/
+
+#ifndef BONE_WEIGHT_H_
+#define BONE_WEIGHT_H_
+
+#include "objects/components/component.h"
+
+namespace gvr {
+class BoneWeight: public Component {
+public:
+	BoneWeight();
+    virtual ~BoneWeight();
+
+    void setVertexId(int vertexId);
+    void setWeight(float weight);
+    int getVertexId();
+    float getWeight();
+
+private:
+    BoneWeight(const BoneWeight& boneWeight);
+    BoneWeight(BoneWeight&& boneWeight);
+    BoneWeight& operator=(const BoneWeight& boneWeight);
+    BoneWeight& operator=(BoneWeight&& boneWeight);
+
+private:
+    int vertexId_;
+    float weight_;
+};
+
+}
+#endif

--- a/GVRf/Framework/jni/objects/components/bone_weight_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/bone_weight_jni.cpp
@@ -1,0 +1,75 @@
+/***************************************************************************
+ * JNI
+ ***************************************************************************/
+
+#include "bone_weight.h"
+
+#include "util/gvr_jni.h"
+
+namespace gvr {
+extern "C" {
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeBoneWeight_ctor(JNIEnv * env, jobject clz);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBoneWeight_setVertexId(JNIEnv * env, jobject clz, jlong ptr,
+        int vertexId);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBoneWeight_setWeight(JNIEnv * env, jobject clz, jlong ptr,
+        jfloat weight);
+
+JNIEXPORT int JNICALL
+Java_org_gearvrf_NativeBoneWeight_getVertexId(JNIEnv * env, jobject clz, jlong ptr);
+
+JNIEXPORT float JNICALL
+Java_org_gearvrf_NativeBoneWeight_getWeight(JNIEnv * env, jobject clz, jlong ptr);
+}
+;
+
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeBoneWeight_ctor(JNIEnv * env, jobject obj) {
+    return reinterpret_cast<jlong>(new BoneWeight());
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBoneWeight_setVertexId(JNIEnv * env, jobject clz, jlong ptr,
+        int vertexId) {
+    BoneWeight *boneWeight = reinterpret_cast<BoneWeight *>(ptr);
+    boneWeight->setVertexId(vertexId);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBoneWeight_setWeight(JNIEnv * env, jobject clz, jlong ptr,
+        jfloat weight) {
+    BoneWeight *boneWeight = reinterpret_cast<BoneWeight *>(ptr);
+    boneWeight->setWeight(weight);
+}
+
+JNIEXPORT int JNICALL
+Java_org_gearvrf_NativeBoneWeight_getVertexId(JNIEnv * env, jobject clz, jlong ptr,
+        int vertexId) {
+    BoneWeight *boneWeight = reinterpret_cast<BoneWeight *>(ptr);
+    return boneWeight->getVertexId();
+}
+
+JNIEXPORT float JNICALL
+Java_org_gearvrf_NativeBoneWeight_getWeight(JNIEnv * env, jobject clz, jlong ptr,
+        jfloat weight) {
+    BoneWeight *boneWeight = reinterpret_cast<BoneWeight *>(ptr);
+    return boneWeight->getWeight();
+}
+
+JNIEXPORT int JNICALL
+Java_org_gearvrf_NativeBoneWeight_getVertexId(JNIEnv * env, jobject clz, jlong ptr) {
+    BoneWeight *boneWeight = reinterpret_cast<BoneWeight *>(ptr);
+    return boneWeight->getVertexId();
+}
+
+JNIEXPORT float JNICALL
+Java_org_gearvrf_NativeBoneWeight_getWeight(JNIEnv * env, jobject clz, jlong ptr) {
+    BoneWeight *boneWeight = reinterpret_cast<BoneWeight *>(ptr);
+    return boneWeight->getWeight();
+}
+
+}

--- a/GVRf/Framework/jni/objects/components/transform.cpp
+++ b/GVRf/Framework/jni/objects/components/transform.cpp
@@ -81,6 +81,15 @@ glm::mat4 Transform::getModelMatrix() {
     return model_matrix_.element();
 }
 
+glm::mat4 Transform::getLocalModelMatrix() {
+    glm::mat4 translation_matrix = glm::translate(glm::mat4(), position_);
+    glm::mat4 rotation_matrix = glm::mat4_cast(rotation_);
+    glm::mat4 scale_matrix = glm::scale(glm::mat4(), scale_);
+    glm::mat4 trs_matrix = translation_matrix * rotation_matrix
+            * scale_matrix;
+    return trs_matrix;
+}
+
 void Transform::setModelMatrix(glm::mat4 matrix) {
 
 	glm::vec3 new_position(matrix[3][0], matrix[3][1], matrix[3][2]);

--- a/GVRf/Framework/jni/objects/components/transform.h
+++ b/GVRf/Framework/jni/objects/components/transform.h
@@ -169,6 +169,7 @@ public:
 
     void invalidate(bool rotationUpdated);
     glm::mat4 getModelMatrix();
+    glm::mat4 getLocalModelMatrix();
     void translate(float x, float y, float z);
     void setRotationByAxis(float angle, float x, float y, float z);
     void rotate(float w, float x, float y, float z);

--- a/GVRf/Framework/jni/objects/components/transform_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/transform_jni.cpp
@@ -108,6 +108,10 @@ JNIEXPORT jfloatArray JNICALL
 Java_org_gearvrf_NativeTransform_getModelMatrix(JNIEnv * env,
         jobject obj, jlong jtransform);
 
+JNIEXPORT jfloatArray JNICALL
+Java_org_gearvrf_NativeTransform_getLocalModelMatrix(JNIEnv * env,
+        jobject obj, jlong jtransform);
+
 JNIEXPORT void JNICALL
 Java_org_gearvrf_NativeTransform_setModelMatrix(JNIEnv * env,
         jobject obj, jlong jtransform, jfloatArray mat);
@@ -310,6 +314,21 @@ Java_org_gearvrf_NativeTransform_getModelMatrix(JNIEnv * env,
         jobject obj, jlong jtransform) {
     Transform* transform = reinterpret_cast<Transform*>(jtransform);
     glm::mat4 matrix = transform->getModelMatrix();
+    jsize size = sizeof(matrix) / sizeof(jfloat);
+    if (size != 16) {
+        LOGE("sizeof(matrix) / sizeof(jfloat) != 16");
+        throw "sizeof(matrix) / sizeof(jfloat) != 16";
+    }
+    jfloatArray jmatrix = env->NewFloatArray(size);
+    env->SetFloatArrayRegion(jmatrix, 0, size, glm::value_ptr(matrix));
+    return jmatrix;
+}
+
+JNIEXPORT jfloatArray JNICALL
+Java_org_gearvrf_NativeTransform_getLocalModelMatrix(JNIEnv * env,
+        jobject obj, jlong jtransform) {
+    Transform* transform = reinterpret_cast<Transform*>(jtransform);
+    glm::mat4 matrix = transform->getLocalModelMatrix();
     jsize size = sizeof(matrix) / sizeof(jfloat);
     if (size != 16) {
         LOGE("sizeof(matrix) / sizeof(jfloat) != 16");

--- a/GVRf/Framework/jni/objects/components/vertex_bone_data_jni.cpp
+++ b/GVRf/Framework/jni/objects/components/vertex_bone_data_jni.cpp
@@ -1,0 +1,58 @@
+/***************************************************************************
+ * JNI
+ ***************************************************************************/
+
+#include "glm/glm.hpp"
+#include "glm/gtc/type_ptr.hpp"
+
+#include "objects/components/bone.h"
+#include "objects/mesh.h"
+
+#include "util/gvr_jni.h"
+
+namespace gvr {
+extern "C" {
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeVertexBoneData_get(JNIEnv * env, jclass clz, jlong mesh);
+
+JNIEXPORT jint JNICALL
+Java_org_gearvrf_NativeVertexBoneData_getFreeBoneSlot(JNIEnv * env, jclass clz, jlong ptr,
+        jint vertexId);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeVertexBoneData_setVertexBoneWeight(JNIEnv * env, jclass clz, jlong ptr,
+        jint vertexId, jint boneSlot, jint boneId, jfloat boneWeight);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeVertexBoneData_normalizeWeights(JNIEnv * env, jclass clz, jlong ptr);
+
+} // extern "C"
+;
+
+JNIEXPORT jlong JNICALL
+Java_org_gearvrf_NativeVertexBoneData_get(JNIEnv * env, jclass clz, jlong jmesh) {
+    Mesh *mesh = reinterpret_cast<Mesh*>(jmesh);
+    return reinterpret_cast<jlong>(&mesh->getVertexBoneData());
+}
+
+JNIEXPORT jint JNICALL
+Java_org_gearvrf_NativeVertexBoneData_getFreeBoneSlot(JNIEnv * env, jclass clz, jlong ptr,
+        jint vertexId) {
+    VertexBoneData *boneData = reinterpret_cast<VertexBoneData*>(ptr);
+    return boneData->getFreeBoneSlot(vertexId);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeVertexBoneData_setVertexBoneWeight(JNIEnv * env, jclass clz, jlong ptr,
+        jint vertexId, jint boneSlot, jint boneId, jfloat boneWeight) {
+    VertexBoneData *boneData = reinterpret_cast<VertexBoneData*>(ptr);
+    boneData->setVertexBoneWeight(vertexId, boneSlot, boneId, boneWeight);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeVertexBoneData_normalizeWeights(JNIEnv * env, jclass clz, jlong ptr) {
+    VertexBoneData *boneData = reinterpret_cast<VertexBoneData*>(ptr);
+    boneData->normalizeWeights();
+}
+
+} // namespace gvr

--- a/GVRf/Framework/jni/objects/material.h
+++ b/GVRf/Framework/jni/objects/material.h
@@ -45,6 +45,7 @@ public:
         TEXTURE_SHADER = 7,
         EXTERNAL_RENDERER_SHADER = 8,
         ASSIMP_SHADER = 9,
+        DISTORTION_SHADER = 90, // this shader is implemented and loaded in the distorter
         TEXTURE_SHADER_NOLIGHT = 100
     };
 

--- a/GVRf/Framework/jni/objects/material.h
+++ b/GVRf/Framework/jni/objects/material.h
@@ -45,7 +45,6 @@ public:
         TEXTURE_SHADER = 7,
         EXTERNAL_RENDERER_SHADER = 8,
         ASSIMP_SHADER = 9,
-        DISTORTION_SHADER = 90, // this shader is implemented and loaded in the distorter
         TEXTURE_SHADER_NOLIGHT = 100
     };
 

--- a/GVRf/Framework/jni/objects/mesh.cpp
+++ b/GVRf/Framework/jni/objects/mesh.cpp
@@ -289,4 +289,44 @@ void Mesh::generateVAO() {
 #endif
 }
 
+void Mesh::generateBoneArrayBuffers() {
+    if (!bone_data_dirty_) {
+        return;
+    }
+
+    // delete
+    if (boneVboID_ != GVR_INVALID) {
+        gl_delete.queueBuffer(boneVboID_);
+        boneVboID_ = GVR_INVALID;
+    }
+
+    int nVertices = vertices().size();
+    if (!vertexBoneData_.getNumBones() || !nVertices) {
+        LOGV("no bones or vertices");
+        return;
+    }
+
+    glBindVertexArray(vaoID_);
+
+    // BoneID
+    GLuint boneVboID;
+    glGenBuffers(1, &boneVboID);
+    glBindBuffer(GL_ARRAY_BUFFER, boneVboID);
+    glBufferData(GL_ARRAY_BUFFER,
+            sizeof(vertexBoneData_.boneData[0]) * vertexBoneData_.boneData.size(),
+            &vertexBoneData_.boneData[0], GL_STATIC_DRAW);
+    glEnableVertexAttribArray(getBoneIndicesLoc());
+    glVertexAttribIPointer(getBoneIndicesLoc(), 4, GL_INT, sizeof(VertexBoneData::BoneData), (const GLvoid*) 0);
+
+    // BoneWeight
+    glEnableVertexAttribArray(getBoneWeightsLoc());
+    glVertexAttribPointer(getBoneWeightsLoc(), 4, GL_FLOAT, GL_FALSE, sizeof(VertexBoneData::BoneData),
+            (const GLvoid*) (sizeof(VertexBoneData::BoneData::ids)));
+
+    boneVboID_ = boneVboID;
+
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
 }

--- a/GVRf/Framework/jni/objects/mesh.h
+++ b/GVRf/Framework/jni/objects/mesh.h
@@ -20,7 +20,6 @@
 #ifndef MESH_H_
 #define MESH_H_
 
-#include <algorithm>
 #include <map>
 #include <memory>
 #include <vector>

--- a/GVRf/Framework/jni/objects/mesh.h
+++ b/GVRf/Framework/jni/objects/mesh.h
@@ -20,6 +20,7 @@
 #ifndef MESH_H_
 #define MESH_H_
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <vector>
@@ -33,9 +34,13 @@
 #include "gl/gl_buffer.h"
 #include "gl/gl_program.h"
 
+#include "util/gvr_gl.h"
+
+#include "objects/components/bone.h"
 #include "objects/hybrid_object.h"
 #include "objects/material.h"
 #include "objects/bounding_volume.h"
+#include "objects/vertex_bone_data.h"
 
 #include "engine/memory/gl_delete.h"
 
@@ -46,7 +51,8 @@ public:
             vertices_(), normals_(), tex_coords_(), indices_(), float_vectors_(), vec2_vectors_(), vec3_vectors_(), vec4_vectors_(),
                     have_bounding_volume_(false), vao_dirty_(true),
                     vaoID_(GVR_INVALID), triangle_vboID_(GVR_INVALID), vert_vboID_(GVR_INVALID),
-                    norm_vboID_(GVR_INVALID), tex_vboID_(GVR_INVALID)
+                    norm_vboID_(GVR_INVALID), tex_vboID_(GVR_INVALID),
+                    boneVboID_(GVR_INVALID), vertexBoneData_(this), bone_data_dirty_(true)
     {
     }
 
@@ -81,6 +87,7 @@ public:
         have_bounding_volume_ = false;
         vao_dirty_ = true;
         vaoID_ = triangle_vboID_ = vert_vboID_ = norm_vboID_ = tex_vboID_ = GVR_INVALID;
+        bone_data_dirty_ = true;
     }
 
     const std::vector<glm::vec3>& vertices() const {
@@ -226,6 +233,19 @@ public:
     // /////////////////////////////////////////////////
     //  code for vertex attribute location
 
+    void setBoneLoc(GLuint boneIndicesLoc, GLuint boneWeightsLoc) {
+        boneIndicesLoc_ = boneIndicesLoc;
+        boneWeightsLoc_ = boneWeightsLoc;
+    }
+
+    GLuint getBoneIndicesLoc() {
+        return boneIndicesLoc_;
+    }
+
+    GLuint getBoneWeightsLoc() {
+        return boneWeightsLoc_;
+    }
+
     void setVertexAttribLocF(GLuint location, std::string key) {
         attribute_float_keys_[location] = key;
         vao_dirty_ = true;
@@ -258,6 +278,21 @@ public:
     }
 
     const BoundingVolume& getBoundingVolume();
+
+    bool hasBones() const {
+        return vertexBoneData_.getNumBones();
+    }
+
+    void setBones(std::vector<Bone*>&& bones) {
+        vertexBoneData_.setBones(std::move(bones));
+        bone_data_dirty_ = true;
+    }
+
+    VertexBoneData &getVertexBoneData() {
+        return vertexBoneData_;
+    }
+
+    void generateBoneArrayBuffers();
 
 private:
     Mesh(const Mesh& mesh);
@@ -294,6 +329,14 @@ private:
 
     bool have_bounding_volume_;
     BoundingVolume bounding_volume;
+
+    // Bone data for the shader
+    VertexBoneData vertexBoneData_;
+    GLuint boneIndicesLoc_;
+    GLuint boneWeightsLoc_;
+
+    GLuint boneVboID_;
+    bool bone_data_dirty_;
 };
 }
 #endif

--- a/GVRf/Framework/jni/objects/mesh_jni.cpp
+++ b/GVRf/Framework/jni/objects/mesh_jni.cpp
@@ -385,16 +385,6 @@ Java_org_gearvrf_NativeMesh_getBoundingBox(JNIEnv * env,
 }
 
 JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeMesh_animate(JNIEnv * env,
-        jobject obj, jlong jmesh, jfloat jTimeInSeconds) {
-    Mesh* mesh = reinterpret_cast<Mesh*>(jmesh);
-
-    float timeInSeconds = jTimeInSeconds;
-
-    mesh->animate(timeInSeconds);
-}
-
-JNIEXPORT void JNICALL
 Java_org_gearvrf_NativeMesh_setBones(JNIEnv * env, jobject obj, jlong jmesh,
         jlongArray jBonePtrArray) {
 	Mesh* mesh = reinterpret_cast<Mesh*>(jmesh);

--- a/GVRf/Framework/jni/objects/mesh_jni.cpp
+++ b/GVRf/Framework/jni/objects/mesh_jni.cpp
@@ -94,6 +94,10 @@ Java_org_gearvrf_NativeMesh_setVec4Vector(JNIEnv * env,
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeMesh_getBoundingBox(JNIEnv * env,
         jobject obj, jlong jmesh);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeMesh_setBones(JNIEnv * env,
+        jobject obj, jlong jmesh, jlongArray jBonePtrArray);
 }
 ;
 
@@ -378,6 +382,36 @@ Java_org_gearvrf_NativeMesh_getBoundingBox(JNIEnv * env,
         jobject obj, jlong jmesh) {
     Mesh* mesh = reinterpret_cast<Mesh*>(jmesh);
     return reinterpret_cast<jlong>(mesh->getBoundingBox());
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeMesh_animate(JNIEnv * env,
+        jobject obj, jlong jmesh, jfloat jTimeInSeconds) {
+    Mesh* mesh = reinterpret_cast<Mesh*>(jmesh);
+
+    float timeInSeconds = jTimeInSeconds;
+
+    mesh->animate(timeInSeconds);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeMesh_setBones(JNIEnv * env, jobject obj, jlong jmesh,
+        jlongArray jBonePtrArray) {
+	Mesh* mesh = reinterpret_cast<Mesh*>(jmesh);
+	int arrlen;
+	if (!jBonePtrArray || !(arrlen = env->GetArrayLength(jBonePtrArray))) {
+	    mesh->setBones(std::vector<Bone*>());
+	    return;
+	}
+
+	jlong* bonesPtr = env->GetLongArrayElements(jBonePtrArray, JNI_FALSE);
+	std::vector<Bone*> bonesVec(arrlen);
+	for (int i = 0; i < arrlen; ++i) {
+	    bonesVec[i] = reinterpret_cast<Bone*>(bonesPtr[i]);
+	}
+	mesh->setBones(std::move(bonesVec));
+
+	env->ReleaseLongArrayElements(jBonePtrArray, bonesPtr, JNI_ABORT);
 }
 
 }

--- a/GVRf/Framework/jni/objects/vertex_bone_data.cpp
+++ b/GVRf/Framework/jni/objects/vertex_bone_data.cpp
@@ -68,28 +68,8 @@ void VertexBoneData::normalizeWeights() {
             for (int j = 0; j < BONES_PER_VERTEX; ++j) {
                 boneData[i].weights[j] /= wtSum;
             }
-        } else {
-            LOGV("WARNING: unanimated vertex: %d", i);
         }
     }
-
-    //!DEBUG
-    /*
-    for (int i = 0; i < size; ++i) {
-        glm::mat4 bone(0.f);
-        for (int j = 0; j < BONES_PER_VERTEX; ++j) {
-            bone += boneData[i].weights[j] * boneMatrices[boneData[i].ids[j]];
-        }
-        bone -= glm::mat4(1.0f);
-        float sum = 0.f;
-        for (int i = 0; i < 4; ++i)
-            for (int j = 0; j < 4; ++j)
-                sum += fabs(bone[i][j]);
-        if (sum > 1.f) {
-            LOGV("WARNING: default bone matrix is not identity: vertex %d, diff %f", i, sum);
-        }
-    }
-    */
 }
 
 } // namespace gvr

--- a/GVRf/Framework/jni/objects/vertex_bone_data.cpp
+++ b/GVRf/Framework/jni/objects/vertex_bone_data.cpp
@@ -1,0 +1,95 @@
+/***************************************************************************
+ * Holds dynamic data for the bones
+ ***************************************************************************/
+
+#include <math.h>
+#include "scene.h"
+#include "objects/vertex_bone_data.h"
+#include "objects/components/bone.h"
+#include "util/gvr_log.h"
+
+#define TOL 1e-6
+
+namespace gvr {
+
+VertexBoneData::VertexBoneData(Mesh *mesh)
+: mesh(mesh)
+, bones()
+, boneMatrices()
+, boneData()
+{
+}
+
+void VertexBoneData::setBones(std::vector<Bone*>&& bonesVec) {
+    bones = std::move(bonesVec);
+
+    boneMatrices.clear();
+    boneMatrices.resize(bones.size());
+
+    if (bones.empty())
+        return;
+
+    int vertexNum(mesh->vertices().size());
+    boneData.clear();
+    boneData.resize(vertexNum);
+
+    auto itMat = boneMatrices.begin();
+    for (auto it = bones.begin(); it != bones.end(); ++it, ++itMat) {
+        (*it)->setFinalTransformMatrixPtr(&*itMat);
+    }
+}
+
+int VertexBoneData::getFreeBoneSlot(int vertexId) {
+    int vertexNum(mesh->vertices().size());
+    if (vertexId < 0 || vertexId > vertexNum) {
+        LOGD("Bad vertex id %d vertices %d", vertexId, vertexNum);
+        return -1;
+    }
+
+    return boneData[vertexId].getFreeBoneSlot();
+}
+
+void VertexBoneData::setVertexBoneWeight(int vertexId, int boneSlot, int boneId, float boneWeight) {
+    boneData[vertexId].ids[boneSlot] = boneId;
+    boneData[vertexId].weights[boneSlot] = boneWeight;
+}
+
+void VertexBoneData::normalizeWeights() {
+    if (bones.empty())
+        return;
+
+    int size = mesh->vertices().size();
+    for (int i = 0; i < size; ++i) {
+        float wtSum = 0.f;
+        for (int j = 0; j < BONES_PER_VERTEX; ++j) {
+            wtSum += boneData[i].weights[j];
+        }
+        if (fabs(wtSum) > TOL) {
+            for (int j = 0; j < BONES_PER_VERTEX; ++j) {
+                boneData[i].weights[j] /= wtSum;
+            }
+        } else {
+            LOGV("WARNING: unanimated vertex: %d", i);
+        }
+    }
+
+    //!DEBUG
+    /*
+    for (int i = 0; i < size; ++i) {
+        glm::mat4 bone(0.f);
+        for (int j = 0; j < BONES_PER_VERTEX; ++j) {
+            bone += boneData[i].weights[j] * boneMatrices[boneData[i].ids[j]];
+        }
+        bone -= glm::mat4(1.0f);
+        float sum = 0.f;
+        for (int i = 0; i < 4; ++i)
+            for (int j = 0; j < 4; ++j)
+                sum += fabs(bone[i][j]);
+        if (sum > 1.f) {
+            LOGV("WARNING: default bone matrix is not identity: vertex %d, diff %f", i, sum);
+        }
+    }
+    */
+}
+
+} // namespace gvr

--- a/GVRf/Framework/jni/objects/vertex_bone_data.h
+++ b/GVRf/Framework/jni/objects/vertex_bone_data.h
@@ -31,7 +31,7 @@
 #include "glm/geometric.hpp"
 #include "util/gvr_log.h"
 
-#define MAX_BONES 100
+#define MAX_BONES 60
 #define BONES_PER_VERTEX 4
 
 namespace gvr {

--- a/GVRf/Framework/jni/objects/vertex_bone_data.h
+++ b/GVRf/Framework/jni/objects/vertex_bone_data.h
@@ -1,0 +1,98 @@
+
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/***************************************************************************
+ * The vertex_bone_data for rendering.
+ ***************************************************************************/
+
+#ifndef VERTEX_BONE_DATA_H_
+#define VERTEX_BONE_DATA_H_
+
+#include <map>
+#include <memory>
+#include <vector>
+#include <stdint.h>
+#include <string>
+
+#include "glm/glm.hpp"
+#include "glm/geometric.hpp"
+#include "util/gvr_log.h"
+
+#define MAX_BONES 100
+#define BONES_PER_VERTEX 4
+
+namespace gvr {
+class Bone;
+class Mesh;
+class VertexBoneData {
+public:
+    VertexBoneData(Mesh *mesh);
+    void setBones(std::vector<Bone*>&& bonesVec);
+
+    int getNumBones() const {
+        return bones.size();
+    }
+
+    glm::mat4 getFinalBoneTransform(int boneId) {
+        return boneMatrices[boneId];
+    }
+
+    void setFinalBoneTransform(int boneId, glm::mat4 &transform) {
+        boneMatrices[boneId] = transform;
+    }
+
+    int getFreeBoneSlot(int vertexId);
+    void setVertexBoneWeight(int vertexId, int boneSlot, int boneId, float boneWeight);
+    void normalizeWeights();
+
+    struct BoneData {
+        uint32_t ids[BONES_PER_VERTEX];
+        float weights[BONES_PER_VERTEX];
+
+        BoneData() {
+            reset();
+        }
+
+        void reset() {
+            for(int i = 0; i < BONES_PER_VERTEX; i++) {
+                ids[i] = 0;
+                weights[i]=0;
+            }
+        }
+
+        int getFreeBoneSlot() {
+            for (int i = 0; i < sizeof(ids) / sizeof(ids[0]); i++) {
+                if (weights[i] == 0.0) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+    } __attribute__((packed, aligned(4)));
+
+public:
+    std::vector<glm::mat4>  boneMatrices;
+    std::vector<BoneData>   boneData;
+
+private:
+    Mesh *mesh;
+
+    // Static bone data loaded from model
+    std::vector<Bone*> bones;
+};
+
+} // namespace gvr
+#endif

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
@@ -41,6 +41,9 @@ static const char NO_SKINNING[] = "#undef AS_SKINNING\n";
 static const char SPECULAR_TEXTURE[] = "#define AS_SPECULAR_TEXTURE\n";
 static const char NO_SPECULAR_TEXTURE[] = "#undef AS_SPECULAR_TEXTURE\n";
 
+#define STR_(x) #x
+#define STR(x) STR_(x)
+
 static const char VERTEX_SHADER[] =
                 "precision highp float;\n"
                 "\n"
@@ -57,7 +60,8 @@ static const char VERTEX_SHADER[] =
                 "#ifdef AS_SKINNING\n"
                 "attribute vec4 a_bone_indices;\n"
                 "attribute vec4 a_bone_weights;\n"
-                "uniform mat4 u_bone_matrix[100];\n" // MAX_BONE_NUM = 100
+                "const int MAX_BONES = " STR(MAX_BONES) ";\n"
+                "uniform mat4 u_bone_matrix[MAX_BONES];\n"
                 "#endif\n"
                 "\n"
 

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
@@ -28,6 +28,8 @@
 
 #include "util/gvr_log.h"
 
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
 namespace gvr {
 
 #define AS_TOTAL_SHADER_STRINGS_COUNT    AS_TOTAL_FEATURE_COUNT + 1
@@ -258,7 +260,8 @@ void AssimpShader::render(const glm::mat4& mv_matrix,
         mesh->generateBoneArrayBuffers();
 
         glm::mat4 finalTransform;
-        for (int i = 0; i < mesh->getVertexBoneData().getNumBones(); ++i) {
+        int nBones = MIN(mesh->getVertexBoneData().getNumBones(), MAX_BONES);
+        for (int i = 0; i < nBones; ++i) {
             char name[64];
             memset(name, 0, sizeof(name));
             snprintf(name, sizeof(name), "u_bone_matrix[%d]", i);

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.cpp
@@ -262,6 +262,10 @@ void AssimpShader::render(const glm::mat4& mv_matrix,
     if (ISSET(feature_set, AS_SKINNING)) {
         a_bone_indices_ = glGetAttribLocation(program_->id(), "a_bone_indices");
         a_bone_weights_ = glGetAttribLocation(program_->id(), "a_bone_weights");
+        u_bone_matrices_ = glGetUniformLocation(program_->id(), "u_bone_matrix[0]");
+        if (u_bone_matrices_ == -1) {
+            LOGD("Warning! Unable to get the location of uniform u_bone_matrix[0]\n");
+        }
 
         mesh->setBoneLoc(a_bone_indices_, a_bone_weights_);
         mesh->generateBoneArrayBuffers();
@@ -269,17 +273,8 @@ void AssimpShader::render(const glm::mat4& mv_matrix,
         glm::mat4 finalTransform;
         int nBones = MIN(mesh->getVertexBoneData().getNumBones(), MAX_BONES);
         for (int i = 0; i < nBones; ++i) {
-            char name[64];
-            memset(name, 0, sizeof(name));
-            snprintf(name, sizeof(name), "u_bone_matrix[%d]", i);
-
-            int32_t loc = glGetUniformLocation(program_->id(), name);
-            if (loc == -1) {
-                LOGD("Warning! Unable to get the location of uniform '%s'\n", name);
-            }
-
             finalTransform = mesh->getVertexBoneData().getFinalBoneTransform(i);
-            glUniformMatrix4fv(loc, 1, GL_FALSE, glm::value_ptr(finalTransform));
+            glUniformMatrix4fv(u_bone_matrices_ + i, 1, GL_FALSE, glm::value_ptr(finalTransform));
         }
     }
 

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.h
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.h
@@ -83,6 +83,7 @@ private:
     // Bones
     GLuint a_bone_indices_;
     GLuint a_bone_weights_;
+    GLuint u_bone_matrices_;
 };
 
 }

--- a/GVRf/Framework/jni/shaders/material/assimp_shader.h
+++ b/GVRf/Framework/jni/shaders/material/assimp_shader.h
@@ -32,8 +32,10 @@
 #define ISSET(num, i)                    ((num & (1 << i)) != 0)
 #define CLEARBIT(num, i)                 num = (num & ~(1 << i))
 
-#define AS_DIFFUSE_TEXTURE                0x00000000
-#define AS_SPECULAR_TEXTURE               0x00000001
+// Indices of feature bits
+#define AS_DIFFUSE_TEXTURE                0
+#define AS_SPECULAR_TEXTURE               1
+#define AS_SKINNING                       2
 
 /*
  * As the features are incremented, need to increase AS_TOTAL_FEATURE_COUNT
@@ -44,8 +46,8 @@
  * AS_TOTAL_GL_PROGRAM_COUNT = 8
  *
  */
-#define AS_TOTAL_FEATURE_COUNT            2
-#define AS_TOTAL_GL_PROGRAM_COUNT         4
+#define AS_TOTAL_FEATURE_COUNT            3
+#define AS_TOTAL_GL_PROGRAM_COUNT         (1 << AS_TOTAL_FEATURE_COUNT)
 
 namespace gvr {
 class GLProgram;
@@ -77,6 +79,10 @@ private:
     GLuint u_ambient_color_;
     GLuint u_color_;
     GLuint u_opacity_;
+
+    // Bones
+    GLuint a_bone_indices_;
+    GLuint a_bone_weights_;
 };
 
 }

--- a/GVRf/Framework/src/org/gearvrf/GVRBone.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRBone.java
@@ -1,0 +1,219 @@
+package org.gearvrf;
+
+import java.nio.FloatBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gearvrf.jassimp.AiWrapperProvider;
+import org.gearvrf.utility.Log;
+import org.joml.Matrix4f;
+
+/**
+ * A single bone of a mesh.<p>
+ *
+ * A bone has a name by which it can be found in the frame hierarchy and by
+ * which it can be addressed by animations. In addition it has a number of
+ * influences on vertices. <p>
+ *
+ * This class is designed to be mutable, i.e., the returned collections are
+ * writable and may be modified. <p>
+ *
+ * Instantaneous pose of the bone during animation is not part of this class,
+ * but in {@code GVRSkeleton}. This allows multiple instances of the same mesh
+ * and bones.
+ */
+public final class GVRBone extends GVRComponent implements PrettyPrint {
+    /**
+     * Constructor.
+     */
+    public GVRBone(GVRContext gvrContext) {
+        super(gvrContext, NativeBone.ctor());
+        mBoneWeights = new ArrayList<GVRBoneWeight>();
+    }
+
+    /**
+     * Sets the name of the bone.
+     * 
+     * @param name the name of the bone.
+     */
+    public void setName(String name) {
+        mName = name == null ? null : new String(name);
+        NativeBone.setName(getNative(), mName);
+    }
+
+    /**
+     * Returns the name of the bone.
+     *
+     * @return the name
+     */
+    public String getName() {
+        // Name is currently read-only for native code. So it is
+        // not updated from native object.
+        return mName;
+    }
+
+    /**
+     * Sets the list of bone weights.
+     * 
+     * @param boneWeights the list of weights
+     */
+    public void setBoneWeights(List<GVRBoneWeight> boneWeights) {
+        mBoneWeights.clear();
+        mBoneWeights.addAll(boneWeights);
+        NativeBone.setBoneWeights(getNative(),
+                                  GVRHybridObject.getNativePtrArray(boneWeights));
+    }
+
+    /**
+     * Returns a list of bone weights.
+     *
+     * @return the bone weights
+     */
+    public List<GVRBoneWeight> getBoneWeights() {
+        return mBoneWeights;
+    }
+
+    public void setOffsetMatrix(float[] offsetMatrix) {
+        NativeBone.setOffsetMatrix(getNative(), offsetMatrix);
+    }
+
+    /**
+     * Sets the final transform of the bone during animation.
+     *
+     * @param finalTransform The transform matrix representing
+     * the bone's pose after computing the skeleton.
+     */
+    public void setFinalTransformMatrix(float[] finalTransform) {
+        NativeBone.setFinalTransformMatrix(getNative(), finalTransform);
+    }
+
+    /**
+     * Sets the final transform of the bone during animation.
+     *
+     * @param finalTransform The transform matrix representing
+     * the bone's pose after computing the skeleton.
+     */
+    public void setFinalTransformMatrix(Matrix4f finalTransform) {
+        float[] mat = new float[16];
+        finalTransform.get(mat);
+        NativeBone.setFinalTransformMatrix(getNative(), mat);
+    }
+
+    /**
+     * Gets the final transform of the bone.
+     *
+     * @return the 4x4 matrix representing the final transform of the
+     * bone during animation, which comprises bind pose and skeletal
+     * transform at the current time of the animation.
+     */
+    public Matrix4f getFinalTransformMatrix() {
+        return new Matrix4f(FloatBuffer.wrap(NativeBone.getFinalTransformMatrix(getNative())));
+    }
+
+    /**
+     * Returns the offset matrix.<p>
+     *
+     * The offset matrix is a 4x4 matrix that transforms from mesh space to
+     * bone space in bind pose.<p>
+     *
+     * This method is part of the wrapped API (see {@link AiWrapperProvider}
+     * for details on wrappers).
+     *
+     * @param wrapperProvider the wrapper provider (used for type inference)
+     *
+     * @return the offset matrix
+     */
+    public Matrix4f getOffsetMatrix() {
+        Matrix4f offsetMatrix = new Matrix4f();
+        offsetMatrix.set(NativeBone.getOffsetMatrix(getNative()));
+        return offsetMatrix;
+    }
+
+    /**
+     * Gets the scene object of this bone.
+     *
+     * @return the scene object that represents this bone in a
+     *         hierarchy of bones.
+     */
+    public GVRSceneObject getSceneObject() {
+        return mSceneObject;
+    }
+
+    /**
+     * Sets the scene object of this bone.
+     *
+     * @param sceneObject The scene object that represents this
+     * bone in a hierarchy of bones.
+     */
+    public void setSceneObject(GVRSceneObject sceneObject) {
+        mSceneObject = sceneObject;
+    }
+
+    /**
+     * Pretty-print the object.
+     */
+    @Override
+    public void prettyPrint(StringBuffer sb, int indent) {
+        sb.append(Log.getSpaces(indent));
+        sb.append(GVRBone.class.getSimpleName());
+        sb.append(" [name=" + getName()
+                + ", offsetMatrix=" + getOffsetMatrix()
+                + ", finalTransformMatrix=" + getFinalTransformMatrix()
+                + "]");
+        sb.append(System.lineSeparator());
+
+        final int maxWeightsToPrint = 80;
+        int cntPrinted = 0;
+        sb.append(Log.getSpaces(indent + 2));
+        sb.append("Bone weights: [");
+        for (GVRBoneWeight wt : getBoneWeights()) {
+            if (cntPrinted != 0)
+                sb.append(", ");
+            sb.append(wt.toString());
+            if (++cntPrinted >= maxWeightsToPrint) {
+                if (getBoneWeights().size() > maxWeightsToPrint) {
+                    sb.append("...");
+                }
+                break;
+            }
+        }
+        sb.append("]");
+        sb.append(System.lineSeparator());
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        prettyPrint(sb, 0);
+        return sb.toString();
+    }
+
+    /**
+     * Name of the bone.
+     */
+    private String mName;
+
+    /**
+     * Bone weights.
+     */
+    private final List<GVRBoneWeight> mBoneWeights;
+
+    /**
+     * The scene object that represents the transforms of the
+     * bone.
+     */
+    private GVRSceneObject mSceneObject;
+}
+
+class NativeBone {
+    static native long ctor();
+    static native void setName(long object, String mName);
+    static native void setBoneWeights(long object, long[] nativePtrArray);
+    static native void setOffsetMatrix(long object, float[] offsetMatrix);
+    static native float[] getOffsetMatrix(long object);
+    static native void setFinalTransformMatrix(long object, float[] offsetMatrix);
+    static native float[] getFinalTransformMatrix(long object);
+}

--- a/GVRf/Framework/src/org/gearvrf/GVRBoneWeight.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRBoneWeight.java
@@ -1,0 +1,65 @@
+package org.gearvrf;
+
+/**
+ * A single influence of a bone on a vertex.
+ */
+public final class GVRBoneWeight extends GVRHybridObject {
+    /**
+     * Constructor.
+     */
+    public GVRBoneWeight(GVRContext gvrContext) {
+        super(gvrContext, NativeBoneWeight.ctor());
+    }
+
+    /**
+     * Sets the index of the vertex which is influenced by the bone.
+     *
+     * @param vertexId the vertex index
+     */
+    public void setVertexId(int vertexId) {
+        NativeBoneWeight.setVertexId(getNative(), vertexId);
+    }
+
+    /**
+     * Gets the index of the vertex which is influenced by the bone.
+     *
+     * @return the vertex index
+     */
+    public int getVertexId() {
+        return NativeBoneWeight.getVertexId(getNative());
+    }
+
+    /**
+     * Sets the strength of the influence in the range (0...1). <p>
+     * The influence from all bones at one vertex amounts to 1.
+     *
+     * @param weight the influence
+     */
+    public void setWeight(float weight) {
+        NativeBoneWeight.setWeight(getNative(), weight);
+    }
+
+    /**
+     * The strength of the influence in the range (0...1).<p>
+     *
+     * The influence from all bones at one vertex amounts to 1
+     *
+     * @return the influence
+     */
+    public float getWeight() {
+        return NativeBoneWeight.getWeight(getNative());
+    }
+
+    @Override
+    public String toString() {
+        return "[vid=" + getVertexId() + ", wt=" + getWeight() + "]";
+    }
+}
+
+class NativeBoneWeight {
+    static native long ctor();
+    static native void setVertexId(long ptr, int vertexId);
+    static native int getVertexId(long ptr);
+    static native void setWeight(long ptr, float weight);
+    static native float getWeight(long ptr);
+}

--- a/GVRf/Framework/src/org/gearvrf/GVRComponent.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRComponent.java
@@ -28,7 +28,7 @@ class GVRComponent extends GVRHybridObject {
 
     /**
      * Normal constructor
-     * 
+     *
      * @param gvrContext
      *            The current GVRF context
      * @param nativePointer

--- a/GVRf/Framework/src/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRContext.java
@@ -473,7 +473,7 @@ public abstract class GVRContext {
      * @throws IOException
      *             File does not exist or cannot be read
      *
-     * @deprecated Replaced by {@link #loadJassimpModel}
+     * @deprecated Replaced by {@link #loadModel}
      */
     public GVRSceneObject getAssimpModel(String assetRelativeFilename)
             throws IOException {
@@ -505,19 +505,112 @@ public abstract class GVRContext {
         return GVRImporter.getAssimpModel(this, assetRelativeFilename, settings);
     }
 
+    /**
+     * @deprecated Replaced by {@link #loadModelFromSD}
+     */
     public GVRModelSceneObject loadJassimpModelFromSD(String externalFile) throws IOException {
-        return loadJassimpModelFromSD(externalFile, GVRImportSettings.getRecommendedSettings());
+        return loadModelFromSD(externalFile);
     }
 
+    /**
+     * @deprecated Replaced by {@link #loadModelFromSD}
+     */
     public GVRModelSceneObject loadJassimpModelFromSD(String externalFile, EnumSet<GVRImportSettings> settings) throws IOException {
+        return loadModelFromSD(externalFile, settings);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #loadModel}
+     */
+    public GVRModelSceneObject loadJassimpModel(String assetFile) throws IOException {
+        return loadModel(assetFile);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #loadModel}
+     */
+    public GVRModelSceneObject loadJassimpModel(String assetFile, EnumSet<GVRImportSettings> settings) throws IOException {
+        return loadModel(assetFile, settings);
+    }
+
+    /**
+     * Simple, high-level method to load a scene object {@link GVRModelSceneObject} from
+     * a 3D model stored in the Android SD card.
+     *
+     * @param externalFile
+     *            A filename, relative to the SD card's root directory.
+     *
+     * @return A {@link GVRModelSceneObject} that contains the meshes with textures and bones
+     * and animations.
+     *
+     * @throws IOException
+     *             File does not exist or cannot be read
+     */
+    public GVRModelSceneObject loadModelFromSD(String externalFile) throws IOException {
+        return loadModelFromSD(externalFile, GVRImportSettings.getRecommendedSettings());
+    }
+
+    /**
+     * Simple, high-level method to load a scene object {@link GVRModelSceneObject} from
+     * a 3D model stored in the Android SD card.
+     *
+     * @param externalFile
+     *            A filename, relative to the SD card's root directory.
+     *
+     * @param settings
+     *            Additional import {@link GVRImportSettings settings}
+     *
+     * @return A {@link GVRModelSceneObject} that contains the meshes with textures and bones
+     * and animations.
+     *
+     * @throws IOException
+     *             File does not exist or cannot be read
+     */
+    public GVRModelSceneObject loadModelFromSD(String externalFile, EnumSet<GVRImportSettings> settings) throws IOException {
         return GVRImporter.loadJassimpModelFromSD(this, externalFile, settings);
     }
 
-    public GVRModelSceneObject loadJassimpModel(String assetFile) throws IOException {
-        return loadJassimpModel(assetFile, GVRImportSettings.getRecommendedSettings());
+    /**
+     * Simple, high-level method to load a scene object {@link GVRModelSceneObject} from
+     * a 3D model stored in Android application assets.
+     *
+     * @param assetFile
+     *            A filename, relative to the {@code assets} directory. The file
+     *            can be in a sub-directory of the {@code assets} directory:
+     *            {@code "foo/bar.png"} will open the file
+     *            {@code assets/foo/bar.png}
+     *
+     * @return A {@link GVRModelSceneObject} that contains the meshes with textures and bones
+     * and animations.
+     *
+     * @throws IOException
+     *             File does not exist or cannot be read
+     */
+    public GVRModelSceneObject loadModel(String assetFile) throws IOException {
+        return loadModel(assetFile, GVRImportSettings.getRecommendedSettings());
     }
 
-    public GVRModelSceneObject loadJassimpModel(String assetFile, EnumSet<GVRImportSettings> settings) throws IOException {
+    /**
+     * Simple, high-level method to load a scene object {@link GVRModelSceneObject} from
+     * a 3D model stored in the Android SD card.
+     *
+     * @param assetFile
+     *            A filename, relative to the {@code assets} directory. The file
+     *            can be in a sub-directory of the {@code assets} directory:
+     *            {@code "foo/bar.png"} will open the file
+     *            {@code assets/foo/bar.png}
+     *
+     * @param settings
+     *            Additional import {@link GVRImportSettings settings}
+     *
+     * @return A {@link GVRModelSceneObject} that contains the meshes with textures and bones
+     * and animations.
+     *
+     * @throws IOException
+     *             File does not exist or cannot be read
+     *
+     */
+    public GVRModelSceneObject loadModel(String assetFile, EnumSet<GVRImportSettings> settings) throws IOException {
         return GVRImporter.loadJassimpModel(this, assetFile, settings);
     }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRContext.java
@@ -32,6 +32,7 @@ import org.gearvrf.asynchronous.GVRAsynchronousResourceLoader;
 import org.gearvrf.asynchronous.GVRCompressedTexture;
 import org.gearvrf.asynchronous.GVRCompressedTextureLoader;
 import org.gearvrf.periodic.GVRPeriodicEngine;
+import org.gearvrf.scene_objects.GVRModelSceneObject;
 import org.gearvrf.utility.Log;
 import org.gearvrf.utility.ResourceCache;
 
@@ -504,19 +505,19 @@ public abstract class GVRContext {
         return GVRImporter.getAssimpModel(this, assetRelativeFilename, settings);
     }
 
-    public GVRSceneObject loadJassimpModelFromSD(String externalFile) throws IOException {
+    public GVRModelSceneObject loadJassimpModelFromSD(String externalFile) throws IOException {
         return loadJassimpModelFromSD(externalFile, GVRImportSettings.getRecommendedSettings());
     }
 
-    public GVRSceneObject loadJassimpModelFromSD(String externalFile, EnumSet<GVRImportSettings> settings) throws IOException {
+    public GVRModelSceneObject loadJassimpModelFromSD(String externalFile, EnumSet<GVRImportSettings> settings) throws IOException {
         return GVRImporter.loadJassimpModelFromSD(this, externalFile, settings);
     }
 
-    public GVRSceneObject loadJassimpModel(String assetFile) throws IOException {
+    public GVRModelSceneObject loadJassimpModel(String assetFile) throws IOException {
         return loadJassimpModel(assetFile, GVRImportSettings.getRecommendedSettings());
     }
 
-    public GVRSceneObject loadJassimpModel(String assetFile, EnumSet<GVRImportSettings> settings) throws IOException {
+    public GVRModelSceneObject loadJassimpModel(String assetFile, EnumSet<GVRImportSettings> settings) throws IOException {
         return GVRImporter.loadJassimpModel(this, assetFile, settings);
     }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRHybridObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRHybridObject.java
@@ -154,7 +154,7 @@ public abstract class GVRHybridObject implements Closeable {
         return mNativePointer;
     }
 
-    public static long[] getNativePtrArray(Collection<? extends GVRHybridObject> objects) {
+    /*package*/ static long[] getNativePtrArray(Collection<? extends GVRHybridObject> objects) {
         long[] ptrs = new long[objects.size()];
 
         int i = 0;

--- a/GVRf/Framework/src/org/gearvrf/GVRHybridObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRHybridObject.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -56,7 +57,7 @@ public abstract class GVRHybridObject implements Closeable {
 
     /**
      * Normal constructor
-     * 
+     *
      * @param gvrContext
      *            The current GVRF context
      * @param nativePointer
@@ -151,6 +152,17 @@ public abstract class GVRHybridObject implements Closeable {
      */
     public long getNative() {
         return mNativePointer;
+    }
+
+    public static long[] getNativePtrArray(Collection<? extends GVRHybridObject> objects) {
+        long[] ptrs = new long[objects.size()];
+
+        int i = 0;
+        for (GVRHybridObject obj : objects) {
+            ptrs[i++] = obj.getNative();
+        }
+
+        return ptrs;
     }
 
     @Override

--- a/GVRf/Framework/src/org/gearvrf/GVRImporter.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRImporter.java
@@ -33,6 +33,7 @@ import org.gearvrf.jassimp.GVROldWrapperProvider;
 import org.gearvrf.jassimp2.GVRJassimpAdapter;
 import org.gearvrf.jassimp2.GVRJassimpSceneObject;
 import org.gearvrf.jassimp2.Jassimp;
+import org.gearvrf.scene_objects.GVRModelSceneObject;
 import org.gearvrf.utility.Log;
 
 /**
@@ -116,7 +117,7 @@ final class GVRImporter {
         return new GVRAssimpImporter(gvrContext, nativeValue);
     }
 
-    static GVRSceneObject loadJassimpModelFromSD(final GVRContext context, String externalFile,
+    static GVRModelSceneObject loadJassimpModelFromSD(final GVRContext context, String externalFile,
             EnumSet<GVRImportSettings> settings) throws IOException {
         Jassimp.setWrapperProvider(GVRJassimpAdapter.sWrapperProvider);
         org.gearvrf.jassimp2.AiScene assimpScene = Jassimp.importFile(externalFile,
@@ -127,7 +128,7 @@ final class GVRImporter {
         return new GVRJassimpSceneObject(context, assimpScene);
     }
 
-    static GVRSceneObject loadJassimpModel(final GVRContext context, String assetFile,
+    static GVRModelSceneObject loadJassimpModel(final GVRContext context, String assetFile,
             EnumSet<GVRImportSettings> settings) throws IOException {
         Jassimp.setWrapperProvider(GVRJassimpAdapter.sWrapperProvider);
         org.gearvrf.jassimp2.AiScene assimpScene = Jassimp.importAssetFile(assetFile,

--- a/GVRf/Framework/src/org/gearvrf/GVRImporter.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRImporter.java
@@ -123,7 +123,7 @@ final class GVRImporter {
         org.gearvrf.jassimp2.AiScene assimpScene = Jassimp.importFile(externalFile,
                 GVRJassimpAdapter.get().toJassimpSettings(settings));
         if (assimpScene == null) {
-            return null;
+            throw new IOException("Cannot load a model from SD card");
         }
         return new GVRJassimpSceneObject(context, assimpScene);
     }
@@ -135,7 +135,7 @@ final class GVRImporter {
                 GVRJassimpAdapter.get().toJassimpSettings(settings),
                 context.getContext().getAssets());
         if (assimpScene == null) {
-            return null;
+            throw new IOException("Cannot load a model from android assets");
         }
         return new GVRJassimpSceneObject(context, assimpScene);
     }

--- a/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
@@ -123,17 +123,23 @@ public class GVRMaterial extends GVRHybridObject implements
             public static final GVRMaterialShaderId ID = new GVRStockMaterialShaderId(
                     9);
 
-            /*
+            /**
              * Set this feature enum if diffuse texture is present in Assimp
              * material Diffuse texture maps to main_texture in GearVRf
              */
-            public static int AS_DIFFUSE_TEXTURE = 0x00000000;
+            public static int AS_DIFFUSE_TEXTURE = 0;
 
-            /*
+            /**
              * Set this feature enum if specular texture is present in Assimp
              * material
              */
-            public static int AS_SPECULAR_TEXTURE = 0x00000001;
+            public static int AS_SPECULAR_TEXTURE = 1;
+
+            /**
+             * Set this feature enum if skinning info is present in Assimp
+             * material
+             */
+            public static int AS_SKINNING = 2;
 
             public static int setBit(int number, int index) {
                 return (number |= 1 << index);

--- a/GVRf/Framework/src/org/gearvrf/GVRMesh.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMesh.java
@@ -339,6 +339,9 @@ public class GVRMesh extends GVRHybridObject implements PrettyPrint {
                 }
             }
         }
+        if (getVertexBoneData() != null) {
+            getVertexBoneData().normalizeWeights();
+        }
     }
 
     /**
@@ -354,7 +357,7 @@ public class GVRMesh extends GVRHybridObject implements PrettyPrint {
     public void prettyPrint(StringBuffer sb, int indent) {
         sb.append(getVertices() == null ? 0 : Integer.toString(getVertices().length / 3));
         sb.append(" vertices, ");
-        sb.append(getTriangles() == null ? 0 : Integer.toString(getTriangles().length / 3));
+        sb.append(getIndices() == null ? 0 : Integer.toString(getIndices().length / 3));
         sb.append(" triangles, ");
         sb.append(getTexCoords() == null ? 0 : Integer.toString(getTexCoords().length / 2));
         sb.append(" tex-coords, ");

--- a/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRRenderData.java
@@ -24,10 +24,10 @@ import java.util.ArrayList;
 import org.gearvrf.GVRRenderPass;
 import org.gearvrf.GVRRenderPass.GVRCullFaceEnum;
 
-import android.util.Log;
 import static android.opengl.GLES30.*;
 
 import org.gearvrf.GVRMaterial.GVRShaderType;
+import org.gearvrf.utility.Log;
 import org.gearvrf.utility.Threads;
 
 /**
@@ -37,13 +37,13 @@ import org.gearvrf.utility.Threads;
  * This includes the {@link GVRMesh mesh} itself, the mesh's {@link GVRMaterial
  * material}, camera association, rendering order, and various other parameters.
  */
-public class GVRRenderData extends GVRComponent {
+public class GVRRenderData extends GVRComponent implements PrettyPrint {
 
     private GVRMesh mMesh;
     private ArrayList<GVRRenderPass> mRenderPassList;
     private static final String TAG = "GearVRf";
     private GVRLight mLight;
-    
+
     /** Just for {@link #getMeshEyePointee()} */
     private Future<GVRMesh> mFutureMesh;
 
@@ -691,6 +691,39 @@ public class GVRRenderData extends GVRComponent {
         } else {
             NativeRenderData.setTextureCapturer(getNative(), 0);
         }
+    }
+
+    @Override
+    public void prettyPrint(StringBuffer sb, int indent) {
+        GVRMesh mesh = null;
+        if (mMesh != null) {
+            mesh = mMesh;
+        } else if (this.mFutureMesh != null) {
+            try {
+                mesh = mFutureMesh.get();
+            } catch (Exception e) {
+            }
+        }
+        if (mesh != null) {
+            sb.append(Log.getSpaces(indent));
+            sb.append("Mesh: ");
+            mesh.prettyPrint(sb, indent);
+        }
+
+        sb.append(Log.getSpaces(indent));
+        sb.append("Light: " + mLight);
+        sb.append(System.lineSeparator());
+
+        sb.append(Log.getSpaces(indent));
+        sb.append("Light enabled: " + isLightEnabled);
+        sb.append(System.lineSeparator());
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        prettyPrint(sb, 0);
+        return sb.toString();
     }
 
     private boolean isLightEnabled;

--- a/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
@@ -908,10 +908,6 @@ class NativeSceneObject {
 
     static native void detachEyePointeeHolder(long sceneObject);
 
-    static native void attachBone(long sceneObject, long bone);
-
-    static native void detachBone(long sceneObject);
-
     static native long setParent(long sceneObject, long parent);
 
     static native void addChildObject(long sceneObject, long child);

--- a/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
@@ -17,11 +17,14 @@ package org.gearvrf;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 import org.gearvrf.GVRMaterial.GVRShaderType;
+import org.gearvrf.utility.Log;
 
 /**
  * One of the key GVRF classes: a scene object.
@@ -38,7 +41,7 @@ import org.gearvrf.GVRMaterial.GVRShaderType;
  * {@link GVRRenderData} has a {@link GVRMesh GL mesh} that defines its
  * geometry, and a {@link GVRMaterial} that defines its surface.
  */
-public class GVRSceneObject extends GVRHybridObject {
+public class GVRSceneObject extends GVRHybridObject implements PrettyPrint {
 
     private GVRTransform mTransform;
     private GVRRenderData mRenderData;
@@ -784,10 +787,96 @@ public class GVRSceneObject extends GVRHybridObject {
         }
     }
 
+    private void findChildrenByName(String name, List<GVRSceneObject> objects,
+            boolean onlyFirst, Set<GVRSceneObject> visited) {
+        if (visited.contains(this))
+            return;
+
+        visited.add(this);
+
+        for (GVRSceneObject child : mChildren) {
+            String childName = child.getName();
+            if (name.equals(childName)) {
+                objects.add(child);
+                if (onlyFirst)
+                    return;
+            }
+
+            child.findChildrenByName(name, objects, onlyFirst, visited);
+            if (onlyFirst && !objects.isEmpty())
+                return;
+        }
+    }
+
+    /**
+     * Searches for the all children with the specified name.
+     *
+     * @param name the name of the children.
+     * @return the children found
+     */
+    public List<GVRSceneObject> findAllChildrenByName(String name) {
+        List<GVRSceneObject> objects = new ArrayList<GVRSceneObject>();
+        Set<GVRSceneObject> visited = new HashSet<GVRSceneObject>();
+        findChildrenByName(name, objects, false, visited);
+        return objects;
+    }
+
+    /**
+     * Searches for the first child with the specified name.
+     * 
+     * @param name the name of the child.
+     * @return the child found
+     */
+    public GVRSceneObject findChildByName(String name) {
+        List<GVRSceneObject> objects = new ArrayList<GVRSceneObject>();
+        Set<GVRSceneObject> visited = new HashSet<GVRSceneObject>();
+        findChildrenByName(name, objects, true, visited);
+        return objects.isEmpty() ? null : objects.get(0);
+    }
+
     /**
      * Called when the scene object has been loaded from a model.
      */
     public void onLoaded() {
+    }
+
+    /**
+     * Generate debug dump of the tree from the scene object.
+     * It should include a newline character at the end.
+     * 
+     * @param sb the {@code StringBuffer} to dump the object.
+     * @param indent indentation level as number of spaces.
+     */
+    public void prettyPrint(StringBuffer sb, int indent) {
+        sb.append(Log.getSpaces(indent));
+        sb.append(getClass().getSimpleName());
+        sb.append(" [name=");
+        sb.append(this.getName());
+        sb.append("]");
+        sb.append(System.lineSeparator());
+
+        if (mRenderData == null) {
+            sb.append(Log.getSpaces(indent + 2));
+            sb.append("RenderData: null");
+            sb.append(System.lineSeparator());
+        } else {
+            mRenderData.prettyPrint(sb, indent + 2);
+        }
+        sb.append(Log.getSpaces(indent + 2));
+        sb.append("Transform: "); sb.append(mTransform);
+        sb.append(System.lineSeparator());
+
+        // dump its children
+        for (GVRSceneObject child : getChildren()) {
+            child.prettyPrint(sb, indent + 2);
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        prettyPrint(sb, 0);
+        return sb.toString();
     }
 }
 
@@ -818,6 +907,10 @@ class NativeSceneObject {
             long eyePointeeHolder);
 
     static native void detachEyePointeeHolder(long sceneObject);
+
+    static native void attachBone(long sceneObject, long bone);
+
+    static native void detachBone(long sceneObject);
 
     static native long setParent(long sceneObject, long parent);
 

--- a/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
@@ -787,53 +787,6 @@ public class GVRSceneObject extends GVRHybridObject implements PrettyPrint {
         }
     }
 
-    private void findChildrenByName(String name, List<GVRSceneObject> objects,
-            boolean onlyFirst, Set<GVRSceneObject> visited) {
-        if (visited.contains(this))
-            return;
-
-        visited.add(this);
-
-        for (GVRSceneObject child : mChildren) {
-            String childName = child.getName();
-            if (name.equals(childName)) {
-                objects.add(child);
-                if (onlyFirst)
-                    return;
-            }
-
-            child.findChildrenByName(name, objects, onlyFirst, visited);
-            if (onlyFirst && !objects.isEmpty())
-                return;
-        }
-    }
-
-    /**
-     * Searches for the all children with the specified name.
-     *
-     * @param name the name of the children.
-     * @return the children found
-     */
-    public List<GVRSceneObject> findAllChildrenByName(String name) {
-        List<GVRSceneObject> objects = new ArrayList<GVRSceneObject>();
-        Set<GVRSceneObject> visited = new HashSet<GVRSceneObject>();
-        findChildrenByName(name, objects, false, visited);
-        return objects;
-    }
-
-    /**
-     * Searches for the first child with the specified name.
-     * 
-     * @param name the name of the child.
-     * @return the child found
-     */
-    public GVRSceneObject findChildByName(String name) {
-        List<GVRSceneObject> objects = new ArrayList<GVRSceneObject>();
-        Set<GVRSceneObject> visited = new HashSet<GVRSceneObject>();
-        findChildrenByName(name, objects, true, visited);
-        return objects.isEmpty() ? null : objects.get(0);
-    }
-
     /**
      * Called when the scene object has been loaded from a model.
      */

--- a/GVRf/Framework/src/org/gearvrf/GVRTransform.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRTransform.java
@@ -287,6 +287,16 @@ public class GVRTransform extends GVRComponent {
     }
 
     /**
+     * Get the 4x4 single local transform matrix.
+     * 
+     * @return An array of 16 {@code float}s representing a 4x4 matrix in
+     *         OpenGL-compatible column-major format.
+     */
+    public float[] getLocalModelMatrix() {
+        return NativeTransform.getLocalModelMatrix(getNative());
+    }
+
+    /**
      * Get the 4x4 single matrix.
      *
      * @return An a {@code Matrix4f} representing a 4x4 matrix as a JOML
@@ -295,6 +305,18 @@ public class GVRTransform extends GVRComponent {
     public Matrix4f getModelMatrix4f() {
         Matrix4f modelMatrix = new Matrix4f();
         modelMatrix.set(getModelMatrix());
+        return modelMatrix;
+    }
+
+    /**
+     * Get the 4x4 single single local matrix.
+     *
+     * @return An a {@code Matrix4f} representing a 4x4 matrix as a JOML
+     *         {@code Matrix4f} object.
+     */
+    public Matrix4f getLocalModelMatrix4f() {
+        Matrix4f modelMatrix = new Matrix4f();
+        modelMatrix.set(getLocalModelMatrix());
         return modelMatrix;
     }
 
@@ -520,6 +542,8 @@ class NativeTransform {
     static native void setScaleZ(long transform, float z);
 
     static native float[] getModelMatrix(long transform);
+
+    static native float[] getLocalModelMatrix(long transform);
 
     static native void setModelMatrix(long tranform, float[] mat);
 

--- a/GVRf/Framework/src/org/gearvrf/GVRTransform.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRTransform.java
@@ -15,6 +15,8 @@
 
 package org.gearvrf;
 
+import org.joml.Matrix4f;
+
 /**
  * One of the key GVRF classes: Encapsulates a 4x4 matrix that controls how GL
  * draws a mesh.
@@ -285,6 +287,18 @@ public class GVRTransform extends GVRComponent {
     }
 
     /**
+     * Get the 4x4 single matrix.
+     *
+     * @return An a {@code Matrix4f} representing a 4x4 matrix as a JOML
+     *         {@code Matrix4f} object.
+     */
+    public Matrix4f getModelMatrix4f() {
+        Matrix4f modelMatrix = new Matrix4f();
+        modelMatrix.set(getModelMatrix());
+        return modelMatrix;
+    }
+
+    /**
      * Set the 4x4 model matrix and set current scaling, rotation, and
      * transformation based on this model matrix.
      * 
@@ -297,6 +311,18 @@ public class GVRTransform extends GVRComponent {
             throw new IllegalArgumentException("Size not equal to 16.");
         }
         NativeTransform.setModelMatrix(getNative(), mat);
+    }
+
+    /**
+     * Set the 4x4 model matrix and set current scaling, rotation, and
+     * transformation based on this model matrix.
+     *
+     * @param mat
+     *            A {@code Matrix4f} representing a 4x4 matrix in
+     *            OpenGL-compatible column-major format.
+     */
+    public void setModelMatrix(Matrix4f mat) {
+        setModelMatrix(mat.get(new float[16]));
     }
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/GVRVertexBoneData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRVertexBoneData.java
@@ -1,0 +1,33 @@
+package org.gearvrf;
+
+public final class GVRVertexBoneData extends GVRComponent implements PrettyPrint {
+    /**
+     * Constructor.
+     */
+    public GVRVertexBoneData(GVRContext gvrContext, GVRMesh mesh) {
+        super(gvrContext, NativeVertexBoneData.get(mesh.getNative()), false /* not owned */);
+    }
+
+    public int getFreeBoneSlot(int vertexId) {
+        return NativeVertexBoneData.getFreeBoneSlot(getNative(), vertexId);
+    }
+
+    public void setVertexBoneWeight(int vertexId, int boneSlot, int boneId, float boneWeight) {
+        NativeVertexBoneData.setVertexBoneWeight(getNative(), vertexId, boneSlot, boneId, boneWeight);
+    }
+
+    public void normalizeWeights() {
+        NativeVertexBoneData.normalizeWeights(getNative());
+    }
+
+    @Override
+    public void prettyPrint(StringBuffer sb, int indent) {        
+    }
+}
+
+class NativeVertexBoneData {
+    static native long get(long nativeMesh);
+    static native int getFreeBoneSlot(long nativePtr, int vertexId);
+    static native void setVertexBoneWeight(long nativePtr, int vertexId, int boneSlot, int boneId, float boneWeight);
+    static native void normalizeWeights(long nativePtr);
+}

--- a/GVRf/Framework/src/org/gearvrf/GVRVertexBoneData.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRVertexBoneData.java
@@ -1,11 +1,16 @@
 package org.gearvrf;
 
-public final class GVRVertexBoneData extends GVRComponent implements PrettyPrint {
+public final class GVRVertexBoneData implements PrettyPrint {
+    @SuppressWarnings("unused")
+    private GVRMesh mMesh;
+    private long mNative;
+
     /**
      * Constructor.
      */
     public GVRVertexBoneData(GVRContext gvrContext, GVRMesh mesh) {
-        super(gvrContext, NativeVertexBoneData.get(mesh.getNative()), false /* not owned */);
+        mMesh = mesh; // holds a reference to mesh to avoid GC
+        mNative = NativeVertexBoneData.get(mesh.getNative());
     }
 
     public int getFreeBoneSlot(int vertexId) {
@@ -22,6 +27,10 @@ public final class GVRVertexBoneData extends GVRComponent implements PrettyPrint
 
     @Override
     public void prettyPrint(StringBuffer sb, int indent) {        
+    }
+
+    private long getNative() {
+        return mNative;
     }
 }
 

--- a/GVRf/Framework/src/org/gearvrf/PrettyPrint.java
+++ b/GVRf/Framework/src/org/gearvrf/PrettyPrint.java
@@ -1,0 +1,16 @@
+package org.gearvrf;
+
+/**
+ * PrettyPrint interface
+ */
+public interface PrettyPrint {
+
+    /**
+     * Prints the object with indentation.
+     * 
+     * @param sb the {@code StringBuffer} to receive the output.
+     * 
+     * @param indent indentation in number of spaces
+     */
+    void prettyPrint(StringBuffer sb, int indent);
+}

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationBehavior.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationBehavior.java
@@ -1,0 +1,33 @@
+package org.gearvrf.animation.keyframe;
+
+/** 
+ * Defines how an animation channel behaves outside the defined time range.
+ */
+public enum GVRAnimationBehavior {
+    /** 
+     * The value from the default node transformation is taken.
+     */
+    DEFAULT,  
+
+    
+    /** 
+     * The nearest key value is used without interpolation. 
+     */
+    CONSTANT,
+
+    
+    /** 
+     * The value of the nearest two keys is linearly extrapolated for the 
+     * current time value.
+     */
+    LINEAR,
+
+    
+    /** 
+     * The animation is repeated.<p>
+     *
+     * If the animation key go from n to m and the current time is t, use the 
+     * value at (t-n) % (|m-n|).
+     */
+    REPEAT;
+}

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationChannel.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationChannel.java
@@ -1,0 +1,361 @@
+package org.gearvrf.animation.keyframe;
+
+import org.gearvrf.PrettyPrint;
+import org.gearvrf.utility.Log;
+import org.joml.Matrix4f;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+/** 
+ * Describes the animation of a single node.<p>
+ * 
+ * The node name ({@link #getNodeName()} specifies the bone/node which is 
+ * affected by this animation channel. The keyframes are given in three 
+ * separate series of values, one each for position, rotation and scaling. 
+ * The transformation matrix computed from these values replaces the node's 
+ * original transformation matrix at a specific time.<p>
+ * 
+ * This means all keys are absolute and not relative to the bone default pose.
+ * The order in which the transformations are applied is - as usual - 
+ * scaling, rotation, translation.<p>
+ */
+public final class GVRAnimationChannel implements PrettyPrint {
+    protected static interface Interpolator<T> {
+        T interpolate(Object begin, Object end, float factor);
+    }
+
+    protected static Interpolator<Vector3f> sInterpolatorVector3f = new Interpolator<Vector3f>() {
+        public Vector3f interpolate(Object begin_, Object end_, float factor) {
+            Vector3f begin = (Vector3f) begin_;
+            Vector3f end = (Vector3f) end_;
+
+            return new Vector3f().set(end).sub(begin).mul(factor).add(begin);
+        }
+    };
+
+    protected static Interpolator<Quaternionf> sInterpolatorQuaternion = new Interpolator<Quaternionf>() {
+        public Quaternionf interpolate(Object begin_, Object end_, float factor) {
+            Quaternionf begin = (Quaternionf) begin_;
+            Quaternionf end = (Quaternionf) end_;
+
+            return new Quaternionf().set(begin).slerp(end, factor);
+        }
+    };
+
+    /**
+     * Constructor.
+     * 
+     * @param nodeName name of corresponding scene graph node
+     * @param numPosKeys number of position keys
+     * @param numRotKeys number of rotation keys
+     * @param numScaleKeys number of scaling keys
+     * @param preBehavior behavior before animation start
+     * @param postBehavior behavior after animation end
+     */
+    public GVRAnimationChannel(String nodeName, int numPosKeys, int numRotKeys, 
+            int numScaleKeys, GVRAnimationBehavior preBehavior, GVRAnimationBehavior postBehavior) {
+
+        m_nodeName = nodeName;
+        mPositionKeys = new GVRPositionKey[numPosKeys];
+        mRotationKeys = new GVRRotationKey[numRotKeys];
+        mScaleKeys = new GVRScaleKey[numScaleKeys];
+        mPreState = preBehavior;
+        mPostState = postBehavior;
+
+        mCurrentTransform = new Matrix4f();
+    }
+
+
+    /** 
+     * Returns the name of the scene graph node affected by this animation.<p>
+     * 
+     * The node must exist and it must be unique.
+     * 
+     * @return the name of the affected node
+     */
+    public String getNodeName() {
+        return m_nodeName;
+    }
+
+
+    /** 
+     * Returns the number of position keys.
+     * 
+     * @return the number of position keys
+     */
+    public int getNumPosKeys() {
+        return mPositionKeys.length;
+    }
+    
+    /**
+     * Returns the time component of the specified position key. 
+     * 
+     * @param keyIndex the index of the position key
+     * @return the time component
+     */
+    public double getPosKeyTime(int keyIndex) {
+        return mPositionKeys[keyIndex].getTime();
+    }
+
+    /**
+     * Returns the position as vector.<p>
+     * 
+     * @param keyIndex the index of the position key
+     * 
+     * @return the position as vector
+     */
+    public Vector3f getPosKeyVector(int keyIndex) {
+        return mPositionKeys[keyIndex].getValue();
+    }
+
+    public void setPosKeyVector(int keyIndex, float time, Vector3f pos) {
+        mPositionKeys[keyIndex] = new GVRPositionKey(time, pos.x, pos.y, pos.z);
+    }
+
+    /** 
+     * Returns the number of rotation keys.
+     * 
+     * @return the number of rotation keys
+     */
+    public int getNumRotKeys() {
+       return mRotationKeys.length;
+    }
+
+
+    /**
+     * Returns the time component of the specified rotation key. 
+     * 
+     * @param keyIndex the index of the position key
+     * @return the time component
+     */
+    public double getRotKeyTime(int keyIndex) {
+        return mRotationKeys[keyIndex].getTime();
+    }
+
+
+    /**
+     * Returns the rotation as quaternion.<p>
+     * 
+     * 
+     * @param keyIndex the index of the rotation key
+     * 
+     * @return the rotation as quaternion
+     */
+    public Quaternionf getRotKeyQuaternion(int keyIndex) {
+        return mRotationKeys[keyIndex].getValue();
+    } 
+
+    public void setRotKeyQuaternion(int keyIndex, float time, Quaternionf rot) {
+        mRotationKeys[keyIndex] = new GVRRotationKey(time, rot.x, rot.y, rot.z, rot.w);
+    }
+
+    /** 
+     * Returns the number of scaling keys.
+     * 
+     * @return the number of scaling keys
+     */
+    public int getNumScaleKeys() {
+        return mScaleKeys.length;
+    }
+
+
+    /**
+     * Returns the time component of the specified scaling key. 
+     * 
+     * @param keyIndex the index of the position key
+     * @return the time component
+     */
+    public double getScaleKeyTime(int keyIndex) {
+        return mRotationKeys[keyIndex].getTime();
+    }
+
+
+    /**
+     * Returns the scaling factor as vector.<p>
+     * 
+     * @param keyIndex the index of the scale key
+     * 
+     * @return the scaling factor as vector
+     */
+    public Vector3f getScaleKeyVector(int keyIndex) {
+        return mScaleKeys[keyIndex].getValue();
+    }
+
+    public void setScaleKeyVector(int keyIndex, float time, Vector3f scale) {
+        mScaleKeys[keyIndex] = new GVRScaleKey(time, scale.x, scale.y, scale.z);
+    }
+
+    /** 
+     * Defines how the animation behaves before the first key is encountered.
+     * <p>
+     *
+     * The default value is {@link AiAnimBehavior#DEFAULT} (the original 
+     * transformation matrix of the affected node is used).
+     * 
+     * @return the animation behavior before the first key
+     */
+    public GVRAnimationBehavior getPreState() {
+        return mPreState;
+    }
+    
+
+    /** 
+     * Defines how the animation behaves after the last key was processed.<p>
+     *
+     * The default value is {@link AiAnimBehavior#DEFAULT} (the original
+     * transformation matrix of the affected node is taken).
+     * 
+     * @return the animation behavior before after the last key
+     */
+    public GVRAnimationBehavior getPostState() {
+        return mPostState;
+    }
+
+    /**
+     * Obtains the transform for a specific time in animation.
+     * 
+     * @param animationTime The time in animation.
+     * 
+     * @return The transform.
+     */
+    public Matrix4f animate(float animationTime) {
+        Vector3f scale = getScale(animationTime);
+        Vector3f pos = getPosition(animationTime);
+        Quaternionf rot = getRotation(animationTime);
+
+        // Allocation-free
+        Matrix4f mat = mCurrentTransform.set(rot);
+
+        mat.m00 *= scale.x;
+        mat.m01 *= scale.x;
+        mat.m02 *= scale.x;
+        mat.m10 *= scale.y;
+        mat.m11 *= scale.y;
+        mat.m12 *= scale.y;
+        mat.m20 *= scale.z;
+        mat.m21 *= scale.z;
+        mat.m22 *= scale.z;
+        mat.m30 = pos.x;
+        mat.m31 = pos.y;
+        mat.m32 = pos.z;
+
+        return mat;
+    }
+
+    protected Vector3f getPosition(float time) {
+        Vector3f defaultPosition = new Vector3f();
+        
+        if (mPositionKeys.length == 0) {
+            return defaultPosition;
+        } else if (mPositionKeys.length == 1) {
+            return mPositionKeys[0].getValue();
+        }
+
+        return (Vector3f) interpolate(time, mPositionKeys, sInterpolatorVector3f);
+    }
+
+    protected Vector3f getScale(float time) {
+        Vector3f defaultScale = new Vector3f(1f, 1f, 1f);
+        
+        if (mScaleKeys.length == 0) {
+            return defaultScale;
+        } else if (mScaleKeys.length == 1) {
+            return mScaleKeys[0].getValue();
+        }
+
+        return (Vector3f) interpolate(time, mScaleKeys, sInterpolatorVector3f);
+    }
+
+    protected Quaternionf getRotation(float time) {
+        Quaternionf defaultRotation = new Quaternionf();
+
+        if (mRotationKeys.length == 0) {
+            return defaultRotation;
+        } else if (mRotationKeys.length == 1) {
+            return mRotationKeys[0].getValue();
+        }
+
+        return (Quaternionf) interpolate(time, mRotationKeys, sInterpolatorQuaternion);
+    }
+
+    protected Object interpolate(float time, GVRKeyFrame<?>[] keys, Interpolator<?> interpolator) {
+        int index = getKeyIndex(time, keys);
+        int nextIndex = index + 1;
+
+        if (keys[index].getTime() <= time && time <= keys[nextIndex].getTime()) {
+            // interpolate
+            float deltaTime = (float)(keys[nextIndex].getTime() - keys[index].getTime());
+            float factor = (float)((time - keys[index].getTime()) / deltaTime);
+
+            Object start = keys[index].getValue();
+            Object end = keys[nextIndex].getValue();
+
+            return interpolator.interpolate(start, end, factor);
+        } else {
+            // time is out of range of animation time frame
+            float firstFrameTime = keys[0].getTime();
+            float lastFrameTime = keys[keys.length - 1].getTime();
+            Object firstFrameValue = keys[0].getValue();
+            Object lastFrameValue = keys[keys.length - 1].getValue();
+
+            if (time <= firstFrameTime) {
+                return firstFrameValue;
+            } else if (time >= lastFrameTime) {
+                return lastFrameValue;
+            } else {
+                // Shouldn't happen
+                throw new RuntimeException("Interpolation failed");
+            }
+        }
+    }
+
+    protected int getKeyIndex(float time, GVRKeyFrame<?>[] keys) {
+        for (int i = 0; i < (keys.length - 1); i++) {
+            if (time < (float) keys[i + 1].getTime()) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public void prettyPrint(StringBuffer sb, int indent) {
+        sb.append(Log.getSpaces(indent));
+        sb.append(GVRAnimationChannel.class.getSimpleName());
+        sb.append(" [nodeName=" + m_nodeName + ", positionKeys="
+                + mPositionKeys.length + ", rotationKeys="
+                + mRotationKeys.length + ", scaleKeys="
+                + mScaleKeys.length + ", m_preState=" + mPreState
+                + ", m_postState=" + mPostState + "]");
+        sb.append(System.lineSeparator());
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        prettyPrint(sb, 0);
+        return sb.toString();
+    }
+
+    /**
+     * Node name.
+     */
+    private final String m_nodeName;
+
+    private final GVRPositionKey[] mPositionKeys;
+    private final GVRRotationKey[] mRotationKeys;
+    private final GVRScaleKey[] mScaleKeys;
+
+    protected Matrix4f mCurrentTransform;
+
+    /**
+     * Pre-animation behavior.
+     */
+    private final GVRAnimationBehavior mPreState;
+
+    /**
+     * Post-animation behavior.
+     */
+    private final GVRAnimationBehavior mPostState;
+}
+

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationChannel.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationChannel.java
@@ -1,5 +1,6 @@
 package org.gearvrf.animation.keyframe;
 
+import org.gearvrf.BuildConfig;
 import org.gearvrf.PrettyPrint;
 import org.gearvrf.utility.Log;
 import org.joml.Matrix4f;
@@ -20,6 +21,7 @@ import org.joml.Vector3f;
  * scaling, rotation, translation.<p>
  */
 public final class GVRAnimationChannel implements PrettyPrint {
+    private static final String TAG = GVRAnimationChannel.class.getSimpleName();
     protected static interface ValueInterpolator<T> {
         T interpolate(Object begin, Object end, float factor);
     }
@@ -80,7 +82,11 @@ public final class GVRAnimationChannel implements PrettyPrint {
                     return lastFrameValue;
                 } else {
                     // Shouldn't happen
-                    throw new RuntimeException("Interpolation failed");
+                    if (BuildConfig.DEBUG) {
+                        throw new RuntimeException("Interpolation failed");
+                    } else {
+                        return firstFrameValue;
+                    }
                 }
             }
         }
@@ -104,9 +110,13 @@ public final class GVRAnimationChannel implements PrettyPrint {
                 }
             }
 
+            if (time < keys[0].getTime() || time >= keys[keys.length - 1].getTime()) {
+                return lastKeyIndex = -1;
+            }
+
             // Binary search for the interval
             int low = 0, high = keys.length - 2;
-            // invariant: [low, high) contains time if time can be found
+            // invariant: [low, high) contains time
             // post-condition: |high - low| <= 1, only need to check [low, low + 1)
             while (high - low > 1) {
                 int mid = (low + high) / 2;
@@ -124,6 +134,7 @@ public final class GVRAnimationChannel implements PrettyPrint {
                 return lastKeyIndex = low;
             }
 
+            Log.v(TAG, "Warning: interpolation failed at time " + time);
             return lastKeyIndex = -1;
         }
     }

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationChannel.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationChannel.java
@@ -22,23 +22,17 @@ import org.joml.Vector3f;
 public final class GVRAnimationChannel implements PrettyPrint {
     private static final String TAG = GVRAnimationChannel.class.getSimpleName();
     protected static interface ValueInterpolator<T> {
-        T interpolate(Object begin, Object end, float factor);
+        T interpolate(T begin, T end, float factor);
     }
 
     protected static ValueInterpolator<Vector3f> sInterpolatorVector3f = new ValueInterpolator<Vector3f>() {
-        public Vector3f interpolate(Object begin_, Object end_, float factor) {
-            Vector3f begin = (Vector3f) begin_;
-            Vector3f end = (Vector3f) end_;
-
+        public Vector3f interpolate(Vector3f begin, Vector3f end, float factor) {
             return new Vector3f().set(end).sub(begin).mul(factor).add(begin);
         }
     };
 
     protected static ValueInterpolator<Quaternionf> sInterpolatorQuaternion = new ValueInterpolator<Quaternionf>() {
-        public Quaternionf interpolate(Object begin_, Object end_, float factor) {
-            Quaternionf begin = (Quaternionf) begin_;
-            Quaternionf end = (Quaternionf) end_;
-
+        public Quaternionf interpolate(Quaternionf begin, Quaternionf end, float factor) {
             return new Quaternionf().set(begin).slerp(end, factor);
         }
     };
@@ -64,8 +58,8 @@ public final class GVRAnimationChannel implements PrettyPrint {
                 float deltaTime = (float)(keys[nextIndex].getTime() - keys[index].getTime());
                 float factor = (float)((time - keys[index].getTime()) / deltaTime);
 
-                Object start = keys[index].getValue();
-                Object end = keys[nextIndex].getValue();
+                T start = keys[index].getValue();
+                T end = keys[nextIndex].getValue();
 
                 return interpolator.interpolate(start, end, factor);
             } else {

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrame.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrame.java
@@ -1,0 +1,7 @@
+package org.gearvrf.animation.keyframe;
+
+public interface GVRKeyFrame<T> {
+    float getTime();
+    T getValue();
+    void setValue(T value);
+}

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrame.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrame.java
@@ -1,6 +1,6 @@
 package org.gearvrf.animation.keyframe;
 
-public interface GVRKeyFrame<T> {
+/*package*/ interface GVRKeyFrame<T> {
     float getTime();
     T getValue();
     void setValue(T value);

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrameAnimation.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrameAnimation.java
@@ -1,0 +1,105 @@
+package org.gearvrf.animation.keyframe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gearvrf.GVRHybridObject;
+import org.gearvrf.GVRSceneObject;
+import org.gearvrf.PrettyPrint;
+import org.gearvrf.animation.GVRAnimation;
+import org.gearvrf.utility.Log;
+import org.joml.Matrix4f;
+
+public class GVRKeyFrameAnimation extends GVRAnimation implements PrettyPrint {
+    protected String mName;
+    protected float mTicksPerSecond;
+    protected float mDurationTicks;
+    protected List<GVRAnimationChannel> mChannels;
+    protected GVRSkinningController mSkinningController;
+    protected GVRSceneObject mTarget;
+    protected Matrix4f[] mTransforms;
+
+    public GVRKeyFrameAnimation(String name, GVRSceneObject target, float durationTicks, float ticksPerSecond) {
+    	super(target, durationTicks / ticksPerSecond);
+        mName = name;
+        mDurationTicks = durationTicks;
+        mTicksPerSecond = ticksPerSecond;
+        mChannels = new ArrayList<GVRAnimationChannel>();
+        mSkinningController = null;
+        mTarget = target;
+    }
+
+    /**
+     * Add a channel to the animation.
+     * @param channel The animation channel.
+     */
+    public void addChannel(GVRAnimationChannel channel) {
+        mChannels.add(channel);
+    }
+
+    /**
+     * Must be called after calling all channels.
+     */
+    public void prepare() {
+        mSkinningController = new GVRSkinningController(mTarget, this);
+        mTransforms = new Matrix4f[mChannels.size()];
+        for (int i = 0; i < mTransforms.length; ++i) {
+            mTransforms[i] = new Matrix4f();
+        }
+    }
+
+    @Override
+    public void prettyPrint(StringBuffer sb, int indent) {
+        sb.append(Log.getSpaces(indent));
+        sb.append(GVRKeyFrameAnimation.class.getSimpleName());
+        sb.append("[name=" + mName + ", ticksPerSecond="
+                + mTicksPerSecond + ", duration=" + mDurationTicks + ", "
+                + mChannels.size() + " channels]");
+        sb.append(System.lineSeparator());
+
+        for (GVRAnimationChannel nodeAnim : mChannels) {
+            nodeAnim.prettyPrint(sb, indent + 2);
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        prettyPrint(sb, 0);
+        return sb.toString();
+    }
+
+    public int findChannel(String nodeName) {
+        int i = 0;
+        for (GVRAnimationChannel channel : mChannels) {
+            if (nodeName != null && nodeName.equals(channel.getNodeName())) {
+                return i;
+            }
+            i++;
+        }
+        return -1;
+    }
+
+    @Override
+    protected void animate(GVRHybridObject target, float ratio) {
+        if (mTarget != target) {
+            return;
+        }
+
+        if (mSkinningController == null) {
+            throw new RuntimeException("Animation is not prepared. Call prepare() before starting.");
+        }
+
+        mSkinningController.animate(getDuration() * ratio);
+
+        // TODO: ordinary transform animation
+    }
+
+    protected Matrix4f[] getTransforms(float animationTime) {
+        int i = 0;
+        for (GVRAnimationChannel channel : mChannels) {
+            mTransforms[i++].set(channel.animate(animationTime));
+        }
+        return mTransforms;
+    }
+}

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrameAnimation.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrameAnimation.java
@@ -10,6 +10,9 @@ import org.gearvrf.animation.GVRAnimation;
 import org.gearvrf.utility.Log;
 import org.joml.Matrix4f;
 
+/**
+ * Represents animation based on a sequence of key frames.
+ */
 public class GVRKeyFrameAnimation extends GVRAnimation implements PrettyPrint {
     protected String mName;
     protected float mTicksPerSecond;
@@ -22,6 +25,14 @@ public class GVRKeyFrameAnimation extends GVRAnimation implements PrettyPrint {
     protected GVRSceneObject mTarget;
     protected Matrix4f[] mTransforms;
 
+    /**
+     * Constructor.
+     *
+     * @param name The name of the animation.
+     * @param target The target object it influences.
+     * @param durationTicks Duration of the animation in ticks.
+     * @param ticksPerSecond Number of ticks per second.
+     */
     public GVRKeyFrameAnimation(String name, GVRSceneObject target, float durationTicks, float ticksPerSecond) {
     	super(target, durationTicks / ticksPerSecond);
         mName = name;
@@ -77,7 +88,16 @@ public class GVRKeyFrameAnimation extends GVRAnimation implements PrettyPrint {
         return sb.toString();
     }
 
+    /**
+     * Searches for a channel based on the node it affects.
+     *
+     * @param nodeName The name of the node.
+     * @return The ID of the channel.
+     */
     public int findChannel(String nodeName) {
+        if (nodeName == null)
+            return -1;
+
         int i = 0;
         for (GVRAnimationChannel channel : mChannels) {
             if (nodeName != null && nodeName.equals(channel.getNodeName())) {

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrameAnimation.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrameAnimation.java
@@ -94,7 +94,7 @@ public class GVRKeyFrameAnimation extends GVRAnimation implements PrettyPrint {
             return;
         }
 
-        if (mNodeAnimationController == null && mSkinningController == null) {
+        if (mNodeAnimationController == null || mSkinningController == null) {
             throw new RuntimeException("Animation is not prepared. Call prepare() before starting.");
         }
 

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrameAnimation.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRKeyFrameAnimation.java
@@ -15,7 +15,10 @@ public class GVRKeyFrameAnimation extends GVRAnimation implements PrettyPrint {
     protected float mTicksPerSecond;
     protected float mDurationTicks;
     protected List<GVRAnimationChannel> mChannels;
+
+    protected GVRNodeAnimationController mNodeAnimationController;
     protected GVRSkinningController mSkinningController;
+
     protected GVRSceneObject mTarget;
     protected Matrix4f[] mTransforms;
 
@@ -25,7 +28,10 @@ public class GVRKeyFrameAnimation extends GVRAnimation implements PrettyPrint {
         mDurationTicks = durationTicks;
         mTicksPerSecond = ticksPerSecond;
         mChannels = new ArrayList<GVRAnimationChannel>();
+
+        mNodeAnimationController = null;
         mSkinningController = null;
+
         mTarget = target;
     }
 
@@ -38,9 +44,11 @@ public class GVRKeyFrameAnimation extends GVRAnimation implements PrettyPrint {
     }
 
     /**
-     * Must be called after calling all channels.
+     * Must be called after adding all channels.
      */
     public void prepare() {
+        mNodeAnimationController = new GVRNodeAnimationController(mTarget, this);
+
         mSkinningController = new GVRSkinningController(mTarget, this);
         mTransforms = new Matrix4f[mChannels.size()];
         for (int i = 0; i < mTransforms.length; ++i) {
@@ -86,13 +94,13 @@ public class GVRKeyFrameAnimation extends GVRAnimation implements PrettyPrint {
             return;
         }
 
-        if (mSkinningController == null) {
+        if (mNodeAnimationController == null && mSkinningController == null) {
             throw new RuntimeException("Animation is not prepared. Call prepare() before starting.");
         }
 
-        mSkinningController.animate(getDuration() * ratio);
+        mNodeAnimationController.animate(getDuration() * ratio);
 
-        // TODO: ordinary transform animation
+        mSkinningController.animate(getDuration() * ratio);
     }
 
     protected Matrix4f[] getTransforms(float animationTime) {

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRNodeAnimationController.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRNodeAnimationController.java
@@ -44,16 +44,21 @@ public class GVRNodeAnimationController {
         }
     }
 
-    protected void scanTree(GVRSceneObject node) {
+    /* Returns true if subtree contains renderables */
+    protected boolean scanTree(GVRSceneObject node) {
+        boolean containsRenderable = node.getRenderData() != null;
+
+        for (GVRSceneObject child : node.getChildren()) {
+            containsRenderable |= scanTree(child);
+        }
+
         // Find channel Id
         int channelId = animation.findChannel(node.getName());
-        if (channelId != -1) {
+        if (channelId != -1 && containsRenderable) {
             animatedNodes.add(new AnimationItem(node, channelId));
         }
 
-        for (GVRSceneObject child : node.getChildren()) {
-            scanTree(child);
-        }
+        return containsRenderable;
     }
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRNodeAnimationController.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRNodeAnimationController.java
@@ -1,0 +1,81 @@
+package org.gearvrf.animation.keyframe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gearvrf.GVRSceneObject;
+import org.joml.Matrix4f;
+
+/**
+ * Controls node animation.
+ */
+public class GVRNodeAnimationController {
+    private static final String TAG = GVRNodeAnimationController.class.getSimpleName();
+
+    protected GVRSceneObject sceneRoot;
+    protected GVRKeyFrameAnimation animation;
+
+    protected class AnimationItem {
+        GVRSceneObject target;
+        int channelId;
+
+        AnimationItem(GVRSceneObject target, int channelId) {
+            this.target = target;
+            this.channelId = channelId;
+        }
+    }
+
+    protected List<AnimationItem> animatedNodes;
+
+    /**
+     * Constructs a list of animated {@link GVRSceneObject}.
+     *
+     * @param gvrContext The GVR context.
+     * @param sceneRoot The scene root.
+     * @param animation The animation object.
+     */
+    public GVRNodeAnimationController(GVRSceneObject sceneRoot, GVRKeyFrameAnimation animation) {
+        this.sceneRoot = sceneRoot;
+        this.animation = animation;
+
+        animatedNodes = new ArrayList<AnimationItem>();
+        if (animation != null) {
+            scanTree(sceneRoot);
+        }
+    }
+
+    protected void scanTree(GVRSceneObject node) {
+        // Find channel Id
+        int channelId = animation.findChannel(node.getName());
+        if (channelId != -1) {
+            animatedNodes.add(new AnimationItem(node, channelId));
+        }
+
+        for (GVRSceneObject child : node.getChildren()) {
+            scanTree(child);
+        }
+    }
+
+    /**
+     * Update node transforms at each animation step.
+     */
+    public void animate(float timeInSeconds) {
+        float ticksPerSecond;
+        float timeInTicks;
+        Matrix4f[] animationTransform = null;
+
+        if (animation.mTicksPerSecond != 0) {
+            ticksPerSecond = (float) animation.mTicksPerSecond;
+        } else {
+            ticksPerSecond = 25.0f;
+        }
+        timeInTicks = timeInSeconds * ticksPerSecond;
+
+        float animationTime = timeInTicks % animation.mDurationTicks; // auto-repeat
+        animationTransform = animation.getTransforms(animationTime);
+
+        for (AnimationItem item : animatedNodes) {
+            item.target.getTransform().setModelMatrix(animationTransform[item.channelId]);
+        }
+    }
+}

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRPositionKey.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRPositionKey.java
@@ -1,0 +1,30 @@
+package org.gearvrf.animation.keyframe;
+
+import org.joml.Vector3f;
+
+public class GVRPositionKey implements GVRKeyFrame<Vector3f> {
+    public GVRPositionKey(float time, float x, float y, float z) {
+        mTime = time;
+        mX = x;
+        mY = y;
+        mZ = z;
+    }
+
+    @Override
+    public float getTime() {
+        return mTime;
+    }
+
+    public Vector3f getValue() {
+        return new Vector3f(mX, mY, mZ);
+    }
+
+    public void setValue(Vector3f pos) {
+        mX = pos.x;
+        mY = pos.y;
+        mZ = pos.z;
+    }
+
+    private float mTime;
+    private float mX, mY, mZ;
+}

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRPositionKey.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRPositionKey.java
@@ -2,7 +2,18 @@ package org.gearvrf.animation.keyframe;
 
 import org.joml.Vector3f;
 
+/**
+ * Represents a position keyframe.
+ */
 public class GVRPositionKey implements GVRKeyFrame<Vector3f> {
+    /**
+     * Constructor.
+     *
+     * @param time The time of the key frame.
+     * @param x The X component of the position.
+     * @param y The Y component of the position.
+     * @param z The Z component of the position.
+     */
     public GVRPositionKey(float time, float x, float y, float z) {
         mTime = time;
         mX = x;
@@ -10,15 +21,24 @@ public class GVRPositionKey implements GVRKeyFrame<Vector3f> {
         mZ = z;
     }
 
+    /**
+     * Gets the time of the keyframe.
+     */
     @Override
     public float getTime() {
         return mTime;
     }
 
+    /**
+     * Gets the position vector of the keyframe.
+     */
     public Vector3f getValue() {
         return new Vector3f(mX, mY, mZ);
     }
 
+    /**
+     * Sets the position vector of the keyframe.
+     */
     public void setValue(Vector3f pos) {
         mX = pos.x;
         mY = pos.y;

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRRotationKey.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRRotationKey.java
@@ -1,0 +1,32 @@
+package org.gearvrf.animation.keyframe;
+
+import org.joml.Quaternionf;
+
+public class GVRRotationKey implements GVRKeyFrame<Quaternionf> {
+    public GVRRotationKey(float time, float x, float y, float z, float w) {
+        mTime = time;
+        mX = x;
+        mY = y;
+        mZ = z;
+        mW = w;
+    }
+
+    @Override
+    public float getTime() {
+        return mTime;
+    }
+
+    public Quaternionf getValue() {
+        return new Quaternionf(mX, mY, mZ, mW);
+    }
+
+    public void setValue(Quaternionf rot) {
+        mX = rot.x;
+        mY = rot.y;
+        mZ = rot.z;
+        mW = rot.w;
+    }
+
+    private float mTime;
+    private float mX, mY, mZ, mW; // w is the real part
+}

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRRotationKey.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRRotationKey.java
@@ -2,7 +2,19 @@ package org.gearvrf.animation.keyframe;
 
 import org.joml.Quaternionf;
 
+/**
+ * Represents a rotation keyframe.
+ */
 public class GVRRotationKey implements GVRKeyFrame<Quaternionf> {
+    /**
+     * Constructor.
+     *
+     * @param time The time of the keyframe.
+     * @param x The X component of the quaternion.
+     * @param y The Y component of the quaternion.
+     * @param z The Z component of the quaternion.
+     * @param w The W component of the quaternion.
+     */
     public GVRRotationKey(float time, float x, float y, float z, float w) {
         mTime = time;
         mX = x;
@@ -11,15 +23,24 @@ public class GVRRotationKey implements GVRKeyFrame<Quaternionf> {
         mW = w;
     }
 
+    /**
+     * Gets the time of the keyframe.
+     */
     @Override
     public float getTime() {
         return mTime;
     }
 
+    /**
+     * Gets the quaternion of the keyframe.
+     */
     public Quaternionf getValue() {
         return new Quaternionf(mX, mY, mZ, mW);
     }
 
+    /**
+     * Sets the quaternion of the keyframe.
+     */
     public void setValue(Quaternionf rot) {
         mX = rot.x;
         mY = rot.y;

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRScaleKey.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRScaleKey.java
@@ -1,0 +1,30 @@
+package org.gearvrf.animation.keyframe;
+
+import org.joml.Vector3f;
+
+public class GVRScaleKey implements GVRKeyFrame<Vector3f> {
+    public GVRScaleKey(float time, float x, float y, float z) {
+        mTime = time;
+        mX = x;
+        mY = y;
+        mZ = z;
+    }
+
+    @Override
+    public float getTime() {
+        return mTime;
+    }
+
+    public Vector3f getValue() {
+        return new Vector3f(mX, mY, mZ);
+    }
+
+    public void setValue(Vector3f scale) {
+        mX = scale.x;
+        mY = scale.y;
+        mZ = scale.z;
+    }
+
+    private float mTime;
+    private float mX, mY, mZ;
+}

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRScaleKey.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRScaleKey.java
@@ -2,7 +2,18 @@ package org.gearvrf.animation.keyframe;
 
 import org.joml.Vector3f;
 
+/**
+ * Represents a scale keyframe.
+ */
 public class GVRScaleKey implements GVRKeyFrame<Vector3f> {
+    /**
+     * Constructor.
+     *
+     * @param time The time of the key frame.
+     * @param x The X component of the scaling vector.
+     * @param y The Y component of the scaling vector.
+     * @param z The Z component of the scaling vector.
+     */
     public GVRScaleKey(float time, float x, float y, float z) {
         mTime = time;
         mX = x;
@@ -10,15 +21,24 @@ public class GVRScaleKey implements GVRKeyFrame<Vector3f> {
         mZ = z;
     }
 
+    /**
+     * Gets the time of the keyframe.
+     */
     @Override
     public float getTime() {
         return mTime;
     }
 
+    /**
+     * Gets the scale vector of the keyframe.
+     */
     public Vector3f getValue() {
         return new Vector3f(mX, mY, mZ);
     }
 
+    /**
+     * Sets the scale vector of the keyframe.
+     */
     public void setValue(Vector3f scale) {
         mX = scale.x;
         mY = scale.y;

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRSkinningController.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRSkinningController.java
@@ -101,7 +101,7 @@ public class GVRSkinningController {
             for (GVRBone bone : mesh.getBones()) {
                 bone.setSceneObject(node);
 
-                GVRSceneObject skeletalNode = sceneRoot.findChildByName(bone.getName());
+                GVRSceneObject skeletalNode = sceneRoot.getSceneObjectByName(bone.getName());
                 if (skeletalNode == null) {
                     Log.w(TAG, "what? cannot find the skeletal node for bone: %s", bone.toString());
                     continue;

--- a/GVRf/Framework/src/org/gearvrf/jassimp2/GVRJassimpSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/jassimp2/GVRJassimpSceneObject.java
@@ -2,30 +2,25 @@ package org.gearvrf.jassimp2;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Future;
 
 import org.gearvrf.FutureWrapper;
 import org.gearvrf.GVRAndroidResource;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRMaterial;
+import org.gearvrf.GVRMaterial.GVRShaderType;
 import org.gearvrf.GVRMesh;
 import org.gearvrf.GVRRenderData;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRTexture;
-import org.gearvrf.GVRMaterial.GVRShaderType;
+import org.gearvrf.scene_objects.GVRModelSceneObject;
 import org.gearvrf.utility.Log;
-import org.gearvrf.animation.keyframe.GVRKeyFrameAnimation;
 
-public class GVRJassimpSceneObject extends GVRSceneObject {
+public class GVRJassimpSceneObject extends GVRModelSceneObject {
     private static final String TAG = GVRJassimpSceneObject.class.getSimpleName();
     protected AiScene scene;
-    protected List<GVRKeyFrameAnimation> animations;
-
     public GVRJassimpSceneObject(GVRContext gvrContext, AiScene scene) {
         super(gvrContext);
-        animations = new ArrayList<GVRKeyFrameAnimation>();
 
         if (scene != null) {
             this.scene = scene;
@@ -33,13 +28,9 @@ public class GVRJassimpSceneObject extends GVRSceneObject {
 
             // Animations
             for (AiAnimation aiAnim : scene.getAnimations()) {
-                animations.add(GVRJassimpAdapter.get().createAnimation(aiAnim, this));
+                mAnimations.add(GVRJassimpAdapter.get().createAnimation(aiAnim, this));
             }
         }
-    }
-
-    public List<GVRKeyFrameAnimation> getAnimations() {
-        return animations;
     }
 
     private void recurseAssimpNodes(
@@ -183,14 +174,5 @@ public class GVRJassimpSceneObject extends GVRSceneObject {
         sceneObject.attachRenderData(sceneObjectRenderData);
 
         return sceneObject;
-    }
-
-    @Override
-    public void prettyPrint(StringBuffer sb, int indent) {
-        super.prettyPrint(sb, indent);
-        // dump its animations
-        for (GVRKeyFrameAnimation anim : animations) {
-            anim.prettyPrint(sb, indent + 2);
-        }
     }
 }

--- a/GVRf/Framework/src/org/gearvrf/jassimp2/GVRNewWrapperProvider.java
+++ b/GVRf/Framework/src/org/gearvrf/jassimp2/GVRNewWrapperProvider.java
@@ -3,12 +3,13 @@ package org.gearvrf.jassimp2;
 import java.nio.ByteBuffer;
 
 import org.apache.commons.math3.complex.Quaternion;
+import org.joml.Quaternionf;
 
 /*
  * V3, M4, C, N, Q
  */
-public class GVRNewWrapperProvider implements AiWrapperProvider<float[], float[], AiColor, AiNode, Quaternion> {
-	/**
+public class GVRNewWrapperProvider implements AiWrapperProvider<float[], float[], AiColor, AiNode, Quaternionf> {
+    /**
      * Wraps a RGBA color.
      * <p>
      * 
@@ -57,12 +58,12 @@ public class GVRNewWrapperProvider implements AiWrapperProvider<float[], float[]
      * @return the wrapped quaternion
      */
     @Override
-    public Quaternion wrapQuaternion(ByteBuffer buffer, int offset) {
+    public Quaternionf wrapQuaternion(ByteBuffer buffer, int offset) {
     	float w = buffer.getFloat(offset);
     	float x = buffer.getFloat(offset + 4);
     	float y = buffer.getFloat(offset + 8);
     	float z = buffer.getFloat(offset + 12);
-        return new Quaternion(w, x, y, z);
+        return new Quaternionf(x, y, z, w);
     }
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRModelSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRModelSceneObject.java
@@ -1,0 +1,69 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf.scene_objects;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRSceneObject;
+import org.gearvrf.PrettyPrint;
+import org.gearvrf.animation.GVRAnimation;
+import org.gearvrf.utility.Log;
+
+/**
+ * {@linkplain GVRSceneObject Scene object} that holds a loaded model.
+ */
+
+public class GVRModelSceneObject extends GVRSceneObject {
+    protected List<GVRAnimation> mAnimations;
+
+    /**
+     * Holds a loaded model.
+     *
+     * @param gvrContext
+     *            current {@link GVRContext}
+     */
+    public GVRModelSceneObject(GVRContext gvrContext) {
+        super(gvrContext);
+        mAnimations = new ArrayList<GVRAnimation>();
+    }
+
+    /**
+     * Gets the list of animations loaded with the model.
+     * 
+     * @return list of animations.
+     */
+    public List<GVRAnimation> getAnimations() {
+        return mAnimations;
+    }
+
+    @Override
+    public void prettyPrint(StringBuffer sb, int indent) {
+        super.prettyPrint(sb, indent);
+
+        // dump animations
+        for (GVRAnimation anim : mAnimations) {
+            if (anim instanceof PrettyPrint) {
+                ((PrettyPrint) anim).prettyPrint(sb, indent + 2);
+            } else {
+                sb.append(Log.getSpaces(indent + 2));
+                sb.append(anim);
+                sb.append(System.lineSeparator());
+            }
+        }
+    }
+}

--- a/GVRf/Framework/src/org/gearvrf/utility/Cell.java
+++ b/GVRf/Framework/src/org/gearvrf/utility/Cell.java
@@ -1,0 +1,22 @@
+package org.gearvrf.utility;
+
+/**
+ * Wrapper class to pass any data type by reference.
+ *
+ * @param <T> the type parameter.
+ */
+public class Cell<T> {
+    T value;
+
+    public Cell(T t) {
+        value = t;
+    }
+
+    public void set(T t) {
+        value = t;
+    }
+
+    public T get() {
+        return value;
+    }
+}

--- a/GVRf/Framework/src/org/gearvrf/utility/Log.java
+++ b/GVRf/Framework/src/org/gearvrf/utility/Log.java
@@ -15,6 +15,14 @@
 
 package org.gearvrf.utility;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Scanner;
+
+import org.apache.commons.math3.geometry.euclidean.threed.Line;
+
 /** {@link android.util.Log} with String.format() pattern */
 public abstract class Log {
 
@@ -87,5 +95,33 @@ public abstract class Log {
             result = outer.getSimpleName() + "." + result;
         }
         return result;
+    }
+
+    /**
+     * Generates a string with {@code length} spaces.
+     *
+     * @param length length of the string
+     * @return the string
+     */
+    public static String getSpaces(int length) {
+        char[] charArray = new char[length];
+        Arrays.fill(charArray, ' ');
+        String str = new String(charArray);
+        return str;
+    }
+
+    /**
+     * Log long string using verbose tag
+     * 
+     * @param TAG The tag.
+     * @param longString The long string.
+     */
+    public static void logLong(String TAG, String longString) {
+        InputStream is = new ByteArrayInputStream( longString.getBytes() );
+        @SuppressWarnings("resource")
+        Scanner scan = new Scanner(is);
+        while (scan.hasNextLine()) {
+            Log.v(TAG, scan.nextLine());
+        }
     }
 }

--- a/GVRf/Framework/src/org/joml/AxisAngle4d.java
+++ b/GVRf/Framework/src/org/joml/AxisAngle4d.java
@@ -1,0 +1,597 @@
+/*
+ * (C) Copyright 2015 Kai Burjack
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Represents a 3D rotation of a given radians about an axis represented as an
+ * unit 3D vector.
+ * <p>
+ * This class uses double-precision components.
+ * 
+ * @author Kai Burjack
+ */
+public class AxisAngle4d implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The angle in radians.
+     */
+    public double angle;
+    /**
+     * The x-component of the rotation axis.
+     */
+    public double x;
+    /**
+     * The y-component of the rotation axis.
+     */
+    public double y;
+    /**
+     * The z-component of the rotation axis.
+     */
+    public double z;
+
+    /**
+     * Create a new {@link AxisAngle4d} with zero rotation about <tt>(0, 0, 1)</tt>.
+     */
+    public AxisAngle4d() {
+        z = 1.0;
+    }
+
+    /**
+     * Create a new {@link AxisAngle4d} with the same values of <code>a</code>.
+     * 
+     * @param a
+     *            the AngleAxis4d to copy the values from
+     */
+    public AxisAngle4d(AxisAngle4d a) {
+        x = a.x;
+        y = a.y;
+        z = a.z;
+        angle = (a.angle < 0.0 ? 2.0 * Math.PI + a.angle % (2.0 * Math.PI) : a.angle) % (2.0 * Math.PI);
+    }
+
+    /**
+     * Create a new {@link AxisAngle4d} with the same values of <code>a</code>.
+     * 
+     * @param a
+     *            the AngleAxis4f to copy the values from
+     */
+    public AxisAngle4d(AxisAngle4f a) {
+        x = a.x;
+        y = a.y;
+        z = a.z;
+        angle = (a.angle < 0.0 ? 2.0 * Math.PI + a.angle % (2.0 * Math.PI) : a.angle) % (2.0 * Math.PI);
+    }
+
+    /**
+     * Create a new {@link AxisAngle4d} from the given {@link Quaternionf}.
+     * <p>
+     * Reference: <a href=
+     * "http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle/"
+     * >http://www.euclideanspace.com</a>
+     * 
+     * @param q
+     *            the quaternion from which to create the new AngleAxis4f
+     */
+    public AxisAngle4d(Quaternionf q) {
+        double acos = Math.acos(q.w);
+        double invSqrt = 1.0 / Math.sqrt(1.0 - q.w * q.w);
+        x = q.x * invSqrt;
+        y = q.y * invSqrt;
+        z = q.z * invSqrt;
+        angle = 2.0 * acos;
+    }
+
+    /**
+     * Create a new {@link AxisAngle4d} from the given {@link Quaterniond}.
+     * <p>
+     * Reference: <a href=
+     * "http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle/"
+     * >http://www.euclideanspace.com</a>
+     * 
+     * @param q
+     *            the quaternion from which to create the new AngleAxis4d
+     */
+    public AxisAngle4d(Quaterniond q) {
+        double acos = Math.acos(q.w);
+        double invSqrt = 1.0 / Math.sqrt(1.0 - q.w * q.w);
+        x = q.x * invSqrt;
+        y = q.y * invSqrt;
+        z = q.z * invSqrt;
+        angle = 2.0 * acos;
+    }
+
+    /**
+     * Create a new {@link AxisAngle4d} with the given values.
+     *
+     * @param angle
+     *            the angle in radians
+     * @param x
+     *            the x-coordinate of the rotation axis
+     * @param y
+     *            the y-coordinate of the rotation axis
+     * @param z
+     *            the z-coordinate of the rotation axis
+     */
+    public AxisAngle4d(double angle, double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.angle = (angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI);
+    }
+
+    /**
+     * Create a new {@link AxisAngle4d} with the given values.
+     *
+     * @param angle the angle in radians
+     * @param v     the rotation axis as a {@link Vector3d}
+     */
+    public AxisAngle4d(double angle, Vector3d v) {
+        this(angle, v.x, v.y, v.z);
+    }
+
+    /**
+     * Create a new {@link AxisAngle4d} with the given values.
+     *
+     * @param angle the angle in radians
+     * @param v     the rotation axis as a {@link Vector3f}
+     */
+    public AxisAngle4d(double angle, Vector3f v) {
+        this(angle, v.x, v.y, v.z);
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to the values of <code>a</code>.
+     * 
+     * @param a
+     *            the AngleAxis4f to copy the values from
+     * @return this
+     */
+    public AxisAngle4d set(AxisAngle4d a) {
+        x = a.x;
+        y = a.y;
+        z = a.z;
+        angle = (a.angle < 0.0 ? 2.0 * Math.PI + a.angle % (2.0 * Math.PI) : a.angle) % (2.0 * Math.PI);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to the values of <code>a</code>.
+     * 
+     * @param a
+     *            the AngleAxis4f to copy the values from
+     * @return this
+     */
+    public AxisAngle4d set(AxisAngle4f a) {
+        x = a.x;
+        y = a.y;
+        z = a.z;
+        angle = (a.angle < 0.0 ? 2.0 * Math.PI + a.angle % (2.0 * Math.PI) : a.angle) % (2.0 * Math.PI);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to the given values.
+     * 
+     * @param angle
+     *            the angle in radians
+     * @param x
+     *            the x-coordinate of the rotation axis
+     * @param y
+     *            the y-coordinate of the rotation axis
+     * @param z
+     *            the z-coordinate of the rotation axis
+     * @return this
+     */
+    public AxisAngle4d set(double angle, double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.angle = (angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to the given values.
+     *
+     * @param angle
+     *            the angle in radians
+     * @param v    
+     *            the rotation axis as a {@link Vector3d}
+     * @return this
+     */
+    public AxisAngle4d set(double angle, Vector3d v) {
+        return set(angle, v.x, v.y, v.z);
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to the given values.
+     *
+     * @param angle
+     *            the angle in radians
+     * @param v    
+     *            the rotation axis as a {@link Vector3f}
+     * @return this
+     */
+    public AxisAngle4d set(double angle, Vector3f v) {
+        return set(angle, v.x, v.y, v.z);
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to be equivalent to the given
+     * {@link Quaternionf}.
+     * 
+     * @param q
+     *            the quaternion to set this AngleAxis4d from
+     * @return this
+     */
+    public AxisAngle4d set(Quaternionf q) {
+        double acos = Math.acos(q.w);
+        double invSqrt = 1.0 / Math.sqrt(1.0 - q.w * q.w);
+        this.x = q.x * invSqrt;
+        this.y = q.y * invSqrt;
+        this.z = q.z * invSqrt;
+        this.angle = 2.0f * acos;
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to be equivalent to the given
+     * {@link Quaterniond}.
+     * 
+     * @param q
+     *            the quaternion to set this AngleAxis4d from
+     * @return this
+     */
+    public AxisAngle4d set(Quaterniond q) {
+        double acos = Math.acos(q.w);
+        double invSqrt = 1.0 / Math.sqrt(1.0 - q.w * q.w);
+        this.x = q.x * invSqrt;
+        this.y = q.y * invSqrt;
+        this.z = q.z * invSqrt;
+        this.angle = 2.0f * acos;
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to be equivalent to the rotation 
+     * of the given {@link Matrix3f}.
+     * 
+     * @param m
+     *            the Matrix3f to set this AngleAxis4d from
+     * @return this
+     */
+    public AxisAngle4d set(Matrix3f m) {
+        double cos = (m.m00 + m.m11 + m.m22 - 1.0)*0.5;
+        x = m.m12 - m.m21;
+        y = m.m20 - m.m02;
+        z = m.m01 - m.m10;
+        double sin = 0.5*Math.sqrt(x*x + y*y + z*z);
+        angle = Math.atan2(sin, cos);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to be equivalent to the rotation 
+     * of the given {@link Matrix3d}.
+     * 
+     * @param m
+     *            the Matrix3d to set this AngleAxis4d from
+     * @return this
+     */
+    public AxisAngle4d set(Matrix3d m) {
+        double cos = (m.m00 + m.m11 + m.m22 - 1.0)*0.5;
+        x = m.m12 - m.m21;
+        y = m.m20 - m.m02;
+        z = m.m01 - m.m10;
+        double sin = 0.5*Math.sqrt(x*x + y*y + z*z);
+        angle = Math.atan2(sin, cos);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to be equivalent to the rotational component 
+     * of the given {@link Matrix4f}.
+     * 
+     * @param m
+     *            the Matrix4f to set this AngleAxis4d from
+     * @return this
+     */
+    public AxisAngle4d set(Matrix4f m) {
+        double cos = (m.m00 + m.m11 + m.m22 - 1.0)*0.5;
+        x = m.m12 - m.m21;
+        y = m.m20 - m.m02;
+        z = m.m01 - m.m10;
+        double sin = 0.5*Math.sqrt(x*x + y*y + z*z);
+        angle = Math.atan2(sin, cos);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4d} to be equivalent to the rotational component 
+     * of the given {@link Matrix4d}.
+     * 
+     * @param m
+     *            the Matrix4d to set this AngleAxis4d from
+     * @return this
+     */
+    public AxisAngle4d set(Matrix4d m) {
+        double cos = (m.m00 + m.m11 + m.m22 - 1.0)*0.5;
+        x = m.m12 - m.m21;
+        y = m.m20 - m.m02;
+        z = m.m01 - m.m10;
+        double sin = 0.5*Math.sqrt(x*x + y*y + z*z);
+        angle = Math.atan2(sin, cos);
+        return this;
+    }
+
+    /**
+     * Set the given {@link Quaternionf} to be equivalent to this {@link AxisAngle4d} rotation.
+     * 
+     * @see Quaternionf#set(AxisAngle4d)
+     * 
+     * @param q
+     *          the quaternion to set
+     * @return q
+     */
+    public Quaternionf get(Quaternionf q) {
+        return q.set(this);
+    }
+
+    /**
+     * Set the given {@link Quaterniond} to be equivalent to this {@link AxisAngle4d} rotation.
+     * 
+     * @see Quaterniond#set(AxisAngle4d)
+     * 
+     * @param q
+     *          the quaternion to set
+     * @return q
+     */
+    public Quaterniond get(Quaterniond q) {
+        return q.set(this);
+    }
+
+    /**
+     * Set the given {@link Matrix4f} to a rotation transformation equivalent to this {@link AxisAngle4d}.
+     * 
+     * @see Matrix4f#set(AxisAngle4d)
+     * 
+     * @param m
+     *          the matrix to set
+     * @return m
+     */
+    public Matrix4f get(Matrix4f m) {
+        return m.set(this);
+    }
+
+    /**
+     * Set the given {@link Matrix3f} to a rotation transformation equivalent to this {@link AxisAngle4d}.
+     * 
+     * @see Matrix3f#set(AxisAngle4d)
+     * 
+     * @param m
+     *          the matrix to set
+     * @return m
+     */
+    public Matrix3f get(Matrix3f m) {
+        return m.set(this);
+    }
+
+    /**
+     * Set the given {@link Matrix4d} to a rotation transformation equivalent to this {@link AxisAngle4d}.
+     * 
+     * @see Matrix4f#set(AxisAngle4d)
+     * 
+     * @param m
+     *          the matrix to set
+     * @return m
+     */
+    public Matrix4d get(Matrix4d m) {
+        return m.set(this);
+    }
+
+    /**
+     * Set the given {@link Matrix3d} to a rotation transformation equivalent to this {@link AxisAngle4d}.
+     * 
+     * @see Matrix3f#set(AxisAngle4d)
+     * 
+     * @param m
+     *          the matrix to set
+     * @return m
+     */
+    public Matrix3d get(Matrix3d m) {
+        return m.set(this);
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeDouble(angle);
+        out.writeDouble(x);
+        out.writeDouble(y);
+        out.writeDouble(z);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        angle = in.readDouble();
+        x = in.readDouble();
+        y = in.readDouble();
+        z = in.readDouble();
+    }
+
+    /**
+     * Normalize the axis vector.
+     * 
+     * @return this
+     */
+    public AxisAngle4d normalize() {
+        double invLength = 1.0 / Math.sqrt(x * x + y * y + z * z);
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        return this;
+    }
+
+    /**
+     * Increase the rotation angle by the given amount.
+     * <p>
+     * This method also takes care of wrapping around.
+     * 
+     * @param ang
+     *          the angle increase
+     * @return this
+     */
+    public AxisAngle4d rotate(double ang) {
+        angle += ang;
+        angle = (angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI);
+        return this;
+    }
+
+    /**
+     * Transform the given vector by the rotation transformation described by this {@link AxisAngle4d}.
+     * 
+     * @param v
+     *          the vector to transform
+     * @return v
+     */
+    public Vector3d transform(Vector3d v) {
+        return transform(v, v);
+    }
+
+    /**
+     * Transform the given vector by the rotation transformation described by this {@link AxisAngle4d}
+     * and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d transform(Vector3d v, Vector3d dest) {
+        double cos = Math.cos(angle);
+        double sin = Math.sin(angle);
+        double dot = x * v.x + y * v.y + z * v.z;
+        dest.set(v.x * cos + sin * (y * v.z - z * v.y) + (1.0 - cos) * dot * x,
+                 v.y * cos + sin * (z * v.x - x * v.z) + (1.0 - cos) * dot * y,
+                 v.z * cos + sin * (x * v.y - y * v.x) + (1.0 - cos) * dot * z);
+        return dest;
+    }
+
+    /**
+     * Transform the given vector by the rotation transformation described by this {@link AxisAngle4d}.
+     * 
+     * @param v
+     *          the vector to transform
+     * @return v
+     */
+    public Vector4d transform(Vector4d v) {
+        return transform(v, v);
+    }
+
+    /**
+     * Transform the given vector by the rotation transformation described by this {@link AxisAngle4d}
+     * and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d transform(Vector4d v, Vector4d dest) {
+        double cos = Math.cos(angle);
+        double sin = Math.sin(angle);
+        double dot = x * v.x + y * v.y + z * v.z;
+        dest.set(v.x * cos + sin * (y * v.z - z * v.y) + (1.0 - cos) * dot * x,
+                 v.y * cos + sin * (z * v.x - x * v.z) + (1.0 - cos) * dot * y,
+                 v.z * cos + sin * (x * v.y - y * v.x) + (1.0 - cos) * dot * z,
+                 dest.w);
+        return dest;
+    }
+
+    /**
+     * Return a string representation of this {@link AxisAngle4d}.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this {@link AxisAngle4d} by formatting the components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the vector components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + formatter.format(y) + formatter.format(z) + " <|" + formatter.format(angle) + " )"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits((angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI));
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(x);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(y);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(z);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AxisAngle4d other = (AxisAngle4d) obj;
+        if (Double.doubleToLongBits((angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI)) != 
+                Double.doubleToLongBits((other.angle < 0.0 ? 2.0 * Math.PI + other.angle % (2.0 * Math.PI) : other.angle) % (2.0 * Math.PI)))
+            return false;
+        if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+            return false;
+        if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
+            return false;
+        if (Double.doubleToLongBits(z) != Double.doubleToLongBits(other.z))
+            return false;
+        return true;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/AxisAngle4f.java
+++ b/GVRf/Framework/src/org/joml/AxisAngle4f.java
@@ -1,0 +1,525 @@
+/*
+ * (C) Copyright 2015 Kai Burjack
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Represents a 3D rotation of a given radians about an axis represented as an
+ * unit 3D vector.
+ * <p>
+ * This class uses single-precision components.
+ * 
+ * @author Kai Burjack
+ */
+public class AxisAngle4f implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The angle in radians.
+     */
+    public float angle;
+    /**
+     * The x-component of the rotation axis.
+     */
+    public float x;
+    /**
+     * The y-component of the rotation axis.
+     */
+    public float y;
+    /**
+     * The z-component of the rotation axis.
+     */
+    public float z;
+
+    /**
+     * Create a new {@link AxisAngle4f} with zero rotation about <tt>(0, 0, 1)</tt>.
+     */
+    public AxisAngle4f() {
+        z = 1.0f;
+    }
+
+    /**
+     * Create a new {@link AxisAngle4f} with the same values of <code>a</code>.
+     * 
+     * @param a
+     *            the AngleAxis4f to copy the values from
+     */
+    public AxisAngle4f(AxisAngle4f a) {
+        x = a.x;
+        y = a.y;
+        z = a.z;
+        angle = (float) ((a.angle < 0.0 ? 2.0 * Math.PI + a.angle % (2.0 * Math.PI) : a.angle) % (2.0 * Math.PI));
+    }
+
+    /**
+     * Create a new {@link AxisAngle4f} from the given {@link Quaternionf}.
+     * <p>
+     * Reference: <a href=
+     * "http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle/"
+     * >http://www.euclideanspace.com</a>
+     * 
+     * @param q
+     *            the quaternion from which to create the new AngleAxis4f
+     */
+    public AxisAngle4f(Quaternionf q) {
+        float acos = (float) Math.acos(q.w);
+        float invSqrt = (float) (1.0 / Math.sqrt(1.0 - q.w * q.w));
+        this.x = q.x * invSqrt;
+        this.y = q.y * invSqrt;
+        this.z = q.z * invSqrt;
+        this.angle = (float) 2.0 * acos;
+    }
+
+    /**
+     * Create a new {@link AxisAngle4f} with the given values.
+     *
+     * @param angle
+     *            the angle in radians
+     * @param x
+     *            the x-coordinate of the rotation axis
+     * @param y
+     *            the y-coordinate of the rotation axis
+     * @param z
+     *            the z-coordinate of the rotation axis
+     */
+    public AxisAngle4f(float angle, float x, float y, float z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.angle = (float) ((angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI));
+    }
+
+    /**
+     * Create a new {@link AxisAngle4f} with the given values.
+     *
+     * @param angle the angle in radians
+     * @param v     the rotation axis as a {@link Vector3f}
+     */
+    public AxisAngle4f(float angle, Vector3f v) {
+        this(angle, v.x, v.y, v.z);
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to the values of <code>a</code>.
+     * 
+     * @param a
+     *            the AngleAxis4f to copy the values from
+     * @return this
+     */
+    public AxisAngle4f set(AxisAngle4f a) {
+        x = a.x;
+        y = a.y;
+        z = a.z;
+        angle = a.angle;
+        angle = (float) ((angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI));
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to the given values.
+     * 
+     * @param angle
+     *            the angle in radians
+     * @param x
+     *            the x-coordinate of the rotation axis
+     * @param y
+     *            the y-coordinate of the rotation axis
+     * @param z
+     *            the z-coordinate of the rotation axis
+     * @return this
+     */
+    public AxisAngle4f set(float angle, float x, float y, float z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.angle = (float) ((angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI));
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to the given values.
+     *
+     * @param angle
+     *            the angle in radians
+     * @param v    
+     *            the rotation axis as a {@link Vector3f}
+     * @return this
+     */
+    public AxisAngle4f set(float angle, Vector3f v) {
+        return set(angle, v.x, v.y, v.z);
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to be equivalent to the given
+     * {@link Quaternionf}.
+     * 
+     * @param q
+     *            the quaternion to set this AngleAxis4f from
+     * @return this
+     */
+    public AxisAngle4f set(Quaternionf q) {
+        double acos = Math.acos(q.w);
+        double invSqrt = 1.0 / Math.sqrt(1.0 - q.w * q.w);
+        this.x = (float) (q.x * invSqrt);
+        this.y = (float) (q.y * invSqrt);
+        this.z = (float) (q.z * invSqrt);
+        this.angle = (float) (2.0f * acos);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to be equivalent to the given
+     * {@link Quaterniond}.
+     * 
+     * @param q
+     *            the quaternion to set this AngleAxis4f from
+     * @return this
+     */
+    public AxisAngle4f set(Quaterniond q) {
+        double acos = Math.acos(q.w);
+        double invSqrt = 1.0 / Math.sqrt(1.0 - q.w * q.w);
+        this.x = (float) (q.x * invSqrt);
+        this.y = (float) (q.y * invSqrt);
+        this.z = (float) (q.z * invSqrt);
+        this.angle = (float) (2.0f * acos);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to be equivalent to the rotation 
+     * of the given {@link Matrix3f}.
+     * 
+     * @param m
+     *            the Matrix3f to set this AngleAxis4f from
+     * @return this
+     */
+    public AxisAngle4f set(Matrix3f m) {
+        double cos = (m.m00 + m.m11 + m.m22 - 1.0)*0.5;
+        x = m.m12 - m.m21;
+        y = m.m20 - m.m02;
+        z = m.m01 - m.m10;
+        double sin = 0.5*Math.sqrt(x*x + y*y + z*z);
+        angle = (float) Math.atan2(sin, cos);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to be equivalent to the rotation 
+     * of the given {@link Matrix3d}.
+     * 
+     * @param m
+     *            the Matrix3d to set this AngleAxis4f from
+     * @return this
+     */
+    public AxisAngle4f set(Matrix3d m) {
+        double cos = (m.m00 + m.m11 + m.m22 - 1.0)*0.5;
+        x = (float) (m.m12 - m.m21);
+        y = (float) (m.m20 - m.m02);
+        z = (float) (m.m01 - m.m10);
+        double sin = 0.5*Math.sqrt(x*x + y*y + z*z);
+        angle = (float) Math.atan2(sin, cos);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to be equivalent to the rotational component 
+     * of the given {@link Matrix4f}.
+     * 
+     * @param m
+     *            the Matrix4f to set this AngleAxis4f from
+     * @return this
+     */
+    public AxisAngle4f set(Matrix4f m) {
+        double cos = (m.m00 + m.m11 + m.m22 - 1.0)*0.5;
+        x = m.m12 - m.m21;
+        y = m.m20 - m.m02;
+        z = m.m01 - m.m10;
+        double sin = 0.5*Math.sqrt(x*x + y*y + z*z);
+        angle = (float) Math.atan2(sin, cos);
+        return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to be equivalent to the rotational component 
+     * of the given {@link Matrix4d}.
+     * 
+     * @param m
+     *            the Matrix4d to set this AngleAxis4f from
+     * @return this
+     */
+    public AxisAngle4f set(Matrix4d m) {
+        double cos = (m.m00 + m.m11 + m.m22 - 1.0)*0.5;
+        x = (float) (m.m12 - m.m21);
+        y = (float) (m.m20 - m.m02);
+        z = (float) (m.m01 - m.m10);
+        double sin = 0.5*Math.sqrt(x*x + y*y + z*z);
+        angle = (float) Math.atan2(sin, cos);
+        return this;
+    }
+
+    /**
+     * Set the given {@link Quaternionf} to be equivalent to this {@link AxisAngle4f} rotation.
+     * 
+     * @see Quaternionf#set(AxisAngle4f)
+     * 
+     * @param q
+     *          the quaternion to set
+     * @return q
+     */
+    public Quaternionf get(Quaternionf q) {
+        return q.set(this);
+    }
+
+    /**
+     * Set the given {@link Quaterniond} to be equivalent to this {@link AxisAngle4f} rotation.
+     * 
+     * @see Quaterniond#set(AxisAngle4f)
+     * 
+     * @param q
+     *          the quaternion to set
+     * @return q
+     */
+    public Quaterniond get(Quaterniond q) {
+        return q.set(this);
+    }
+
+    /**
+     * Set the given {@link Matrix4f} to a rotation transformation equivalent to this {@link AxisAngle4f}.
+     * 
+     * @see Matrix4f#set(AxisAngle4f)
+     * 
+     * @param m
+     *          the matrix to set
+     * @return m
+     */
+    public Matrix4f get(Matrix4f m) {
+        return m.set(this);
+    }
+
+    /**
+     * Set the given {@link Matrix3f} to a rotation transformation equivalent to this {@link AxisAngle4f}.
+     * 
+     * @see Matrix3f#set(AxisAngle4f)
+     * 
+     * @param m
+     *          the matrix to set
+     * @return m
+     */
+    public Matrix3f get(Matrix3f m) {
+        return m.set(this);
+    }
+
+    /**
+     * Set the given {@link Matrix4d} to a rotation transformation equivalent to this {@link AxisAngle4f}.
+     * 
+     * @see Matrix4f#set(AxisAngle4f)
+     * 
+     * @param m
+     *          the matrix to set
+     * @return m
+     */
+    public Matrix4d get(Matrix4d m) {
+        return m.set(this);
+    }
+
+    /**
+     * Set the given {@link Matrix3d} to a rotation transformation equivalent to this {@link AxisAngle4f}.
+     * 
+     * @see Matrix3f#set(AxisAngle4f)
+     * 
+     * @param m
+     *          the matrix to set
+     * @return m
+     */
+    public Matrix3d get(Matrix3d m) {
+        return m.set(this);
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeFloat(angle);
+        out.writeFloat(x);
+        out.writeFloat(y);
+        out.writeFloat(z);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        angle = in.readFloat();
+        x = in.readFloat();
+        y = in.readFloat();
+        z = in.readFloat();
+    }
+
+    /**
+     * Normalize the axis vector.
+     * 
+     * @return this
+     */
+    public AxisAngle4f normalize() {
+        float invLength = (float) (1.0 / Math.sqrt(x * x + y * y + z * z));
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        return this;
+    }
+
+    /**
+     * Increase the rotation angle by the given amount.
+     * <p>
+     * This method also takes care of wrapping around.
+     * 
+     * @param ang
+     *          the angle increase
+     * @return this
+     */
+    public AxisAngle4f rotate(float ang) {
+        angle += ang;
+        angle = (float) ((angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI));
+        return this;
+    }
+
+    /**
+     * Transform the given vector by the rotation transformation described by this {@link AxisAngle4f}.
+     * 
+     * @param v
+     *          the vector to transform
+     * @return v
+     */
+    public Vector3f transform(Vector3f v) {
+        return transform(v, v);
+    }
+
+    /**
+     * Transform the given vector by the rotation transformation described by this {@link AxisAngle4f}
+     * and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f transform(Vector3f v, Vector3f dest) {
+        double cos = Math.cos(angle);
+        double sin = Math.sin(angle);
+        float dot = x * v.x + y * v.y + z * v.z;
+        dest.set((float) (v.x * cos + sin * (y * v.z - z * v.y) + (1.0 - cos) * dot * x),
+                 (float) (v.y * cos + sin * (z * v.x - x * v.z) + (1.0 - cos) * dot * y),
+                 (float) (v.z * cos + sin * (x * v.y - y * v.x) + (1.0 - cos) * dot * z));
+        return dest;
+    }
+
+    /**
+     * Transform the given vector by the rotation transformation described by this {@link AxisAngle4f}.
+     * 
+     * @param v
+     *          the vector to transform
+     * @return v
+     */
+    public Vector4f transform(Vector4f v) {
+        return transform(v, v);
+    }
+
+    /**
+     * Transform the given vector by the rotation transformation described by this {@link AxisAngle4f}
+     * and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f transform(Vector4f v, Vector4f dest) {
+        double cos = Math.cos(angle);
+        double sin = Math.sin(angle);
+        float dot = x * v.x + y * v.y + z * v.z;
+        dest.set((float) (v.x * cos + sin * (y * v.z - z * v.y) + (1.0 - cos) * dot * x),
+                 (float) (v.y * cos + sin * (z * v.x - x * v.z) + (1.0 - cos) * dot * y),
+                 (float) (v.z * cos + sin * (x * v.y - y * v.x) + (1.0 - cos) * dot * z),
+                 dest.w);
+        return dest;
+    }
+
+    /**
+     * Return a string representation of this {@link AxisAngle4f}.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this {@link AxisAngle4f} by formatting the components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the vector components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + formatter.format(y) + formatter.format(z) + " <|" + formatter.format(angle) + " )"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        float nangle = (float) ((angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI));
+        result = prime * result + Float.floatToIntBits(nangle);
+        result = prime * result + Float.floatToIntBits(x);
+        result = prime * result + Float.floatToIntBits(y);
+        result = prime * result + Float.floatToIntBits(z);
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AxisAngle4f other = (AxisAngle4f) obj;
+        float nangle = (float) ((angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI));
+        float nangleOther = (float) ((other.angle < 0.0 ? 2.0 * Math.PI + other.angle % (2.0 * Math.PI) : other.angle) % (2.0 * Math.PI));
+        if (Float.floatToIntBits(nangle) != Float.floatToIntBits(nangleOther))
+            return false;
+        if (Float.floatToIntBits(x) != Float.floatToIntBits(other.x))
+            return false;
+        if (Float.floatToIntBits(y) != Float.floatToIntBits(other.y))
+            return false;
+        if (Float.floatToIntBits(z) != Float.floatToIntBits(other.z))
+            return false;
+        return true;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/FrustumCuller.java
+++ b/GVRf/Framework/src/org/joml/FrustumCuller.java
@@ -1,0 +1,416 @@
+/*
+ * (C) Copyright 2015 Kai Burjack
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+/**
+ * Performs frustum culling by caching the frustum planes of an arbitrary transformation {@link Matrix4f matrix}.
+ * <p>
+ * This class is preferred over the frustum culling methods in {@link Matrix4f} when many objects need to be culled
+ * by the same static frustum.
+ * 
+ * @author Kai Burjack
+ */
+public class FrustumCuller {
+
+    /**
+     * Return value of {@link #isAabInsideFrustum(float, float, float, float, float, float) isAabInsideFrustum()} or
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * identifying the plane with equation <tt>x=-1</tt> when using the identity frustum.  
+     */
+    public static final int PLANE_NX = 0;
+    /**
+     * Return value of {@link #isAabInsideFrustum(float, float, float, float, float, float) isAabInsideFrustum()} or
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * identifying the plane with equation <tt>x=1</tt> when using the identity frustum.  
+     */
+    public static final int PLANE_PX = 1;
+    /**
+     * Return value of {@link #isAabInsideFrustum(float, float, float, float, float, float) isAabInsideFrustum()} or
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * identifying the plane with equation <tt>y=-1</tt> when using the identity frustum.  
+     */
+    public static final int PLANE_NY= 2;
+    /**
+     * Return value of {@link #isAabInsideFrustum(float, float, float, float, float, float) isAabInsideFrustum()} or
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * identifying the plane with equation <tt>y=1</tt> when using the identity frustum.  
+     */
+    public static final int PLANE_PY = 3;
+    /**
+     * Return value of {@link #isAabInsideFrustum(float, float, float, float, float, float) isAabInsideFrustum()} or
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * identifying the plane with equation <tt>z=-1</tt> when using the identity frustum.  
+     */
+    public static final int PLANE_NZ = 4;
+    /**
+     * Return value of {@link #isAabInsideFrustum(float, float, float, float, float, float) isAabInsideFrustum()} or
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * identifying the plane with equation <tt>z=1</tt> when using the identity frustum.  
+     */
+    public static final int PLANE_PZ = 5;
+
+    /**
+     * The value in a bitmask for
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * that identifies the plane with equation <tt>x=-1</tt> when using the identity frustum.
+     */
+    public static final int PLANE_MASK_NX = 1<<PLANE_NX;
+    /**
+     * The value in a bitmask for
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * that identifies the plane with equation <tt>x=1</tt> when using the identity frustum.
+     */
+    public static final int PLANE_MASK_PX = 1<<PLANE_PX;
+    /**
+     * The value in a bitmask for
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * that identifies the plane with equation <tt>y=-1</tt> when using the identity frustum.
+     */
+    public static final int PLANE_MASK_NY = 1<<PLANE_NY;
+    /**
+     * The value in a bitmask for
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * that identifies the plane with equation <tt>y=1</tt> when using the identity frustum.
+     */
+    public static final int PLANE_MASK_PY = 1<<PLANE_PY;
+    /**
+     * The value in a bitmask for
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * that identifies the plane with equation <tt>z=-1</tt> when using the identity frustum.
+     */
+    public static final int PLANE_MASK_NZ = 1<<PLANE_NZ;
+    /**
+     * The value in a bitmask for
+     * {@link #isAabInsideFrustumMasked(float, float, float, float, float, float, int) isAabInsideFrustumMasked()}
+     * that identifies the plane with equation <tt>z=1</tt> when using the identity frustum.
+     */
+    public static final int PLANE_MASK_PZ = 1<<PLANE_PZ;
+
+    private float nxX, nxY, nxZ, nxW;
+    private float pxX, pxY, pxZ, pxW;
+    private float nyX, nyY, nyZ, nyW;
+    private float pyX, pyY, pyZ, pyW;
+    private float nzX, nzY, nzZ, nzW;
+    private float pzX, pzY, pzZ, pzW;
+
+    /**
+     * Create a new {@link FrustumCuller} with undefined frustum planes.
+     * <p>
+     * Before using any of the frustum culling methods, make sure to define the frustum planes using {@link #set(Matrix4f)}.
+     */
+    public FrustumCuller() {
+    }
+
+    /**
+     * Create a new {@link FrustumCuller} from the given {@link Matrix4f matrix} by extracing the matrix's frustum planes.
+     * <p>
+     * In order to update the compute frustum planes later on, call {@link #set(Matrix4f)}.
+     * 
+     * @see #set(Matrix4f)
+     * 
+     * @param m
+     *          the {@link Matrix4f} to create the frustum culler from
+     */
+    public FrustumCuller(Matrix4f m) {
+        set(m);
+    }
+
+    /**
+     * Update the stored frustum planes of <code>this</code> {@link FrustumCuller} with the given {@link Matrix4f matrix}.
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * 
+     * @param m
+     *          the {@link Matrix4f matrix} to update <code>this</code> frustum culler's frustum planes from
+     * @return this
+     */
+    public FrustumCuller set(Matrix4f m) {
+        float invl;
+        nxX = m.m03 + m.m00; nxY = m.m13 + m.m10; nxZ = m.m23 + m.m20; nxW = m.m33 + m.m30;
+        invl = (float) (1.0 / Math.sqrt(nxX * nxX + nxY * nxY + nxZ * nxZ));
+        nxX *= invl; nxY *= invl; nxZ *= invl; nxW *= invl;
+        pxX = m.m03 - m.m00; pxY = m.m13 - m.m10; pxZ = m.m23 - m.m20; pxW = m.m33 - m.m30;
+        invl = (float) (1.0 / Math.sqrt(pxX * pxX + pxY * pxY + pxZ * pxZ));
+        pxX *= invl; pxY *= invl; pxZ *= invl; pxW *= invl;
+        nyX = m.m03 + m.m01; nyY = m.m13 + m.m11; nyZ = m.m23 + m.m21; nyW = m.m33 + m.m31;
+        invl = (float) (1.0 / Math.sqrt(nyX * nyX + nyY * nyY + nyZ * nyZ));
+        nyX *= invl; nyY *= invl; nyZ *= invl; nyW *= invl;
+        pyX = m.m03 - m.m01; pyY = m.m13 - m.m11; pyZ = m.m23 - m.m21; pyW = m.m33 - m.m31;
+        invl = (float) (1.0 / Math.sqrt(pyX * pyX + pyY * pyY + pyZ * pyZ));
+        pyX *= invl; pyY *= invl; pyZ *= invl; pyW *= invl;
+        nzX = m.m03 + m.m02; nzY = m.m13 + m.m12; nzZ = m.m23 + m.m22; nzW = m.m33 + m.m32;
+        invl = (float) (1.0 / Math.sqrt(nzX * nzX + nzY * nzY + nzZ * nzZ));
+        nzX *= invl; nzY *= invl; nzZ *= invl; nzW *= invl;
+        pzX = m.m03 - m.m02; pzY = m.m13 - m.m12; pzZ = m.m23 - m.m22; pzW = m.m33 - m.m32;
+        invl = (float) (1.0 / Math.sqrt(pzX * pzX + pzY * pzY + pzZ * pzZ));
+        pzX *= invl; pzY *= invl; pzZ *= invl; pzW *= invl;
+        return this;
+    }
+
+    /**
+     * Determine whether the given point is within the viewing frustum
+     * defined by <code>this</code> frustum culler.
+     * 
+     * @param point
+     *          the point to test
+     * @return <code>true</code> if the given point is inside the clipping frustum; <code>false</code> otherwise
+     */
+    public boolean isPointInsideFrustum(Vector3f point) {
+        return isPointInsideFrustum(point.x, point.y, point.z);
+    }
+
+    /**
+     * Determine whether the given point <tt>(x, y, z)</tt> is within the viewing frustum defined by <code>this</code> frustum culler.
+     * 
+     * @param x
+     *          the x-coordinate of the point
+     * @param y
+     *          the y-coordinate of the point
+     * @param z
+     *          the z-coordinate of the point
+     * @return <code>true</code> if the given point is inside the clipping frustum; <code>false</code> otherwise
+     */
+    public boolean isPointInsideFrustum(float x, float y, float z) {
+        return nxX * x + nxY * y + nxZ * z + nxW >= 0 &&
+               pxX * x + pxY * y + pxZ * z + pxW >= 0 &&
+               nyX * x + nyY * y + nyZ * z + nyW >= 0 &&
+               pyX * x + pyY * y + pyZ * z + pyW >= 0 &&
+               nzX * x + nzY * y + nzZ * z + nzW >= 0 &&
+               pzX * x + pzY * y + pzZ * z + pzW >= 0;
+    }
+
+    /**
+     * Determine whether the given sphere is partly or completely within the viewing frustum defined by <code>this</code> frustum culler.
+     * <p>
+     * The algorithm implemented by this method is conservative. This means that in certain circumstances a <i>false positive</i>
+     * can occur, when the method returns <tt>true</tt> for spheres that are actually not visible.
+     * See <a href="http://iquilezles.org/www/articles/frustumcorrect/frustumcorrect.htm">iquilezles.org</a> for an examination of this problem.
+     * 
+     * @param center
+     *          the sphere's center
+     * @param radius
+     *          the sphere's radius
+     * @return <code>true</code> if the given sphere is partly or completely inside the clipping frustum;
+     *         <code>false</code> otherwise
+     */
+    public boolean isSphereInsideFrustum(Vector3f center, float radius) {
+        return isSphereInsideFrustum(center.x, center.y, center.z, radius);
+    }
+
+    /**
+     * Determine whether the given sphere is partly or completely within the viewing frustum defined by <code>this</code> frustum culler.
+     * <p>
+     * The algorithm implemented by this method is conservative. This means that in certain circumstances a <i>false positive</i>
+     * can occur, when the method returns <tt>true</tt> for spheres that are actually not visible.
+     * See <a href="http://iquilezles.org/www/articles/frustumcorrect/frustumcorrect.htm">iquilezles.org</a> for an examination of this problem.
+     * 
+     * @param x
+     *          the x-coordinate of the sphere's center
+     * @param y
+     *          the y-coordinate of the sphere's center
+     * @param z
+     *          the z-coordinate of the sphere's center
+     * @param r
+     *          the sphere's radius
+     * @return <code>true</code> if the given sphere is partly or completely inside the clipping frustum;
+     *         <code>false</code> otherwise
+     */
+    public boolean isSphereInsideFrustum(float x, float y, float z, float r) {
+        return nxX * x + nxY * y + nxZ * z + nxW >= -r &&
+               pxX * x + pxY * y + pxZ * z + pxW >= -r &&
+               nyX * x + nyY * y + nyZ * z + nyW >= -r &&
+               pyX * x + pyY * y + pyZ * z + pyW >= -r &&
+               nzX * x + nzY * y + nzZ * z + nzW >= -r &&
+               pzX * x + pzY * y + pzZ * z + pzW >= -r;
+    }
+
+    /**
+     * Determine whether the given axis-aligned box is partly or completely within the viewing frustum defined by <code>this</code> frustum culler
+     * and, if the box is not inside this frustum, return the index of the plane that culled it.
+     * The box is specified via its <code>min</code> and <code>max</code> corner coordinates.
+     * <p>
+     * The algorithm implemented by this method is conservative. This means that in certain circumstances a <i>false positive</i>
+     * can occur, when the method returns <tt>true</tt> for boxes that are actually not visible.
+     * See <a href="http://iquilezles.org/www/articles/frustumcorrect/frustumcorrect.htm">iquilezles.org</a> for an examination of this problem.
+     * 
+     * @param min
+     *          the minimum corner coordinates of the axis-aligned box
+     * @param max
+     *          the maximum corner coordinates of the axis-aligned box
+     * @return the index of the first plane that culled the box, if the box does not intersect the frustum;
+     *         or <tt>-1</tt> if the box intersects the frustum.
+     *         The plane index is one of
+     *         {@link #PLANE_NX}, {@link #PLANE_PX},
+     *         {@link #PLANE_NY}, {@link #PLANE_PY},
+     *         {@link #PLANE_NZ} and {@link #PLANE_PZ}
+     */
+    public int isAabInsideFrustum(Vector3f min, Vector3f max) {
+        return isAabInsideFrustum(min.x, min.y, min.z, max.x, max.y, max.z);
+    }
+
+    /**
+     * Determine whether the given axis-aligned box is partly or completely within the viewing frustum defined by <code>this</code> frustum culler
+     * and, if the box is not inside this frustum, return the index of the plane that culled it.
+     * The box is specified via its min and max corner coordinates.
+     * <p>
+     * The algorithm implemented by this method is conservative. This means that in certain circumstances a <i>false positive</i>
+     * can occur, when the method returns <tt>true</tt> for boxes that are actually not visible.
+     * See <a href="http://iquilezles.org/www/articles/frustumcorrect/frustumcorrect.htm">iquilezles.org</a> for an examination of this problem.
+     * <p>
+     * Reference: <a href="http://www.cescg.org/CESCG-2002/DSykoraJJelinek/">Efficient View Frustum Culling</a>
+     * 
+     * @param minX
+     *          the x-coordinate of the minimum corner
+     * @param minY
+     *          the y-coordinate of the minimum corner
+     * @param minZ
+     *          the z-coordinate of the minimum corner
+     * @param maxX
+     *          the x-coordinate of the maximum corner
+     * @param maxY
+     *          the y-coordinate of the maximum corner
+     * @param maxZ
+     *          the z-coordinate of the maximum corner
+     * @return the index of the first plane that culled the box, if the box does not intersect the frustum;
+     *         or <tt>-1</tt> if the box intersects the frustum.
+     *         The plane index is one of
+     *         {@link #PLANE_NX}, {@link #PLANE_PX},
+     *         {@link #PLANE_NY}, {@link #PLANE_PY},
+     *         {@link #PLANE_NZ} and {@link #PLANE_PZ}
+     */
+    public int isAabInsideFrustum(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+        /*
+         * This is an implementation of the "2.4 Basic intersection test" of the mentioned site.
+         * It does not distinguish between partially inside and fully inside, though, so the test with the 'p' vertex is omitted.
+         * 
+         * In addition to the algorithm in the paper, this method also returns the index of the first plane that culled the box
+         * or -1 if the box intersects the frustum.
+         */
+        int plane = PLANE_NX;
+        if (nxX * (nxX < 0 ? minX : maxX) + nxY * (nxY < 0 ? minY : maxY) + nxZ * (nxZ < 0 ? minZ : maxZ) >= -nxW && (plane = PLANE_PX) != 0 &&
+            pxX * (pxX < 0 ? minX : maxX) + pxY * (pxY < 0 ? minY : maxY) + pxZ * (pxZ < 0 ? minZ : maxZ) >= -pxW && (plane = PLANE_NY) != 0 &&
+            nyX * (nyX < 0 ? minX : maxX) + nyY * (nyY < 0 ? minY : maxY) + nyZ * (nyZ < 0 ? minZ : maxZ) >= -nyW && (plane = PLANE_PY) != 0 &&
+            pyX * (pyX < 0 ? minX : maxX) + pyY * (pyY < 0 ? minY : maxY) + pyZ * (pyZ < 0 ? minZ : maxZ) >= -pyW && (plane = PLANE_NZ) != 0 &&
+            nzX * (nzX < 0 ? minX : maxX) + nzY * (nzY < 0 ? minY : maxY) + nzZ * (nzZ < 0 ? minZ : maxZ) >= -nzW && (plane = PLANE_PZ) != 0 &&
+            pzX * (pzX < 0 ? minX : maxX) + pzY * (pzY < 0 ? minY : maxY) + pzZ * (pzZ < 0 ? minZ : maxZ) >= -pzW)
+            return -1;
+        return plane;
+    }
+
+    /**
+     * Determine whether the given axis-aligned box is partly or completely within the viewing frustum defined by <code>this</code> frustum culler
+     * and, if the box is not inside this frustum, return the index of the plane that culled it.
+     * The box is specified via its <code>min</code> and <code>max</code> corner coordinates.
+     * <p>
+     * This method differs from {@link #isAabInsideFrustum(Vector3f, Vector3f) isAabInsideFrustum()} in that
+     * it allows to mask-off planes that should not be calculated. For example, in order to only test a box against the
+     * left frustum plane, use a mask of {@link #PLANE_MASK_NX}. Or in order to test all planes <i>except</i> the left plane, use 
+     * a mask of <tt>(~0 ^ PLANE_MASK_NX)</tt>.
+     * <p>
+     * The algorithm implemented by this method is conservative. This means that in certain circumstances a <i>false positive</i>
+     * can occur, when the method returns <tt>true</tt> for boxes that are actually not visible.
+     * See <a href="http://iquilezles.org/www/articles/frustumcorrect/frustumcorrect.htm">iquilezles.org</a> for an examination of this problem.
+     * 
+     * @param min
+     *          the minimum corner coordinates of the axis-aligned box
+     * @param max
+     *          the maximum corner coordinates of the axis-aligned box
+     * @param mask
+     *          contains as bitset all the planes that should be tested.
+     *          This value can be any combination of 
+     *          {@link #PLANE_MASK_NX}, {@link #PLANE_MASK_PY},
+     *          {@link #PLANE_MASK_NY}, {@link #PLANE_MASK_PY}, 
+     *          {@link #PLANE_MASK_NZ} and {@link #PLANE_MASK_PZ}
+     * @return the index of the first plane that culled the box, if the box does not intersect the frustum;
+     *         or <tt>-1</tt> if the box intersects the frustum.
+     *         The plane index is one of
+     *         {@link #PLANE_NX}, {@link #PLANE_PX},
+     *         {@link #PLANE_NY}, {@link #PLANE_PY},
+     *         {@link #PLANE_NZ} and {@link #PLANE_PZ}
+     */
+    public int isAabInsideFrustumMasked(Vector3f min, Vector3f max, int mask) {
+        return isAabInsideFrustumMasked(min.x, min.y, min.z, max.x, max.y, max.z, mask);
+    }
+
+    /**
+     * Determine whether the given axis-aligned box is partly or completely within the viewing frustum defined by <code>this</code> frustum culler
+     * and, if the box is not inside this frustum, return the index of the plane that culled it.
+     * The box is specified via its min and max corner coordinates.
+     * <p>
+     * This method differs from {@link #isAabInsideFrustum(float, float, float, float, float, float) isAabInsideFrustum()} in that
+     * it allows to mask-off planes that should not be calculated. For example, in order to only test a box against the
+     * left frustum plane, use a mask of {@link #PLANE_MASK_NX}. Or in order to test all planes <i>except</i> the left plane, use 
+     * a mask of <tt>(~0 ^ PLANE_MASK_NX)</tt>.
+     * <p>
+     * The algorithm implemented by this method is conservative. This means that in certain circumstances a <i>false positive</i>
+     * can occur, when the method returns <tt>true</tt> for boxes that are actually not visible.
+     * See <a href="http://iquilezles.org/www/articles/frustumcorrect/frustumcorrect.htm">iquilezles.org</a> for an examination of this problem.
+     * <p>
+     * Reference: <a href="http://www.cescg.org/CESCG-2002/DSykoraJJelinek/">Efficient View Frustum Culling</a>
+     * 
+     * @param minX
+     *          the x-coordinate of the minimum corner
+     * @param minY
+     *          the y-coordinate of the minimum corner
+     * @param minZ
+     *          the z-coordinate of the minimum corner
+     * @param maxX
+     *          the x-coordinate of the maximum corner
+     * @param maxY
+     *          the y-coordinate of the maximum corner
+     * @param maxZ
+     *          the z-coordinate of the maximum corner
+     * @param mask
+     *          contains as bitset all the planes that should be tested.
+     *          This value can be any combination of 
+     *          {@link #PLANE_MASK_NX}, {@link #PLANE_MASK_PY},
+     *          {@link #PLANE_MASK_NY}, {@link #PLANE_MASK_PY}, 
+     *          {@link #PLANE_MASK_NZ} and {@link #PLANE_MASK_PZ}
+     * @return the index of the first plane that culled the box, if the box does not intersect the frustum;
+     *         or <tt>-1</tt> if the box intersects the frustum.
+     *         The plane index is one of
+     *         {@link #PLANE_NX}, {@link #PLANE_PX},
+     *         {@link #PLANE_NY}, {@link #PLANE_PY},
+     *         {@link #PLANE_NZ} and {@link #PLANE_PZ}
+     */
+    public int isAabInsideFrustumMasked(float minX, float minY, float minZ, float maxX, float maxY, float maxZ, int mask) {
+        /*
+         * This is an implementation of the "2.5 Plane masking and coherency" of the mentioned site.
+         * It does not distinguish between partially inside and fully inside, though, so the test with the 'p' vertex is omitted.
+         * 
+         * In addition to the algorithm in the paper, this method also returns the index of the first plane that culled the box
+         * or -1 if the box intersects the frustum.
+         */
+        int plane = PLANE_NX;
+        if (((mask & PLANE_MASK_NX) == 0 || nxX * (nxX < 0 ? minX : maxX) + nxY * (nxY < 0 ? minY : maxY) + nxZ * (nxZ < 0 ? minZ : maxZ) >= -nxW) && (plane = PLANE_PX) != 0 &&
+            ((mask & PLANE_MASK_PX) == 0 || pxX * (pxX < 0 ? minX : maxX) + pxY * (pxY < 0 ? minY : maxY) + pxZ * (pxZ < 0 ? minZ : maxZ) >= -pxW) && (plane = PLANE_NY) != 0 &&
+            ((mask & PLANE_MASK_NY) == 0 || nyX * (nyX < 0 ? minX : maxX) + nyY * (nyY < 0 ? minY : maxY) + nyZ * (nyZ < 0 ? minZ : maxZ) >= -nyW) && (plane = PLANE_PY) != 0 &&
+            ((mask & PLANE_MASK_PY) == 0 || pyX * (pyX < 0 ? minX : maxX) + pyY * (pyY < 0 ? minY : maxY) + pyZ * (pyZ < 0 ? minZ : maxZ) >= -pyW) && (plane = PLANE_NZ) != 0 &&
+            ((mask & PLANE_MASK_NZ) == 0 || nzX * (nzX < 0 ? minX : maxX) + nzY * (nzY < 0 ? minY : maxY) + nzZ * (nzZ < 0 ? minZ : maxZ) >= -nzW) && (plane = PLANE_PZ) != 0 &&
+            ((mask & PLANE_MASK_PZ) == 0 || pzX * (pzX < 0 ? minX : maxX) + pzY * (pzY < 0 ? minY : maxY) + pzZ * (pzZ < 0 ? minZ : maxZ) >= -pzW))
+            return -1;
+        return plane;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/FrustumRayBuilder.java
+++ b/GVRf/Framework/src/org/joml/FrustumRayBuilder.java
@@ -1,0 +1,153 @@
+/*
+ * (C) Copyright 2015 Kai Burjack
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+/**
+ * Provides methods to compute rays through an arbitrary perspective transformation defined by a {@link Matrix4f}.
+ * <p>
+ * This can be used to compute the eye-rays in simple software-based raycasting/raytracing.
+ * <p>
+ * To obtain the origin of the rays call {@link #origin(Vector3f)}.
+ * Then to compute the directions of subsequent rays use {@link #dir(float, float, Vector3f)}.
+ * 
+ * @author Kai Burjack
+ */
+public class FrustumRayBuilder {
+
+    private float nxnyX, nxnyY, nxnyZ;
+    private float pxnyX, pxnyY, pxnyZ;
+    private float pxpyX, pxpyY, pxpyZ;
+    private float nxpyX, nxpyY, nxpyZ;
+    private float cx, cy, cz;
+
+    /**
+     * Create a new {@link FrustumRayBuilder} with an undefined frustum.
+     * <p>
+     * Before obtaining ray directions, make sure to define the frustum using {@link #set(Matrix4f)}.
+     */
+    public FrustumRayBuilder() {
+    }
+
+    /**
+     * Create a new {@link FrustumRayBuilder} from the given {@link Matrix4f matrix} by extracing the matrix's frustum.
+     * 
+     * @param m
+     *          the {@link Matrix4f} to create the frustum from
+     */
+    public FrustumRayBuilder(Matrix4f m) {
+        set(m);
+    }
+
+    /**
+     * Update the stored frustum corner rays and origin of <code>this</code> {@link FrustumRayBuilder} with the given {@link Matrix4f matrix}.
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * <p>
+     * Reference: <a href="http://geomalgorithms.com/a05-_intersect-1.html">http://geomalgorithms.com</a>
+     * 
+     * @param m
+     *          the {@link Matrix4f matrix} to update the frustum corner rays and origin with
+     * @return this
+     */
+    public FrustumRayBuilder set(Matrix4f m) {
+        float nxX = m.m03 + m.m00, nxY = m.m13 + m.m10, nxZ = m.m23 + m.m20, d1 = m.m33 + m.m30;
+        float pxX = m.m03 - m.m00, pxY = m.m13 - m.m10, pxZ = m.m23 - m.m20, d2 = m.m33 - m.m30;
+        float nyX = m.m03 + m.m01, nyY = m.m13 + m.m11, nyZ = m.m23 + m.m21;
+        float pyX = m.m03 - m.m01, pyY = m.m13 - m.m11, pyZ = m.m23 - m.m21, d3 = m.m33 - m.m31;
+        // bottom left
+        nxnyX = nyY * nxZ - nyZ * nxY;
+        nxnyY = nyZ * nxX - nyX * nxZ;
+        nxnyZ = nyX * nxY - nyY * nxX;
+        // bottom right
+        pxnyX = pxY * nyZ - pxZ * nyY;
+        pxnyY = pxZ * nyX - pxX * nyZ;
+        pxnyZ = pxX * nyY - pxY * nyX;
+        // top left
+        nxpyX = nxY * pyZ - nxZ * pyY;
+        nxpyY = nxZ * pyX - nxX * pyZ;
+        nxpyZ = nxX * pyY - nxY * pyX;
+        // top right
+        pxpyX = pyY * pxZ - pyZ * pxY;
+        pxpyY = pyZ * pxX - pyX * pxZ;
+        pxpyZ = pyX * pxY - pyY * pxX;
+        // compute origin
+        float pxnxX, pxnxY, pxnxZ;
+        pxnxX = pxY * nxZ - pxZ * nxY;
+        pxnxY = pxZ * nxX - pxX * nxZ;
+        pxnxZ = pxX * nxY - pxY * nxX;
+        float invDot = 1.0f / (nxX * pxpyX + nxY * pxpyY + nxZ * pxpyZ);
+        cx = (-pxpyX * d1 - nxpyX * d2 - pxnxX * d3) * invDot;
+        cy = (-pxpyY * d1 - nxpyY * d2 - pxnxY * d3) * invDot;
+        cz = (-pxpyZ * d1 - nxpyZ * d2 - pxnxZ * d3) * invDot;
+        return this;
+    }
+
+    /**
+     * Store the eye/origin of the perspective frustum in the given <code>origin</code>.
+     * 
+     * @param origin
+     *          will hold the perspective origin
+     * @return the <code>origin</code> vector
+     */
+    public Vector3f origin(Vector3f origin) {
+        origin.x = cx;
+        origin.y = cy;
+        origin.z = cz;
+        return origin;
+    }
+
+    /**
+     * Obtain the normalized direction of a ray starting at the center of the coordinate system and going 
+     * through the near frustum plane.
+     * <p>
+     * The parameters <code>x</code> and <code>y</code> are used to interpolate the generated ray direction
+     * from the bottom-left to the top-right frustum corners.
+     * 
+     * @param x
+     *          the interpolation factor along the left-to-right frustum planes, within <tt>[0..1]</tt>
+     * @param y
+     *          the interpolation factor along the bottom-to-top frustum planes, within <tt>[0..1]</tt>
+     * @param dir
+     *          will hold the normalized ray direction
+     * @return the <code>dir</code> vector
+     */
+    public Vector3f dir(float x, float y, Vector3f dir) {
+        float y1x = nxnyX + (nxpyX - nxnyX) * y;
+        float y1y = nxnyY + (nxpyY - nxnyY) * y;
+        float y1z = nxnyZ + (nxpyZ - nxnyZ) * y;
+        float y2x = pxnyX + (pxpyX - pxnyX) * y;
+        float y2y = pxnyY + (pxpyY - pxnyY) * y;
+        float y2z = pxnyZ + (pxpyZ - pxnyZ) * y;
+        float dx = y1x + (y2x - y1x) * x;
+        float dy = y1y + (y2y - y1y) * x;
+        float dz = y1z + (y2z - y1z) * x;
+        // normalize the vector
+        float invLen = (float) (1.0 / Math.sqrt(dx * dx + dy * dy + dz * dz));
+        dir.x = dx * invLen;
+        dir.y = dy * invLen;
+        dir.z = dz * invLen;
+        return dir;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/GeometryUtils.java
+++ b/GVRf/Framework/src/org/joml/GeometryUtils.java
@@ -1,0 +1,137 @@
+/*
+ * (C) Copyright 2015 Kai Burjack
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+/**
+ * Useful geometry methods.
+ * 
+ * @author Kai Burjack
+ * @author Richard Greenlees
+ */
+public class GeometryUtils {
+
+    /**
+     * Calculate the normal of a surface defined by points <code>v1</code>, <code>v2</code> and <code>v3</code> and
+     * store it in <code>dest</code>.
+     * 
+     * @param v1
+     *          the first position
+     * @param v2
+     *          the second position
+     * @param v3
+     *          the third position
+     * @param dest
+     *          will hold the result
+     */
+    public static void normal(Vector3f v1, Vector3f v2, Vector3f v3, Vector3f dest) {
+        dest.x = ((v2.y - v1.y) * (v3.z - v1.z)) - ((v2.z - v1.z) * (v3.y - v1.y));
+        dest.y = ((v2.z - v1.z) * (v3.x - v1.x)) - ((v2.x - v1.x) * (v3.z - v1.z));
+        dest.z = ((v2.x - v1.x) * (v3.y - v1.y)) - ((v2.y - v1.y) * (v3.x - v1.x));
+        dest.normalize();
+    }
+
+    /**
+     * Calculate the surface tangent for the three supplied vertices and UV
+     * coordinates and store the result in <code>dest</code>.
+     *
+     * @param v1 XYZ of first vertex
+     * @param uv1 UV of first vertex
+     * @param v2 XYZ of second vertex
+     * @param uv2 UV of second vertex
+     * @param v3 XYZ of third vertex
+     * @param uv3 UV of third vertex
+     * @param dest the tangent will be stored here
+     */
+    public static void tangent(Vector3f v1, Vector2f uv1, Vector3f v2, Vector2f uv2, Vector3f v3, Vector2f uv3, Vector3f dest) {
+        float DeltaV1 = uv2.y - uv1.y;
+        float DeltaV2 = uv3.y - uv1.y;
+
+        float f = 1.0f / ((uv2.x - uv1.x) * DeltaV2 - (uv3.x - uv1.x) * DeltaV1);
+
+        dest.x = f * (DeltaV2 * (v2.x - v1.x) - DeltaV1 * (v3.x - v1.x));
+        dest.y = f * (DeltaV2 * (v2.y - v1.y) - DeltaV1 * (v3.y - v1.y));
+        dest.z = f * (DeltaV2 * (v2.z - v1.z) - DeltaV1 * (v3.z - v1.z));
+
+        dest.normalize();
+    }
+
+    /**
+     * Calculate the surface bitangent for the three supplied vertices and UV
+     * coordinates and store the result in <code>dest</code>.
+     *
+     * @param v1 XYZ of first vertex
+     * @param uv1 UV of first vertex
+     * @param v2 XYZ of second vertex
+     * @param uv2 UV of second vertex
+     * @param v3 XYZ of third vertex
+     * @param uv3 UV of third vertex
+     * @param dest the binormal will be stored here
+     */
+    public static void bitangent(Vector3f v1, Vector2f uv1, Vector3f v2, Vector2f uv2, Vector3f v3, Vector2f uv3, Vector3f dest) {
+        float DeltaU1 = uv2.x - uv1.x;
+        float DeltaU2 = uv3.x - uv1.x;
+
+        float f = 1.0f / (DeltaU1 * (uv3.y - uv1.y) - DeltaU2 * (uv2.y - uv1.y));
+
+        dest.x = f * (-DeltaU2 * (v2.x - v1.x) - DeltaU1 * (v3.x - v1.x));
+        dest.y = f * (-DeltaU2 * (v2.y - v1.y) - DeltaU1 * (v3.y - v1.y));
+        dest.z = f * (-DeltaU2 * (v2.z - v1.z) - DeltaU1 * (v3.z - v1.z));
+
+        dest.normalize();
+    }
+
+    /**
+     * Calculate the surface tangent and bitangent for the three supplied vertices
+     * and UV coordinates and store the result in <code>dest</code>.
+     *
+     * @param v1 XYZ of first vertex
+     * @param uv1 UV of first vertex
+     * @param v2 XYZ of second vertex
+     * @param uv2 UV of second vertex
+     * @param v3 XYZ of third vertex
+     * @param uv3 UV of third vertex
+     * @param destTangent the tangent will be stored here
+     * @param destBitangent the bitangent will be stored here
+     */
+    public static void tangentBitangent(Vector3f v1, Vector2f uv1, Vector3f v2, Vector2f uv2, Vector3f v3, Vector2f uv3, Vector3f destTangent, Vector3f destBitangent) {
+        float DeltaV1 = uv2.y - uv1.y;
+        float DeltaV2 = uv3.y - uv1.y;
+        float DeltaU1 = uv2.x - uv1.x;
+        float DeltaU2 = uv3.x - uv1.x;
+
+        float f = 1.0f / (DeltaU1 * DeltaV2 - DeltaU2 * DeltaV1);
+
+        destTangent.x = f * (DeltaV2 * (v2.x - v1.x) - DeltaV1 * (v3.x - v1.x));
+        destTangent.y = f * (DeltaV2 * (v2.y - v1.y) - DeltaV1 * (v3.y - v1.y));
+        destTangent.z = f * (DeltaV2 * (v2.z - v1.z) - DeltaV1 * (v3.z - v1.z));
+
+        destTangent.normalize();
+
+        destBitangent.x = f * (-DeltaU2 * (v2.x - v1.x) - DeltaU1 * (v3.x - v1.x));
+        destBitangent.y = f * (-DeltaU2 * (v2.y - v1.y) - DeltaU1 * (v3.y - v1.y));
+        destBitangent.z = f * (-DeltaU2 * (v2.z - v1.z) - DeltaU1 * (v3.z - v1.z));
+
+        destBitangent.normalize();
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/LICENSE
+++ b/GVRf/Framework/src/org/joml/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 JOML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/GVRf/Framework/src/org/joml/Matrix3d.java
+++ b/GVRf/Framework/src/org/joml/Matrix3d.java
@@ -1,0 +1,2953 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Contains the definition of a 3x3 Matrix of doubles, and associated functions to transform
+ * it. The matrix is column-major to match OpenGL's interpretation, and it looks like this:
+ * <p>
+ *      m00  m10  m20<br>
+ *      m01  m11  m21<br>
+ *      m02  m12  m22<br>
+ * 
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Matrix3d implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    public double m00, m10, m20;
+    public double m01, m11, m21;
+    public double m02, m12, m22;
+
+    /**
+     * Create a new {@link Matrix3d} and initialize it to {@link #identity() identity}.
+     */
+    public Matrix3d() {
+        m00 = 1.0;
+        m01 = 0.0;
+        m02 = 0.0;
+        m10 = 0.0;
+        m11 = 1.0;
+        m12 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = 1.0;
+    }
+
+    /**
+     * Create a new {@link Matrix3d} and initialize it with the values from the given matrix.
+     * 
+     * @param mat
+     *          the matrix to initialize this matrix with
+     */
+    public Matrix3d(Matrix3d mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+    }
+
+    /**
+     * Create a new {@link Matrix3d} and initialize it with the values from the given matrix.
+     * 
+     * @param mat
+     *          the matrix to initialize this matrix with
+     */
+    public Matrix3d(Matrix3f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+    }
+
+    /**
+     * Create a new {@link Matrix3d} and make it a copy of the upper left 3x3 of the given {@link Matrix4f}.
+     *
+     * @param mat
+     *          the {@link Matrix4f} to copy the values from
+     */
+    public Matrix3d(Matrix4f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+    }
+
+    /**
+     * Create a new {@link Matrix3d} and make it a copy of the upper left 3x3 of the given {@link Matrix4d}.
+     *
+     * @param mat
+     *          the {@link Matrix4d} to copy the values from
+     */
+    public Matrix3d(Matrix4d mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+    }
+
+    /**
+     * Create a new {@link Matrix3d} and initialize its elements with the given values.
+     * 
+     * @param m00
+     *          the value of m00
+     * @param m01
+     *          the value of m01
+     * @param m02
+     *          the value of m02
+     * @param m10
+     *          the value of m10
+     * @param m11
+     *          the value of m11
+     * @param m12
+     *          the value of m12
+     * @param m20
+     *          the value of m20
+     * @param m21
+     *          the value of m21
+     * @param m22
+     *          the value of m22
+     */
+    public Matrix3d(double m00, double m01, double m02,
+                    double m10, double m11, double m12, 
+                    double m20, double m21, double m22) {
+        this.m00 = m00;
+        this.m01 = m01;
+        this.m02 = m02;
+        this.m10 = m10;
+        this.m11 = m11;
+        this.m12 = m12;
+        this.m20 = m20;
+        this.m21 = m21;
+        this.m22 = m22;
+    }
+
+    /**
+     * Set the values in this matrix to the ones in m.
+     * 
+     * @param m
+     *          the matrix whose values will be copied
+     * @return this
+     */
+    public Matrix3d set(Matrix3d m) {
+        m00 = m.m00;
+        m01 = m.m01;
+        m02 = m.m02;
+        m10 = m.m10;
+        m11 = m.m11;
+        m12 = m.m12;
+        m20 = m.m20;
+        m21 = m.m21;
+        m22 = m.m22;
+        return this;
+    }
+
+    /**
+     * Set the values in this matrix to the ones in m.
+     * 
+     * @param m
+     *          the matrix whose values will be copied
+     * @return this
+     */
+    public Matrix3d set(Matrix3f m) {
+        m00 = m.m00;
+        m01 = m.m01;
+        m02 = m.m02;
+        m10 = m.m10;
+        m11 = m.m11;
+        m12 = m.m12;
+        m20 = m.m20;
+        m21 = m.m21;
+        m22 = m.m22;
+        return this;
+    }
+
+    /**
+     * Set the elements of this matrix to the upper left 3x3 of the given {@link Matrix4f}.
+     *
+     * @param mat
+     *          the {@link Matrix4f} to copy the values from
+     * @return this
+     */
+    public Matrix3d set(Matrix4f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        return this;
+    }
+
+    /**
+     * Set the elements of this matrix to the upper left 3x3 of the given {@link Matrix4d}.
+     *
+     * @param mat
+     *          the {@link Matrix4d} to copy the values from
+     * @return this
+     */
+    public Matrix3d set(Matrix4d mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        return this;
+    }
+    
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link AxisAngle4f}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f}
+     * @return this
+     */
+    public Matrix3d set(AxisAngle4f axisAngle) {
+        double x = axisAngle.x;
+        double y = axisAngle.y;
+        double z = axisAngle.z;
+        double angle = axisAngle.angle;
+        double invLength = 1.0 / Math.sqrt(x*x + y*y + z*z);
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        double c = Math.cos(angle);
+        double s = Math.sin(angle);
+        double omc = 1.0 - c;
+        m00 = c + x*x*omc;
+        m11 = c + y*y*omc;
+        m22 = c + z*z*omc;
+        double tmp1 = x*y*omc;
+        double tmp2 = z*s;
+        m10 = tmp1 - tmp2;
+        m01 = tmp1 + tmp2;
+        tmp1 = x*z*omc;
+        tmp2 = y*s;
+        m20 = tmp1 + tmp2;
+        m02 = tmp1 - tmp2;
+        tmp1 = y*z*omc;
+        tmp2 = x*s;
+        m21 = tmp1 - tmp2;
+        m12 = tmp1 + tmp2;
+        return this;
+    }
+    
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link AxisAngle4d}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d}
+     * @return this
+     */
+    public Matrix3d set(AxisAngle4d axisAngle) {
+        double x = axisAngle.x;
+        double y = axisAngle.y;
+        double z = axisAngle.z;
+        double angle = axisAngle.angle;
+        double invLength = 1.0 / Math.sqrt(x*x + y*y + z*z);
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        double c = Math.cos(angle);
+        double s = Math.sin(angle);
+        double omc = 1.0 - c;
+        m00 = c + x*x*omc;
+        m11 = c + y*y*omc;
+        m22 = c + z*z*omc;
+        double tmp1 = x*y*omc;
+        double tmp2 = z*s;
+        m10 = tmp1 - tmp2;
+        m01 = tmp1 + tmp2;
+        tmp1 = x*z*omc;
+        tmp2 = y*s;
+        m20 = tmp1 + tmp2;
+        m02 = tmp1 - tmp2;
+        tmp1 = y*z*omc;
+        tmp2 = x*s;
+        m21 = tmp1 - tmp2;
+        m12 = tmp1 + tmp2;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation equivalent to the given quaternion.
+     * 
+     * @see Quaternionf#get(Matrix3d)
+     * 
+     * @param q
+     *          the quaternion
+     * @return this
+     */
+    public Matrix3d set(Quaternionf q) {
+        q.get(this);
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation equivalent to the given quaternion.
+     * 
+     * @see Quaterniond#get(Matrix3d)
+     * 
+     * @param q
+     *          the quaternion
+     * @return this
+     */
+    public Matrix3d set(Quaterniond q) {
+        q.get(this);
+        return this;
+    }
+
+    /**
+     * Multiply this matrix by the supplied matrix.
+     * This matrix will be the left one.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand
+     * @return this
+     */
+    public Matrix3d mul(Matrix3d right) {
+        return mul(right, this);
+    }
+
+    /**
+     * Multiply this matrix by the supplied matrix and store the result in <code>dest</code>.
+     * This matrix will be the left one.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3d mul(Matrix3d right, Matrix3d dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22 );
+        return dest;
+    }
+
+    /**
+     * Multiply this matrix by the supplied matrix.
+     * This matrix will be the left one.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand
+     * @return this
+     */
+    public Matrix3d mul(Matrix3f right) {
+        return mul(right, this);
+    }
+
+    /**
+     * Multiply this matrix by the supplied matrix and store the result in <code>dest</code>.
+     * This matrix will be the left one.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3d mul(Matrix3f right, Matrix3d dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22);
+        return dest;
+    }
+
+    /**
+     * Multiply the <code>left</code> matrix by the <code>right</code> and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param left
+     *          the left matrix
+     * @param right
+     *          the right matrix
+     * @param dest
+     *          will hold the result
+     */
+    public static void mul(Matrix3f left, Matrix3d right, Matrix3d dest) {
+        dest.set(left.m00 * right.m00 + left.m10 * right.m01 + left.m20 * right.m02,
+                 left.m01 * right.m00 + left.m11 * right.m01 + left.m21 * right.m02,
+                 left.m02 * right.m00 + left.m12 * right.m01 + left.m22 * right.m02,
+                 left.m00 * right.m10 + left.m10 * right.m11 + left.m20 * right.m12,
+                 left.m01 * right.m10 + left.m11 * right.m11 + left.m21 * right.m12,
+                 left.m02 * right.m10 + left.m12 * right.m11 + left.m22 * right.m12,
+                 left.m00 * right.m20 + left.m10 * right.m21 + left.m20 * right.m22,
+                 left.m01 * right.m20 + left.m11 * right.m21 + left.m21 * right.m22,
+                 left.m02 * right.m20 + left.m12 * right.m21 + left.m22 * right.m22 );
+    }
+
+    /**
+     * Set the values within this matrix to the supplied double values. The result looks like this:
+     * <p>
+     * m00, m10, m20<br>
+     * m01, m11, m21<br>
+     * m02, m12, m22<br>
+     * 
+     * @param m00
+     *          the new value of m00
+     * @param m01
+     *          the new value of m01
+     * @param m02
+     *          the new value of m02
+     * @param m10
+     *          the new value of m10
+     * @param m11
+     *          the new value of m11
+     * @param m12
+     *          the new value of m12
+     * @param m20
+     *          the new value of m20
+     * @param m21
+     *          the new value of m21
+     * @param m22
+     *          the new value of m22
+     * @return this
+     */
+    public Matrix3d set(double m00, double m01, double m02, 
+                        double m10, double m11, double m12, 
+                        double m20, double m21, double m22) {
+        this.m00 = m00;
+        this.m01 = m01;
+        this.m02 = m02;
+        this.m10 = m10;
+        this.m11 = m11;
+        this.m12 = m12;
+        this.m20 = m20;
+        this.m21 = m21;
+        this.m22 = m22;
+        return this;
+    }
+
+    /**
+     * Set the values in this matrix based on the supplied double array. The result looks like this:
+     * <p>
+     * 0, 3, 6<br>
+     * 1, 4, 7<br>
+     * 2, 5, 8<br>
+     * <p>
+     * Only uses the first 9 values, all others are ignored.
+     * 
+     * @param m
+     *          the array to read the matrix values from
+     * @return this
+     */
+    public Matrix3d set(double m[]) {
+        m00 = m[0];
+        m01 = m[1];
+        m02 = m[2];
+        m10 = m[3];
+        m11 = m[4];
+        m12 = m[5];
+        m20 = m[6];
+        m21 = m[7];
+        m22 = m[8];
+        return this;
+    }
+
+    /**
+     * Set the values in this matrix based on the supplied double array. The result looks like this:
+     * <p>
+     * 0, 3, 6<br>
+     * 1, 4, 7<br>
+     * 2, 5, 8<br>
+     * <p>
+     * Only uses the first 9 values, all others are ignored
+     *
+     * @param m
+     *          the array to read the matrix values from
+     * @return this
+     */
+    public Matrix3d set(float m[]) {
+        m00 = m[0];
+        m01 = m[1];
+        m02 = m[2];
+        m10 = m[3];
+        m11 = m[4];
+        m12 = m[5];
+        m20 = m[6];
+        m21 = m[7];
+        m22 = m[8];
+        return this;
+    }
+
+    /**
+     * Return the determinant of this matrix.
+     * 
+     * @return the determinant
+     */
+    public double determinant() {
+        return m00 * (m11 * m22 - m12 * m21)
+             + m01 * (m12 * m20 - m10 * m22)
+             + m02 * (m01 * m21 - m11 * m20);
+    }
+
+    /**
+     * Invert this matrix.
+     * 
+     * @return this
+     */
+    public Matrix3d invert() {
+        return invert(this);
+    }
+
+    /**
+     * Invert <code>this</code> matrix and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3d invert(Matrix3d dest) {
+        double s = determinant();
+        // client must make sure that matrix is invertible
+        s = 1.0 / s;
+        dest.set((m11 * m22 - m21 * m12) * s,
+                 (m21 * m02 - m01 * m22) * s,
+                 (m01 * m12 - m11 * m02) * s,
+                 (m20 * m12 - m10 * m22) * s,
+                 (m00 * m22 - m20 * m02) * s,
+                 (m10 * m02 - m00 * m12) * s,
+                 (m10 * m21 - m20 * m11) * s,
+                 (m20 * m01 - m00 * m21) * s,
+                 (m00 * m11 - m10 * m01) * s);
+        return dest;
+    }
+
+    /**
+     * Transpose this matrix.
+     * 
+     * @return this
+     */
+    public Matrix3d transpose() {
+        return transpose(this);
+    }
+
+    /**
+     * Transpose <code>this</code> matrix and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3d transpose(Matrix3d dest) {
+        dest.set(m00, m10, m20,
+                 m01, m11, m21,
+                 m02, m12, m22);
+        return dest;
+    }
+
+    /**
+     * Return a string representation of this matrix.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt>  0.000E0; -</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat("  0.000E0; -"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this matrix by formatting the matrix elements with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the matrix values with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return formatter.format(m00) + formatter.format(m10) + formatter.format(m20) + "\n" //$NON-NLS-1$
+             + formatter.format(m01) + formatter.format(m11) + formatter.format(m21) + "\n" //$NON-NLS-1$
+             + formatter.format(m02) + formatter.format(m12) + formatter.format(m22) + "\n"; //$NON-NLS-1$
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store them into
+     * <code>dest</code>.
+     * <p>
+     * This is the reverse method of {@link #set(Matrix3d)} and allows to obtain
+     * intermediate calculation results when chaining multiple transformations.
+     * 
+     * @see #set(Matrix3d)
+     * 
+     * @param dest
+     *          the destination matrix
+     * @return the passed in destination
+     */
+    public Matrix3d get(Matrix3d dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link AxisAngle4f}.
+     * 
+     * @see AxisAngle4f#set(Matrix3d)
+     * 
+     * @param dest
+     *          the destination {@link AxisAngle4f}
+     * @return the passed in destination
+     */
+    public AxisAngle4f getRotation(AxisAngle4f dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaternionf}.
+     * <p>
+     * This method assumes that the three column vectors of this matrix are not normalized and
+     * thus allows to ignore any additional scaling factor that is applied to the matrix.
+     * 
+     * @see Quaternionf#setFromUnnormalized(Matrix3d)
+     * 
+     * @param dest
+     *          the destination {@link Quaternionf}
+     * @return the passed in destination
+     */
+    public Quaternionf getUnnormalizedRotation(Quaternionf dest) {
+        return dest.setFromUnnormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaternionf}.
+     * <p>
+     * This method assumes that the three column vectors of this matrix are normalized.
+     * 
+     * @see Quaternionf#setFromNormalized(Matrix3d)
+     * 
+     * @param dest
+     *          the destination {@link Quaternionf}
+     * @return the passed in destination
+     */
+    public Quaternionf getNormalizedRotation(Quaternionf dest) {
+        return dest.setFromNormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaterniond}.
+     * <p>
+     * This method assumes that the three column vectors of this matrix are not normalized and
+     * thus allows to ignore any additional scaling factor that is applied to the matrix.
+     * 
+     * @see Quaterniond#setFromUnnormalized(Matrix3d)
+     * 
+     * @param dest
+     *          the destination {@link Quaterniond}
+     * @return the passed in destination
+     */
+    public Quaterniond getUnnormalizedRotation(Quaterniond dest) {
+        return dest.setFromUnnormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaterniond}.
+     * <p>
+     * This method assumes that the three column vectors of this matrix are normalized.
+     * 
+     * @see Quaterniond#setFromNormalized(Matrix3d)
+     * 
+     * @param dest
+     *          the destination {@link Quaterniond}
+     * @return the passed in destination
+     */
+    public Quaterniond getNormalizedRotation(Quaterniond dest) {
+        return dest.setFromNormalized(this);
+    }
+
+    /**
+     * Store this matrix into the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position} using column-major order.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer} at which
+     * the matrix is stored, use {@link #get(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, DoubleBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public DoubleBuffer get(DoubleBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix into the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index using column-major order.
+     * <p>
+     * This method will not increment the position of the given {@link DoubleBuffer}.
+     * 
+     * @param index
+     *            the absolute position into the {@link DoubleBuffer}
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public DoubleBuffer get(int index, DoubleBuffer buffer) {
+        buffer.put(index, m00);
+        buffer.put(index+1, m01);
+        buffer.put(index+2, m02);
+        buffer.put(index+3, m10);
+        buffer.put(index+4, m11);
+        buffer.put(index+5, m12);
+        buffer.put(index+6, m20);
+        buffer.put(index+7, m21);
+        buffer.put(index+8, m22);
+        return buffer;
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the matrix is stored, use {@link #get(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     * <p>
+     * Please note that due to this matrix storing double values those values will potentially
+     * lose precision when they are converted to float values before being put into the given FloatBuffer.
+     * 
+     * @see #get(int, FloatBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(FloatBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * Please note that due to this matrix storing double values those values will potentially
+     * lose precision when they are converted to float values before being put into the given FloatBuffer.
+     * 
+     * @param index
+     *            the absolute position into the FloatBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(int index, FloatBuffer buffer) {
+        buffer.put(index, (float) m00);
+        buffer.put(index+1, (float) m01);
+        buffer.put(index+2, (float) m02);
+        buffer.put(index+3, (float) m10);
+        buffer.put(index+4, (float) m11);
+        buffer.put(index+5, (float) m12);
+        buffer.put(index+6, (float) m20);
+        buffer.put(index+7, (float) m21);
+        buffer.put(index+8, (float) m22);
+        return buffer;
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the matrix is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, ByteBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * 
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putDouble(index+8*0, m00);
+        buffer.putDouble(index+8*1, m01);
+        buffer.putDouble(index+8*2, m02);
+        buffer.putDouble(index+8*3, m10);
+        buffer.putDouble(index+8*4, m11);
+        buffer.putDouble(index+8*5, m12);
+        buffer.putDouble(index+8*6, m20);
+        buffer.putDouble(index+8*7, m21);
+        buffer.putDouble(index+8*8, m22);
+        return buffer;
+    }
+
+    /**
+     * Store the elements of this matrix as float values in column-major order into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * Please note that due to this matrix storing double values those values will potentially
+     * lose precision when they are converted to float values before being put into the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the matrix is stored, use {@link #getFloats(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #getFloats(int, ByteBuffer)
+     * 
+     * @param buffer
+     *            will receive the elements of this matrix as float values in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public ByteBuffer getFloats(ByteBuffer buffer) {
+        return getFloats(buffer.position(), buffer);
+    }
+
+    /**
+     * Store the elements of this matrix as float values in column-major order into the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * Please note that due to this matrix storing double values those values will potentially
+     * lose precision when they are converted to float values before being put into the given ByteBuffer.
+     * 
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            will receive the elements of this matrix as float values in column-major order
+     * @return the passed in buffer
+     */
+    public ByteBuffer getFloats(int index, ByteBuffer buffer) {
+        buffer.putFloat(index+4*0,  (float)m00);
+        buffer.putFloat(index+4*1,  (float)m01);
+        buffer.putFloat(index+4*2,  (float)m02);
+        buffer.putFloat(index+4*3,  (float)m10);
+        buffer.putFloat(index+4*4,  (float)m11);
+        buffer.putFloat(index+4*5,  (float)m12);
+        buffer.putFloat(index+4*6,  (float)m20);
+        buffer.putFloat(index+4*7,  (float)m21);
+        buffer.putFloat(index+4*8, (float)m22);
+        return buffer;
+    }
+
+    /**
+     * Set the values of this matrix by reading 9 double values from the given {@link DoubleBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The DoubleBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the DoubleBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the DoubleBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix3d set(DoubleBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.get(pos);
+        m01 = buffer.get(pos+1);
+        m02 = buffer.get(pos+2);
+        m10 = buffer.get(pos+3);
+        m11 = buffer.get(pos+4);
+        m12 = buffer.get(pos+5);
+        m20 = buffer.get(pos+6);
+        m21 = buffer.get(pos+7);
+        m22 = buffer.get(pos+8);
+        return this;
+    }
+
+    /**
+     * Set the values of this matrix by reading 9 float values from the given {@link FloatBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The FloatBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the FloatBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the FloatBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix3d set(FloatBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.get(pos);
+        m01 = buffer.get(pos+1);
+        m02 = buffer.get(pos+2);
+        m10 = buffer.get(pos+3);
+        m11 = buffer.get(pos+4);
+        m12 = buffer.get(pos+5);
+        m20 = buffer.get(pos+6);
+        m21 = buffer.get(pos+7);
+        m22 = buffer.get(pos+8);
+        return this;
+    }
+
+    /**
+     * Set the values of this matrix by reading 9 double values from the given {@link ByteBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The ByteBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the ByteBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the ByteBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix3d set(ByteBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.getDouble(pos);
+        m01 = buffer.getDouble(pos+8*1);
+        m02 = buffer.getDouble(pos+8*2);
+        m10 = buffer.getDouble(pos+8*3);
+        m11 = buffer.getDouble(pos+8*4);
+        m12 = buffer.getDouble(pos+8*5);
+        m20 = buffer.getDouble(pos+8*6);
+        m21 = buffer.getDouble(pos+8*7);
+        m22 = buffer.getDouble(pos+8*8);
+        return this;
+    }
+
+    /**
+     * Set the values of this matrix by reading 9 float values from the given {@link ByteBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The ByteBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the ByteBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the ByteBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix3d setFloats(ByteBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.getFloat(pos);
+        m01 = buffer.getFloat(pos+4*1);
+        m02 = buffer.getFloat(pos+4*2);
+        m10 = buffer.getFloat(pos+4*3);
+        m11 = buffer.getFloat(pos+4*4);
+        m12 = buffer.getFloat(pos+4*5);
+        m20 = buffer.getFloat(pos+4*6);
+        m21 = buffer.getFloat(pos+4*7);
+        m22 = buffer.getFloat(pos+4*8);
+        return this;
+    }
+
+    /**
+     * Set all the values within this matrix to 0.
+     * 
+     * @return this
+     */
+    public Matrix3d zero() {
+        m00 = 0.0;
+        m01 = 0.0;
+        m02 = 0.0;
+        m10 = 0.0;
+        m11 = 0.0;
+        m12 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = 0.0;
+        return this;
+    }
+    
+    /**
+     * Set this matrix to the identity.
+     * 
+     * @return this
+     */
+    public Matrix3d identity() {
+        m00 = 1.0;
+        m01 = 0.0;
+        m02 = 0.0;
+        m10 = 0.0;
+        m11 = 1.0;
+        m12 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix, which scales all axes uniformly by the given factor.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional scaling.
+     * <p>
+     * In order to post-multiply a scaling transformation directly to a
+     * matrix, use {@link #scale(double) scale()} instead.
+     * 
+     * @see #scale(double)
+     * 
+     * @param factor
+     *             the scale factor in x, y and z
+     * @return this
+     */
+    public Matrix3d scaling(double factor) {
+        m00 = factor;
+        m01 = 0.0;
+        m02 = 0.0;
+        m10 = 0.0;
+        m11 = factor;
+        m12 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = factor;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix.
+     * 
+     * @param x
+     *             the scale in x
+     * @param y
+     *             the scale in y
+     * @param z
+     *             the scale in z
+     * @return this
+     */
+    public Matrix3d scaling(double x, double y, double z) {
+        m00 = x;
+        m01 = 0.0;
+        m02 = 0.0;
+        m10 = 0.0;
+        m11 = y;
+        m12 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = z;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix which scales the base axes by <tt>xyz.x</tt>, <tt>xyz.y</tt> and <tt>xyz.z</tt> respectively.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional scaling.
+     * <p>
+     * In order to post-multiply a scaling transformation directly to a
+     * matrix use {@link #scale(Vector3d) scale()} instead.
+     * 
+     * @see #scale(Vector3d)
+     * 
+     * @param xyz
+     *             the scale in x, y and z respectively
+     * @return this
+     */
+    public Matrix3d scaling(Vector3d xyz) {
+        m00 = xyz.x;
+        m01 = 0.0;
+        m02 = 0.0;
+        m10 = 0.0;
+        m11 = xyz.y;
+        m12 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = xyz.z;
+        return this;
+    }
+
+    /**
+     * Apply scaling to the this matrix by scaling the base axes by the given <tt>xyz.x</tt>,
+     * <tt>xyz.y</tt> and <tt>xyz.z</tt> factors, respectively and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param xyz
+     *            the factors of the x, y and z component, respectively
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d scale(Vector3d xyz, Matrix3d dest) {
+        return scale(xyz.x, xyz.y, xyz.z, dest);
+    }
+
+    /**
+     * Apply scaling to this matrix by scaling the base axes by the given <tt>xyz.x</tt>,
+     * <tt>xyz.y</tt> and <tt>xyz.z</tt> factors, respectively.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * scaling will be applied first!
+     * 
+     * @param xyz
+     *            the factors of the x, y and z component, respectively
+     * @return this
+     */
+    public Matrix3d scale(Vector3d xyz) {
+        return scale(xyz.x, xyz.y, xyz.z, this);
+    }
+
+    /**
+     * Apply scaling to this matrix by scaling the base axes by the given x,
+     * y and z factors and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param x
+     *            the factor of the x component
+     * @param y
+     *            the factor of the y component
+     * @param z
+     *            the factor of the z component
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d scale(double x, double y, double z, Matrix3d dest) {
+        // scale matrix elements:
+        // m00 = x, m11 = y, m22 = z
+        // all others = 0
+        dest.m00 = m00 * x;
+        dest.m01 = m01 * x;
+        dest.m02 = m02 * x;
+        dest.m10 = m10 * y;
+        dest.m11 = m11 * y;
+        dest.m12 = m12 * y;
+        dest.m20 = m20 * z;
+        dest.m21 = m21 * z;
+        dest.m22 = m22 * z;
+        return dest;
+    }
+
+    /**
+     * Apply scaling to this matrix by scaling the base axes by the given x,
+     * y and z factors.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param x
+     *            the factor of the x component
+     * @param y
+     *            the factor of the y component
+     * @param z
+     *            the factor of the z component
+     * @return this
+     */
+    public Matrix3d scale(double x, double y, double z) {
+        return scale(x, y, z, this);
+    }
+
+    /**
+     * Apply scaling to this matrix by uniformly scaling all base axes by the given <code>xyz</code> factor
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @see #scale(double, double, double, Matrix3d)
+     * 
+     * @param xyz
+     *            the factor for all components
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d scale(double xyz, Matrix3d dest) {
+        return scale(xyz, xyz, xyz, dest);
+    }
+
+    /**
+     * Apply scaling to this matrix by uniformly scaling all base axes by the given <code>xyz</code> factor.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @see #scale(double, double, double)
+     * 
+     * @param xyz
+     *            the factor for all components
+     * @return this
+     */
+    public Matrix3d scale(double xyz) {
+        return scale(xyz, xyz, xyz);
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to post-multiply a rotation transformation directly to a
+     * matrix, use {@link #rotate(double, Vector3d) rotate()} instead.
+     * 
+     * @see #rotate(double, Vector3d)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the axis to rotate about (needs to be {@link Vector3d#normalize() normalized})
+     * @return this
+     */
+    public Matrix3d rotation(double angle, Vector3d axis) {
+        return rotation(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to post-multiply a rotation transformation directly to a
+     * matrix, use {@link #rotate(double, Vector3f) rotate()} instead.
+     * 
+     * @see #rotate(double, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the axis to rotate about (needs to be {@link Vector3f#normalize() normalized})
+     * @return this
+     */
+    public Matrix3d rotation(double angle, Vector3f axis) {
+        return rotation(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation using the given {@link AxisAngle4f}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(AxisAngle4f) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     *
+     * @see #rotate(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @return this
+     */
+    public Matrix3d rotation(AxisAngle4f axisAngle) {
+        return rotation(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation using the given {@link AxisAngle4d}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(AxisAngle4d) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     *
+     * @see #rotate(AxisAngle4d)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d} (needs to be {@link AxisAngle4d#normalize() normalized})
+     * @return this
+     */
+    public Matrix3d rotation(AxisAngle4d axisAngle) {
+        return rotation(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * <p>
+     * The axis described by the three components needs to be a unit vector.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(double, double, double, double) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param x
+     *          the x-component of the rotation axis
+     * @param y
+     *          the y-component of the rotation axis
+     * @param z
+     *          the z-component of the rotation axis
+     * @return this
+     */
+    public Matrix3d rotation(double angle, double x, double y, double z) {
+        double cos = Math.cos(angle);
+        double sin = Math.sin(angle);
+        double C = 1.0 - cos;
+        double xy = x * y, xz = x * z, yz = y * z;
+        m00 = cos + x * x * C;
+        m10 = xy * C - z * sin;
+        m20 = xz * C + y * sin;
+        m01 = xy * C + z * sin;
+        m11 = cos + y * y * C;
+        m21 = yz * C - x * sin;
+        m02 = xz * C - y * sin;
+        m12 = yz * C + x * sin;
+        m22 = cos + z * z * C;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the X axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3d rotationX(double ang) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        m00 = 1.0;
+        m01 = 0.0;
+        m02 = 0.0;
+        m10 = 0.0;
+        m11 = cos;
+        m12 = sin;
+        m20 = 0.0;
+        m21 = -sin;
+        m22 = cos;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the Y axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3d rotationY(double ang) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        m00 = cos;
+        m01 = 0.0;
+        m02 = -sin;
+        m10 = 0.0;
+        m11 = 1.0;
+        m12 = 0.0;
+        m20 = sin;
+        m21 = 0.0;
+        m22 = cos;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the Z axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3d rotationZ(double ang) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        m00 = cos;
+        m01 = sin;
+        m02 = 0.0;
+        m10 = -sin;
+        m11 = cos;
+        m12 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleX</code> radians about the X axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix3d rotationXYZ(double angleX, double angleY, double angleZ) {
+        double cosX =  Math.cos(angleX);
+        double sinX =  Math.sin(angleX);
+        double cosY =  Math.cos(angleY);
+        double sinY =  Math.sin(angleY);
+        double cosZ =  Math.cos(angleZ);
+        double sinZ =  Math.sin(angleZ);
+        double m_sinX = -sinX;
+        double m_sinY = -sinY;
+        double m_sinZ = -sinZ;
+
+        // rotateX
+        double nm11 = cosX;
+        double nm12 = sinX;
+        double nm21 = m_sinX;
+        double nm22 = cosX;
+        // rotateY
+        double nm00 = cosY;
+        double nm01 = nm21 * m_sinY;
+        double nm02 = nm22 * m_sinY;
+        m20 = sinY;
+        m21 = nm21 * cosY;
+        m22 = nm22 * cosY;
+        // rotateZ
+        m00 = nm00 * cosZ;
+        m01 = nm01 * cosZ + nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m10 = nm00 * m_sinZ;
+        m11 = nm01 * m_sinZ + nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix3d rotationZYX(double angleZ, double angleY, double angleX) {
+        double cosZ =  Math.cos(angleZ);
+        double sinZ =  Math.sin(angleZ);
+        double cosY =  Math.cos(angleY);
+        double sinY =  Math.sin(angleY);
+        double cosX =  Math.cos(angleX);
+        double sinX =  Math.sin(angleX);
+        double m_sinZ = -sinZ;
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+
+        // rotateZ
+        double nm00 = cosZ;
+        double nm01 = sinZ;
+        double nm10 = m_sinZ;
+        double nm11 = cosZ;
+        // rotateY
+        double nm20 = nm00 * sinY;
+        double nm21 = nm01 * sinY;
+        double nm22 = cosY;
+        m00 = nm00 * cosY;
+        m01 = nm01 * cosY;
+        m02 = m_sinY;
+        // rotateX
+        m10 = nm10 * cosX + nm20 * sinX;
+        m11 = nm11 * cosX + nm21 * sinX;
+        m12 = nm22 * sinX;
+        m20 = nm10 * m_sinX + nm20 * cosX;
+        m21 = nm11 * m_sinX + nm21 * cosX;
+        m22 = nm22 * cosX;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleY</code> radians about the Y axis, followed by a rotation
+     * of <code>angleX</code> radians about the X axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix3d rotationYXZ(double angleY, double angleX, double angleZ) {
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+        double m_sinZ = -sinZ;
+
+        // rotateY
+        double nm00 = cosY;
+        double nm02 = m_sinY;
+        double nm20 = sinY;
+        double nm22 = cosY;
+        // rotateX
+        double nm10 = nm20 * sinX;
+        double nm11 = cosX;
+        double nm12 = nm22 * sinX;
+        m20 = nm20 * cosX;
+        m21 = m_sinX;
+        m22 = nm22 * cosX;
+        // rotateZ
+        m00 = nm00 * cosZ + nm10 * sinZ;
+        m01 = nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m10 = nm00 * m_sinZ + nm10 * cosZ;
+        m11 = nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return this;
+    }
+
+    /**
+     * Set this matrix to the rotation transformation of the given {@link Quaterniond}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(Quaterniond) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(Quaterniond)
+     * 
+     * @param quat
+     *          the {@link Quaterniond}
+     * @return this
+     */
+    public Matrix3d rotation(Quaterniond quat) {
+        double dqx = 2.0 * quat.x;
+        double dqy = 2.0 * quat.y;
+        double dqz = 2.0 * quat.z;
+        double q00 = dqx * quat.x;
+        double q11 = dqy * quat.y;
+        double q22 = dqz * quat.z;
+        double q01 = dqx * quat.y;
+        double q02 = dqx * quat.z;
+        double q03 = dqx * quat.w;
+        double q12 = dqy * quat.z;
+        double q13 = dqy * quat.w;
+        double q23 = dqz * quat.w;
+
+        m00 = 1.0 - q11 - q22;
+        m01 = q01 + q23;
+        m02 = q02 - q13;
+        m10 = q01 - q23;
+        m11 = 1.0 - q22 - q00;
+        m12 = q12 + q03;
+        m20 = q02 + q13;
+        m21 = q12 - q03;
+        m22 = 1.0 - q11 - q00;
+
+        return this;
+    }
+
+    /**
+     * Set this matrix to the rotation transformation of the given {@link Quaternionf}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(Quaternionf) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix3d rotation(Quaternionf quat) {
+        double dqx = 2.0 * quat.x;
+        double dqy = 2.0 * quat.y;
+        double dqz = 2.0 * quat.z;
+        double q00 = dqx * quat.x;
+        double q11 = dqy * quat.y;
+        double q22 = dqz * quat.z;
+        double q01 = dqx * quat.y;
+        double q02 = dqx * quat.z;
+        double q03 = dqx * quat.w;
+        double q12 = dqy * quat.z;
+        double q13 = dqy * quat.w;
+        double q23 = dqz * quat.w;
+
+        m00 = 1.0 - q11 - q22;
+        m01 = q01 + q23;
+        m02 = q02 - q13;
+        m10 = q01 - q23;
+        m11 = 1.0 - q22 - q00;
+        m12 = q12 + q03;
+        m20 = q02 + q13;
+        m21 = q12 - q03;
+        m22 = 1.0 - q11 - q00;
+
+        return this;
+    }
+
+    /**
+     * Transform the given vector by this matrix.
+     * 
+     * @param v
+     *          the vector to transform
+     * @return v
+     */
+    public Vector3d transform(Vector3d v) {
+        return v.mul(this);
+    }
+
+    /**
+     * Transform the given vector by this matrix and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d transform(Vector3d v, Vector3d dest) {
+        v.mul(this, dest);
+        return dest;
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeDouble(m00);
+        out.writeDouble(m01);
+        out.writeDouble(m02);
+        out.writeDouble(m10);
+        out.writeDouble(m11);
+        out.writeDouble(m12);
+        out.writeDouble(m20);
+        out.writeDouble(m21);
+        out.writeDouble(m22);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        m00 = in.readDouble();
+        m01 = in.readDouble();
+        m02 = in.readDouble();
+        m10 = in.readDouble();
+        m11 = in.readDouble();
+        m12 = in.readDouble();
+        m20 = in.readDouble();
+        m21 = in.readDouble();
+        m22 = in.readDouble();
+    }
+
+    /**
+     * Apply rotation about the X axis to this matrix by rotating the given amount of radians
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d rotateX(double ang, Matrix3d dest) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        double rm11 = cos;
+        double rm21 = -sin;
+        double rm12 = sin;
+        double rm22 = cos;
+
+        // add temporaries for dependent values
+        double nm10 = m10 * rm11 + m20 * rm12;
+        double nm11 = m11 * rm11 + m21 * rm12;
+        double nm12 = m12 * rm11 + m22 * rm12;
+        // set non-dependent values directly
+        dest.m20 = m10 * rm21 + m20 * rm22;
+        dest.m21 = m11 * rm21 + m21 * rm22;
+        dest.m22 = m12 * rm21 + m22 * rm22;
+        // set other values
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m00 = m00;
+        dest.m01 = m01;
+        dest.m02 = m02;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the X axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3d rotateX(double ang) {
+        return rotateX(ang, this);
+    }
+
+    /**
+     * Apply rotation about the Y axis to this matrix by rotating the given amount of radians
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d rotateY(double ang, Matrix3d dest) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        double rm00 = cos;
+        double rm20 = sin;
+        double rm02 = -sin;
+        double rm22 = cos;
+
+        // add temporaries for dependent values
+        double nm00 = m00 * rm00 + m20 * rm02;
+        double nm01 = m01 * rm00 + m21 * rm02;
+        double nm02 = m02 * rm00 + m22 * rm02;
+        // set non-dependent values directly
+        dest.m20 = m00 * rm20 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m22 * rm22;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m10 = m10;
+        dest.m11 = m11;
+        dest.m12 = m12;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the Y axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3d rotateY(double ang) {
+        return rotateY(ang, this);
+    }
+
+    /**
+     * Apply rotation about the Z axis to this matrix by rotating the given amount of radians
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d rotateZ(double ang, Matrix3d dest) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        double rm00 = cos;
+        double rm10 = -sin;
+        double rm01 = sin;
+        double rm11 = cos;
+
+        // add temporaries for dependent values
+        double nm00 = m00 * rm00 + m10 * rm01;
+        double nm01 = m01 * rm00 + m11 * rm01;
+        double nm02 = m02 * rm00 + m12 * rm01;
+        // set non-dependent values directly
+        dest.m10 = m00 * rm10 + m10 * rm11;
+        dest.m11 = m01 * rm10 + m11 * rm11;
+        dest.m12 = m02 * rm10 + m12 * rm11;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m20 = m20;
+        dest.m21 = m21;
+        dest.m22 = m22;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the Z axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3d rotateZ(double ang) {
+        return rotateZ(ang, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix3d rotateXYZ(double angleX, double angleY, double angleZ) {
+        return rotateXYZ(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX, dest).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d rotateXYZ(double angleX, double angleY, double angleZ, Matrix3d dest) {
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double m_sinX = -sinX;
+        double m_sinY = -sinY;
+        double m_sinZ = -sinZ;
+
+        // rotateX
+        double nm10 = m10 * cosX + m20 * sinX;
+        double nm11 = m11 * cosX + m21 * sinX;
+        double nm12 = m12 * cosX + m22 * sinX;
+        double nm20 = m10 * m_sinX + m20 * cosX;
+        double nm21 = m11 * m_sinX + m21 * cosX;
+        double nm22 = m12 * m_sinX + m22 * cosX;
+        // rotateY
+        double nm00 = m00 * cosY + nm20 * m_sinY;
+        double nm01 = m01 * cosY + nm21 * m_sinY;
+        double nm02 = m02 * cosY + nm22 * m_sinY;
+        dest.m20 = m00 * sinY + nm20 * cosY;
+        dest.m21 = m01 * sinY + nm21 * cosY;
+        dest.m22 = m02 * sinY + nm22 * cosY;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix3d rotateZYX(double angleZ, double angleY, double angleX) {
+        return rotateZYX(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ, dest).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d rotateZYX(double angleZ, double angleY, double angleX, Matrix3d dest) {
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double m_sinZ = -sinZ;
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+
+        // rotateZ
+        double nm00 = m00 * cosZ + m10 * sinZ;
+        double nm01 = m01 * cosZ + m11 * sinZ;
+        double nm02 = m02 * cosZ + m12 * sinZ;
+        double nm10 = m00 * m_sinZ + m10 * cosZ;
+        double nm11 = m01 * m_sinZ + m11 * cosZ;
+        double nm12 = m02 * m_sinZ + m12 * cosZ;
+        // rotateY
+        double nm20 = nm00 * sinY + m20 * cosY;
+        double nm21 = nm01 * sinY + m21 * cosY;
+        double nm22 = nm02 * sinY + m22 * cosY;
+        dest.m00 = nm00 * cosY + m20 * m_sinY;
+        dest.m01 = nm01 * cosY + m21 * m_sinY;
+        dest.m02 = nm02 * cosY + m22 * m_sinY;
+        // rotateX
+        dest.m10 = nm10 * cosX + nm20 * sinX;
+        dest.m11 = nm11 * cosX + nm21 * sinX;
+        dest.m12 = nm12 * cosX + nm22 * sinX;
+        dest.m20 = nm10 * m_sinX + nm20 * cosX;
+        dest.m21 = nm11 * m_sinX + nm21 * cosX;
+        dest.m22 = nm12 * m_sinX + nm22 * cosX;
+        return dest;
+    }
+
+    /**
+     * Apply rotation to this matrix by rotating the given amount of radians
+     * about the given axis specified as x, y and z components.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param x
+     *            the x component of the axis
+     * @param y
+     *            the y component of the axis
+     * @param z
+     *            the z component of the axis
+     * @return this
+     */
+    public Matrix3d rotate(double ang, double x, double y, double z) {
+        return rotate(ang, x, y, z, this);
+    }
+
+    /**
+     * Apply rotation to this matrix by rotating the given amount of radians
+     * about the given axis specified as x, y and z components, and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param x
+     *            the x component of the axis
+     * @param y
+     *            the y component of the axis
+     * @param z
+     *            the z component of the axis
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d rotate(double ang, double x, double y, double z, Matrix3d dest) {
+        double s = Math.sin(ang);
+        double c = Math.cos(ang);
+        double C = 1.0 - c;
+
+        // rotation matrix elements:
+        // m30, m31, m32, m03, m13, m23 = 0
+        double xx = x * x, xy = x * y, xz = x * z;
+        double yy = y * y, yz = y * z;
+        double zz = z * z;
+        double rm00 = xx * C + c;
+        double rm01 = xy * C + z * s;
+        double rm02 = xz * C - y * s;
+        double rm10 = xy * C - z * s;
+        double rm11 = yy * C + c;
+        double rm12 = yz * C + x * s;
+        double rm20 = xz * C + y * s;
+        double rm21 = yz * C - x * s;
+        double rm22 = zz * C + c;
+
+        // add temporaries for dependent values
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        // set non-dependent values directly
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+
+        return dest;
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaterniond} to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaterniond)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaterniond)
+     * 
+     * @param quat
+     *          the {@link Quaterniond}
+     * @return this
+     */
+    public Matrix3d rotate(Quaterniond quat) {
+        return rotate(quat, this);
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaterniond} to this matrix and store
+     * the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaterniond)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaterniond)
+     * 
+     * @param quat
+     *          the {@link Quaterniond}
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3d rotate(Quaterniond quat, Matrix3d dest) {
+        double dqx = 2.0f * quat.x;
+        double dqy = 2.0f * quat.y;
+        double dqz = 2.0f * quat.z;
+        double q00 = dqx * quat.x;
+        double q11 = dqy * quat.y;
+        double q22 = dqz * quat.z;
+        double q01 = dqx * quat.y;
+        double q02 = dqx * quat.z;
+        double q03 = dqx * quat.w;
+        double q12 = dqy * quat.z;
+        double q13 = dqy * quat.w;
+        double q23 = dqz * quat.w;
+
+        double rm00 = 1.0 - q11 - q22;
+        double rm01 = q01 + q23;
+        double rm02 = q02 - q13;
+        double rm10 = q01 - q23;
+        double rm11 = 1.0 - q22 - q00;
+        double rm12 = q12 + q03;
+        double rm20 = q02 + q13;
+        double rm21 = q12 - q03;
+        double rm22 = 1.0 - q11 - q00;
+
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+
+        return dest;
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaternionf} to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaternionf)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix3d rotate(Quaternionf quat) {
+        return rotate(quat, this);
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaternionf} to this matrix and store
+     * the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaternionf)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3d rotate(Quaternionf quat, Matrix3d dest) {
+        double dqx = 2.0f * quat.x;
+        double dqy = 2.0f * quat.y;
+        double dqz = 2.0f * quat.z;
+        double q00 = dqx * quat.x;
+        double q11 = dqy * quat.y;
+        double q22 = dqz * quat.z;
+        double q01 = dqx * quat.y;
+        double q02 = dqx * quat.z;
+        double q03 = dqx * quat.w;
+        double q12 = dqy * quat.z;
+        double q13 = dqy * quat.w;
+        double q23 = dqz * quat.w;
+
+        double rm00 = 1.0 - q11 - q22;
+        double rm01 = q01 + q23;
+        double rm02 = q02 - q13;
+        double rm10 = q01 - q23;
+        double rm11 = 1.0 - q22 - q00;
+        double rm12 = q12 + q03;
+        double rm20 = q02 + q13;
+        double rm21 = q12 - q03;
+        double rm22 = 1.0 - q11 - q00;
+
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+
+        return dest;
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4f}, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4f},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4f} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @return this
+     */
+    public Matrix3d rotate(AxisAngle4f axisAngle) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4f} and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4f},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4f} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3d rotate(AxisAngle4f axisAngle, Matrix3d dest) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4d}, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4d},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4d} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4d)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(AxisAngle4d)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d} (needs to be {@link AxisAngle4d#normalize() normalized})
+     * @return this
+     */
+    public Matrix3d rotate(AxisAngle4d axisAngle) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4d} and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4d},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4d} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4d)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(AxisAngle4d)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d} (needs to be {@link AxisAngle4d#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3d rotate(AxisAngle4d axisAngle, Matrix3d dest) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given angle and axis,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(double, Vector3d)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(double, Vector3d)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3d#normalize() normalized})
+     * @return this
+     */
+    public Matrix3d rotate(double angle, Vector3d axis) {
+        return rotate(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given axis and angle,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(double, Vector3d)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(double, Vector3d)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3d#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3d rotate(double angle, Vector3d axis, Matrix3d dest) {
+        return rotate(angle, axis.x, axis.y, axis.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given angle and axis,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(double, Vector3f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(double, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3f#normalize() normalized})
+     * @return this
+     */
+    public Matrix3d rotate(double angle, Vector3f axis) {
+        return rotate(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given axis and angle,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(double, Vector3f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(double, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3f#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3d rotate(double angle, Vector3f axis, Matrix3d dest) {
+        return rotate(angle, axis.x, axis.y, axis.z, dest);
+    }
+
+    /**
+     * Get the row at the given <code>row</code> index, starting with <code>0</code>.
+     * 
+     * @param row
+     *          the row index in <tt>[0..2]</tt>
+     * @param dest
+     *          will hold the row components
+     * @return the passed in destination
+     * @throws IndexOutOfBoundsException if <code>row</code> is not in <tt>[0..2]</tt>
+     */
+    public Vector3d getRow(int row, Vector3d dest) throws IndexOutOfBoundsException {
+        switch (row) {
+        case 0:
+            dest.x = m00;
+            dest.y = m10;
+            dest.z = m20;
+            break;
+        case 1:
+            dest.x = m01;
+            dest.y = m11;
+            dest.z = m21;
+            break;
+        case 2:
+            dest.x = m02;
+            dest.y = m12;
+            dest.z = m22;
+            break;
+        default:
+            throw new IndexOutOfBoundsException();
+        }
+        
+        return dest;
+    }
+
+    /**
+     * Get the column at the given <code>column</code> index, starting with <code>0</code>.
+     * 
+     * @param column
+     *          the column index in <tt>[0..2]</tt>
+     * @param dest
+     *          will hold the column components
+     * @return the passed in destination
+     * @throws IndexOutOfBoundsException if <code>column</code> is not in <tt>[0..2]</tt>
+     */
+    public Vector3d getColumn(int column, Vector3d dest) throws IndexOutOfBoundsException {
+        switch (column) {
+        case 0:
+            dest.x = m00;
+            dest.y = m01;
+            dest.z = m02;
+            break;
+        case 1:
+            dest.x = m10;
+            dest.y = m11;
+            dest.z = m12;
+            break;
+        case 2:
+            dest.x = m20;
+            dest.y = m21;
+            dest.z = m22;
+            break;
+        default:
+            throw new IndexOutOfBoundsException();
+        }
+        return dest;
+    }
+
+    /**
+     * Compute a normal matrix from <code>this</code> matrix and store it into <code>dest</code>.
+     * <p>
+     * Please note that, if <code>this</code> is an orthogonal matrix or a matrix whose columns are orthogonal vectors, 
+     * then this method <i>need not</i> be invoked, since in that case <code>this</code> itself is its normal matrix.
+     * In this case, use {@link #set(Matrix3d)} to set a given Matrix3d to this matrix.
+     * 
+     * @see #set(Matrix3d)
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3d normal(Matrix3d dest) {
+        double det = determinant();
+        double s = 1.0 / det;
+        /* Invert and transpose in one go */
+        dest.set((m11 * m22 - m21 * m12) * s,
+                 (m20 * m12 - m10 * m22) * s,
+                 (m10 * m21 - m20 * m11) * s,
+                 (m21 * m02 - m01 * m22) * s,
+                 (m00 * m22 - m20 * m02) * s,
+                 (m20 * m01 - m00 * m21) * s,
+                 (m01 * m12 - m11 * m02) * s,
+                 (m10 * m02 - m00 * m12) * s,
+                 (m00 * m11 - m10 * m01) * s);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(Vector3d, Vector3d) setLookAlong()}.
+     * 
+     * @see #lookAlong(double, double, double, double, double, double)
+     * @see #setLookAlong(Vector3d, Vector3d)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix3d lookAlong(Vector3d dir, Vector3d up) {
+        return lookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z, this);
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>
+     * and store the result in <code>dest</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(Vector3d, Vector3d) setLookAlong()}.
+     * 
+     * @see #lookAlong(double, double, double, double, double, double)
+     * @see #setLookAlong(Vector3d, Vector3d)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3d lookAlong(Vector3d dir, Vector3d up, Matrix3d dest) {
+        return lookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>
+     * and store the result in <code>dest</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(double, double, double, double, double, double) setLookAlong()}
+     * 
+     * @see #setLookAlong(double, double, double, double, double, double)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Matrix3d lookAlong(double dirX, double dirY, double dirZ,
+                              double upX, double upY, double upZ, Matrix3d dest) {
+        // Normalize direction
+        double invDirLength = 1.0 / Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
+        double dirnX = dirX * invDirLength;
+        double dirnY = dirY * invDirLength;
+        double dirnZ = dirZ * invDirLength;
+        // right = direction x up
+        double rightX, rightY, rightZ;
+        rightX = dirnY * upZ - dirnZ * upY;
+        rightY = dirnZ * upX - dirnX * upZ;
+        rightZ = dirnX * upY - dirnY * upX;
+        // normalize right
+        double invRightLength = 1.0 / Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        double upnX = rightY * dirnZ - rightZ * dirnY;
+        double upnY = rightZ * dirnX - rightX * dirnZ;
+        double upnZ = rightX * dirnY - rightY * dirnX;
+
+        // calculate right matrix elements
+        double rm00 = rightX;
+        double rm01 = upnX;
+        double rm02 = -dirnX;
+        double rm10 = rightY;
+        double rm11 = upnY;
+        double rm12 = -dirnY;
+        double rm20 = rightZ;
+        double rm21 = upnZ;
+        double rm22 = -dirnZ;
+
+        // perform optimized matrix multiplication
+        // introduce temporaries for dependent results
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        // set the rest of the matrix elements
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+
+        return dest;
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(double, double, double, double, double, double) setLookAlong()}
+     * 
+     * @see #setLookAlong(double, double, double, double, double, double)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix3d lookAlong(double dirX, double dirY, double dirZ,
+                              double upX, double upY, double upZ) {
+        return lookAlong(dirX, dirY, dirZ, upX, upY, upZ, this);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation to make <code>-z</code>
+     * point along <code>dir</code>.
+     * <p>
+     * In order to apply the lookalong transformation to any previous existing transformation,
+     * use {@link #lookAlong(Vector3d, Vector3d)}.
+     * 
+     * @see #setLookAlong(Vector3d, Vector3d)
+     * @see #lookAlong(Vector3d, Vector3d)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix3d setLookAlong(Vector3d dir, Vector3d up) {
+        return setLookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation to make <code>-z</code>
+     * point along <code>dir</code>.
+     * <p>
+     * In order to apply the lookalong transformation to any previous existing transformation,
+     * use {@link #lookAlong(double, double, double, double, double, double) lookAlong()}
+     * 
+     * @see #setLookAlong(double, double, double, double, double, double)
+     * @see #lookAlong(double, double, double, double, double, double)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix3d setLookAlong(double dirX, double dirY, double dirZ,
+                                 double upX, double upY, double upZ) {
+        // Normalize direction
+        double invDirLength = 1.0 / Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
+        double dirnX = dirX * invDirLength;
+        double dirnY = dirY * invDirLength;
+        double dirnZ = dirZ * invDirLength;
+        // right = direction x up
+        double rightX, rightY, rightZ;
+        rightX = dirnY * upZ - dirnZ * upY;
+        rightY = dirnZ * upX - dirnX * upZ;
+        rightZ = dirnX * upY - dirnY * upX;
+        // normalize right
+        double invRightLength = 1.0 / Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        double upnX = rightY * dirnZ - rightZ * dirnY;
+        double upnY = rightZ * dirnX - rightX * dirnZ;
+        double upnZ = rightX * dirnY - rightY * dirnX;
+
+        m00 = rightX;
+        m01 = upnX;
+        m02 = -dirnX;
+        m10 = rightY;
+        m11 = upnY;
+        m12 = -dirnY;
+        m20 = rightZ;
+        m21 = upnZ;
+        m22 = -dirnZ;
+
+        return this;
+    }
+
+    /**
+     * Get the scaling factors of <code>this</code> matrix for the three base axes.
+     * 
+     * @param dest
+     *          will hold the scaling factors for <tt>x</tt>, <tt>y</tt> and <tt>z</tt>
+     * @return dest
+     */
+    public Vector3d getScale(Vector3d dest) {
+        dest.x = Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02);
+        dest.y = Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12);
+        dest.z = Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22);
+        return dest;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Matrix3f.java
+++ b/GVRf/Framework/src/org/joml/Matrix3f.java
@@ -1,0 +1,2441 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Contains the definition of a 3x3 Matrix of floats, and associated functions to transform
+ * it. The matrix is column-major to match OpenGL's interpretation, and it looks like this:
+ * <p>
+ *      m00  m10  m20<br>
+ *      m01  m11  m21<br>
+ *      m02  m12  m22<br>
+ * 
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Matrix3f implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    public float m00, m10, m20;
+    public float m01, m11, m21;
+    public float m02, m12, m22;
+
+    /**
+     * Create a new {@link Matrix3f} and set it to {@link #identity() identity}.
+     */
+    public Matrix3f() {
+        m00 = 1.0f;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m10 = 0.0f;
+        m11 = 1.0f;
+        m12 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = 1.0f;
+    }
+
+    /**
+     * Create a new {@link Matrix3f} and make it a copy of the given matrix.
+     * 
+     * @param mat
+     *          the {@link Matrix3f} to copy the values from
+     */
+    public Matrix3f(Matrix3f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+    }
+
+    /**
+     * Create a new {@link Matrix3f} and make it a copy of the upper left 3x3 of the given {@link Matrix4f}.
+     * 
+     * @param mat
+     *          the {@link Matrix4f} to copy the values from
+     */
+    public Matrix3f(Matrix4f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+    }
+
+    /**
+     * Create a new 3x3 matrix using the supplied float values. The order of the parameter is column-major, 
+     * so the first three parameters specify the three elements of the first column.
+     * 
+     * @param m00
+     *          the value of m00
+     * @param m01
+     *          the value of m01
+     * @param m02
+     *          the value of m02
+     * @param m10
+     *          the value of m10
+     * @param m11
+     *          the value of m11
+     * @param m12
+     *          the value of m12
+     * @param m20
+     *          the value of m20
+     * @param m21
+     *          the value of m21
+     * @param m22
+     *          the value of m22
+     */
+    public Matrix3f(float m00, float m01, float m02,
+                    float m10, float m11, float m12, 
+                    float m20, float m21, float m22) {
+        this.m00 = m00;
+        this.m01 = m01;
+        this.m02 = m02;
+        this.m10 = m10;
+        this.m11 = m11;
+        this.m12 = m12;
+        this.m20 = m20;
+        this.m21 = m21;
+        this.m22 = m22;
+    }
+
+    /**
+     * Set the elements of this matrix to the ones in <code>m</code>.
+     * 
+     * @param m
+     *          the matrix to copy the elements from
+     * @return this
+     */
+    public Matrix3f set(Matrix3f m) {
+        m00 = m.m00;
+        m01 = m.m01;
+        m02 = m.m02;
+        m10 = m.m10;
+        m11 = m.m11;
+        m12 = m.m12;
+        m20 = m.m20;
+        m21 = m.m21;
+        m22 = m.m22;
+        return this;
+    }
+
+    /**
+     * Set the elements of this matrix to the upper left 3x3 of the given {@link Matrix4f}.
+     *
+     * @param mat
+     *          the {@link Matrix4f} to copy the values from
+     * @return this
+     */
+    public Matrix3f set(Matrix4f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link AxisAngle4f}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f}
+     * @return this
+     */
+    public Matrix3f set(AxisAngle4f axisAngle) {
+        float x = axisAngle.x;
+        float y = axisAngle.y;
+        float z = axisAngle.z;
+        float angle = axisAngle.angle;
+        float invLength = (float) (1.0 / Math.sqrt(x*x + y*y + z*z));
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        float c = (float) Math.cos(angle);
+        float s = (float) Math.sin(angle);
+        float omc = 1.0f - c;
+        m00 = (float)(c + x*x*omc);
+        m11 = (float)(c + y*y*omc);
+        m22 = (float)(c + z*z*omc);
+        float tmp1 = x*y*omc;
+        float tmp2 = z*s;
+        m10 = (float)(tmp1 - tmp2);
+        m01 = (float)(tmp1 + tmp2);
+        tmp1 = x*z*omc;
+        tmp2 = y*s;
+        m20 = (float)(tmp1 + tmp2);
+        m02 = (float)(tmp1 - tmp2);
+        tmp1 = y*z*omc;
+        tmp2 = x*s;
+        m21 = (float)(tmp1 - tmp2);
+        m12 = (float)(tmp1 + tmp2);
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link AxisAngle4d}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d}
+     * @return this
+     */
+    public Matrix3f set(AxisAngle4d axisAngle) {
+        double x = axisAngle.x;
+        double y = axisAngle.y;
+        double z = axisAngle.z;
+        double angle = axisAngle.angle;
+        double invLength = 1.0 / Math.sqrt(x*x + y*y + z*z);
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        double c = Math.cos(angle);
+        double s = Math.sin(angle);
+        double omc = 1.0f - c;
+        m00 = (float)(c + x*x*omc);
+        m11 = (float)(c + y*y*omc);
+        m22 = (float)(c + z*z*omc);
+        double tmp1 = x*y*omc;
+        double tmp2 = z*s;
+        m10 = (float)(tmp1 - tmp2);
+        m01 = (float)(tmp1 + tmp2);
+        tmp1 = x*z*omc;
+        tmp2 = y*s;
+        m20 = (float)(tmp1 + tmp2);
+        m02 = (float)(tmp1 - tmp2);
+        tmp1 = y*z*omc;
+        tmp2 = x*s;
+        m21 = (float)(tmp1 - tmp2);
+        m12 = (float)(tmp1 + tmp2);
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link Quaternionf}.
+     * 
+     * @see Quaternionf#get(Matrix3f)
+     * 
+     * @param q
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix3f set(Quaternionf q) {
+        q.get(this);
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation equivalent to the given quaternion.
+     * 
+     * @see Quaterniond#get(Matrix3f)
+     * 
+     * @param q
+     *          the quaternion
+     * @return this
+     */
+    public Matrix3f set(Quaterniond q) {
+        q.get(this);
+        return this;
+    }
+
+    /**
+     * Multiply this matrix by the supplied <code>right</code> matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand of the matrix multiplication
+     * @return this
+     */
+    public Matrix3f mul(Matrix3f right) {
+        return mul(right, this);
+    }
+
+    /**
+     * Multiply this matrix by the supplied <code>right</code> matrix and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand of the matrix multiplication
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3f mul(Matrix3f right, Matrix3f dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22);
+        return dest;
+    }
+
+    /**
+     * Set the values within this matrix to the supplied float values. The result looks like this:
+     * <p>
+     * m00, m10, m20<br>
+     * m01, m11, m21<br>
+     * m02, m12, m22<br>
+     * 
+     * @param m00
+     *          the new value of m00
+     * @param m01
+     *          the new value of m01
+     * @param m02
+     *          the new value of m02
+     * @param m10
+     *          the new value of m10
+     * @param m11
+     *          the new value of m11
+     * @param m12
+     *          the new value of m12
+     * @param m20
+     *          the new value of m20
+     * @param m21
+     *          the new value of m21
+     * @param m22
+     *          the new value of m22
+     * @return this
+     */
+    public Matrix3f set(float m00, float m01, float m02,
+                        float m10, float m11, float m12, 
+                        float m20, float m21, float m22) {
+        this.m00 = m00;
+        this.m01 = m01;
+        this.m02 = m02;
+        this.m10 = m10;
+        this.m11 = m11;
+        this.m12 = m12;
+        this.m20 = m20;
+        this.m21 = m21;
+        this.m22 = m22;
+        return this;
+    }
+
+    /**
+     * Set the values in this matrix based on the supplied float array. The result looks like this:
+     * <p>
+     * 0, 3, 6<br>
+     * 1, 4, 7<br>
+     * 2, 5, 8<br>
+     * 
+     * This method only uses the first 9 values, all others are ignored.
+     * 
+     * @param m
+     *          the array to read the matrix values from
+     * @return this
+     */
+    public Matrix3f set(float m[]) {
+        m00 = m[0];
+        m01 = m[1];
+        m02 = m[2];
+        m10 = m[3];
+        m11 = m[4];
+        m12 = m[5];
+        m20 = m[6];
+        m21 = m[7];
+        m22 = m[8];
+        return this;
+    }
+
+    /**
+     * Return the determinant of this matrix.
+     * 
+     * @return the determinant
+     */
+    public float determinant() {
+        return m00 * (m11 * m22 - m12 * m21)
+             + m01 * (m12 * m20 - m10 * m22)
+             + m02 * (m01 * m21 - m11 * m20);
+    }
+
+    /**
+     * Invert this matrix.
+     *
+     * @return this
+     */
+    public Matrix3f invert() {
+        return invert(this);
+    }
+
+    /**
+     * Invert the <code>this</code> matrix and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3f invert(Matrix3f dest) {
+        float s = determinant();
+        // client must make sure that matrix is invertible
+        s = 1.0f / s;
+        dest.set((m11 * m22 - m21 * m12) * s,
+                 (m21 * m02 - m01 * m22) * s,
+                 (m01 * m12 - m11 * m02) * s,
+                 (m20 * m12 - m10 * m22) * s,
+                 (m00 * m22 - m20 * m02) * s,
+                 (m10 * m02 - m00 * m12) * s,
+                 (m10 * m21 - m20 * m11) * s,
+                 (m20 * m01 - m00 * m21) * s,
+                 (m00 * m11 - m10 * m01) * s);
+        return dest;
+    }
+
+    /**
+     * Transpose this matrix.
+     * 
+     * @return this
+     */
+    public Matrix3f transpose() {
+        return transpose(this);
+    }
+
+    /**
+     * Transpose <code>this</code> matrix and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3f transpose(Matrix3f dest) {
+        dest.set(m00, m10, m20,
+                 m01, m11, m21,
+                 m02, m12, m22);
+        return dest;
+    }
+
+    /**
+     * Return a string representation of this matrix.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt>  0.000E0; -</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat("  0.000E0; -"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this matrix by formatting the matrix elements with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the matrix values with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return formatter.format(m00) + formatter.format(m10) + formatter.format(m20) + "\n" //$NON-NLS-1$
+             + formatter.format(m01) + formatter.format(m11) + formatter.format(m21) + "\n" //$NON-NLS-1$
+             + formatter.format(m02) + formatter.format(m12) + formatter.format(m22) + "\n"; //$NON-NLS-1$
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store them into
+     * <code>dest</code>.
+     * <p>
+     * This is the reverse method of {@link #set(Matrix3f)} and allows to obtain
+     * intermediate calculation results when chaining multiple transformations.
+     * 
+     * @see #set(Matrix3f)
+     * 
+     * @param dest
+     *          the destination matrix
+     * @return the passed in destination
+     */
+    public Matrix3f get(Matrix3f dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store them as
+     * the rotational component of <code>dest</code>. All other values of <code>dest</code> will
+     * be set to identity.
+     * 
+     * @see Matrix4f#set(Matrix3f)
+     * 
+     * @param dest
+     *          the destination matrix
+     * @return the passed in destination
+     */
+    public Matrix4f get(Matrix4f dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link AxisAngle4f}.
+     * 
+     * @see AxisAngle4f#set(Matrix3f)
+     * 
+     * @param dest
+     *          the destination {@link AxisAngle4f}
+     * @return the passed in destination
+     */
+    public AxisAngle4f getRotation(AxisAngle4f dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaternionf}.
+     * <p>
+     * This method assumes that the three column vectors of this matrix are not normalized and
+     * thus allows to ignore any additional scaling factor that is applied to the matrix.
+     * 
+     * @see Quaternionf#setFromUnnormalized(Matrix3f)
+     * 
+     * @param dest
+     *          the destination {@link Quaternionf}
+     * @return the passed in destination
+     */
+    public Quaternionf getUnnormalizedRotation(Quaternionf dest) {
+        return dest.setFromUnnormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaternionf}.
+     * <p>
+     * This method assumes that the three column vectors of this matrix are normalized.
+     * 
+     * @see Quaternionf#setFromNormalized(Matrix3f)
+     * 
+     * @param dest
+     *          the destination {@link Quaternionf}
+     * @return the passed in destination
+     */
+    public Quaternionf getNormalizedRotation(Quaternionf dest) {
+        return dest.setFromNormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaterniond}.
+     * <p>
+     * This method assumes that the three column vectors of this matrix are not normalized and
+     * thus allows to ignore any additional scaling factor that is applied to the matrix.
+     * 
+     * @see Quaterniond#setFromUnnormalized(Matrix3f)
+     * 
+     * @param dest
+     *          the destination {@link Quaterniond}
+     * @return the passed in destination
+     */
+    public Quaterniond getUnnormalizedRotation(Quaterniond dest) {
+        return dest.setFromUnnormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaterniond}.
+     * <p>
+     * This method assumes that the three column vectors of this matrix are normalized.
+     * 
+     * @see Quaterniond#setFromNormalized(Matrix3f)
+     * 
+     * @param dest
+     *          the destination {@link Quaterniond}
+     * @return the passed in destination
+     */
+    public Quaterniond getNormalizedRotation(Quaterniond dest) {
+        return dest.setFromNormalized(this);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the matrix is stored, use {@link #get(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, FloatBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(FloatBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * 
+     * @param index
+     *            the absolute position into the FloatBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(int index, FloatBuffer buffer) {
+        buffer.put(index,   m00);
+        buffer.put(index+1, m01);
+        buffer.put(index+2, m02);
+        buffer.put(index+3, m10);
+        buffer.put(index+4, m11);
+        buffer.put(index+5, m12);
+        buffer.put(index+6, m20);
+        buffer.put(index+7, m21);
+        buffer.put(index+8, m22);
+        return buffer;
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the matrix is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, ByteBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * 
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putFloat(index,    m00);
+        buffer.putFloat(index+4,  m01);
+        buffer.putFloat(index+8,  m02);
+        buffer.putFloat(index+12, m10);
+        buffer.putFloat(index+16, m11);
+        buffer.putFloat(index+20, m12);
+        buffer.putFloat(index+24, m20);
+        buffer.putFloat(index+28, m21);
+        buffer.putFloat(index+32, m22);
+        return buffer;
+    }
+
+    /**
+     * Store the transpose of this matrix in column-major order into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the matrix is stored, use {@link #getTransposed(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #getTransposed(int, FloatBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public FloatBuffer getTransposed(FloatBuffer buffer) {
+        return getTransposed(buffer.position(), buffer);
+    }
+
+    /**
+     * Store the transpose of this matrix in column-major order into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * 
+     * @param index
+     *            the absolute position into the FloatBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public FloatBuffer getTransposed(int index, FloatBuffer buffer) {
+        buffer.put(index,    m00);
+        buffer.put(index+1,  m10);
+        buffer.put(index+2,  m20);
+        buffer.put(index+3,  m01);
+        buffer.put(index+4,  m11);
+        buffer.put(index+5,  m21);
+        buffer.put(index+6,  m02);
+        buffer.put(index+7,  m12);
+        buffer.put(index+8, m22);
+        return buffer;
+    }
+
+    /**
+     * Store the transpose of this matrix in column-major order into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the matrix is stored, use {@link #getTransposed(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #getTransposed(int, ByteBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public ByteBuffer getTransposed(ByteBuffer buffer) {
+        return getTransposed(buffer.position(), buffer);
+    }
+
+    /**
+     * Store the transpose of this matrix in column-major order into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * 
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public ByteBuffer getTransposed(int index, ByteBuffer buffer) {
+        buffer.putFloat(index,    m00);
+        buffer.putFloat(index+4,  m10);
+        buffer.putFloat(index+8,  m20);
+        buffer.putFloat(index+12, m01);
+        buffer.putFloat(index+16, m11);
+        buffer.putFloat(index+20, m21);
+        buffer.putFloat(index+24, m02);
+        buffer.putFloat(index+28, m12);
+        buffer.putFloat(index+32, m22);
+        return buffer;
+    }
+
+    /**
+     * Set the values of this matrix by reading 9 float values from the given {@link FloatBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The FloatBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the FloatBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the FloatBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix3f set(FloatBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.get(pos);
+        m01 = buffer.get(pos+1);
+        m02 = buffer.get(pos+2);
+        m10 = buffer.get(pos+3);
+        m11 = buffer.get(pos+4);
+        m12 = buffer.get(pos+5);
+        m20 = buffer.get(pos+6);
+        m21 = buffer.get(pos+7);
+        m22 = buffer.get(pos+8);
+        return this;
+    }
+
+    /**
+     * Set the values of this matrix by reading 9 float values from the given {@link ByteBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The ByteBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the ByteBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the ByteBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix3f set(ByteBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.getFloat(pos);
+        m01 = buffer.getFloat(pos+4*1);
+        m02 = buffer.getFloat(pos+4*2);
+        m10 = buffer.getFloat(pos+4*3);
+        m11 = buffer.getFloat(pos+4*4);
+        m12 = buffer.getFloat(pos+4*5);
+        m20 = buffer.getFloat(pos+4*6);
+        m21 = buffer.getFloat(pos+4*7);
+        m22 = buffer.getFloat(pos+4*8);
+        return this;
+    }
+
+    /**
+     * Set all values within this matrix to zero.
+     * 
+     * @return this
+     */
+    public Matrix3f zero() {
+        m00 = 0.0f;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m10 = 0.0f;
+        m11 = 0.0f;
+        m12 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = 0.0f;
+        return this;
+    }
+    
+    /**
+     * Set this matrix to the identity.
+     * 
+     * @return this
+     */
+    public Matrix3f identity() {
+        m00 = 1.0f;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m10 = 0.0f;
+        m11 = 1.0f;
+        m12 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Apply scaling to the this matrix by scaling the base axes by the given <tt>xyz.x</tt>,
+     * <tt>xyz.y</tt> and <tt>xyz.z</tt> factors, respectively and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param xyz
+     *            the factors of the x, y and z component, respectively
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f scale(Vector3f xyz, Matrix3f dest) {
+        return scale(xyz.x, xyz.y, xyz.z, dest);
+    }
+
+    /**
+     * Apply scaling to this matrix by scaling the base axes by the given <tt>xyz.x</tt>,
+     * <tt>xyz.y</tt> and <tt>xyz.z</tt> factors, respectively.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * scaling will be applied first!
+     * 
+     * @param xyz
+     *            the factors of the x, y and z component, respectively
+     * @return this
+     */
+    public Matrix3f scale(Vector3f xyz) {
+        return scale(xyz.x, xyz.y, xyz.z, this);
+    }
+
+    /**
+     * Apply scaling to this matrix by scaling the base axes by the given x,
+     * y and z factors and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param x
+     *            the factor of the x component
+     * @param y
+     *            the factor of the y component
+     * @param z
+     *            the factor of the z component
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f scale(float x, float y, float z, Matrix3f dest) {
+        // scale matrix elements:
+        // m00 = x, m11 = y, m22 = z
+        // all others = 0
+        dest.m00 = m00 * x;
+        dest.m01 = m01 * x;
+        dest.m02 = m02 * x;
+        dest.m10 = m10 * y;
+        dest.m11 = m11 * y;
+        dest.m12 = m12 * y;
+        dest.m20 = m20 * z;
+        dest.m21 = m21 * z;
+        dest.m22 = m22 * z;
+        return dest;
+    }
+
+    /**
+     * Apply scaling to this matrix by scaling the base axes by the given x,
+     * y and z factors.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param x
+     *            the factor of the x component
+     * @param y
+     *            the factor of the y component
+     * @param z
+     *            the factor of the z component
+     * @return this
+     */
+    public Matrix3f scale(float x, float y, float z) {
+        return scale(x, y, z, this);
+    }
+
+    /**
+     * Apply scaling to this matrix by uniformly scaling all base axes by the given <code>xyz</code> factor
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @see #scale(float, float, float, Matrix3f)
+     * 
+     * @param xyz
+     *            the factor for all components
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f scale(float xyz, Matrix3f dest) {
+        return scale(xyz, xyz, xyz, dest);
+    }
+
+    /**
+     * Apply scaling to this matrix by uniformly scaling all base axes by the given <code>xyz</code> factor.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @see #scale(float, float, float)
+     * 
+     * @param xyz
+     *            the factor for all components
+     * @return this
+     */
+    public Matrix3f scale(float xyz) {
+        return scale(xyz, xyz, xyz);
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix, which scales all axes uniformly by the given factor.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional scaling.
+     * <p>
+     * In order to post-multiply a scaling transformation directly to a
+     * matrix, use {@link #scale(float) scale()} instead.
+     * 
+     * @see #scale(float)
+     * 
+     * @param factor
+     *             the scale factor in x, y and z
+     * @return this
+     */
+    public Matrix3f scaling(float factor) {
+        m00 = factor;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m10 = 0.0f;
+        m11 = factor;
+        m12 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = factor;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix.
+     * 
+     * @param x
+     *             the scale in x
+     * @param y
+     *             the scale in y
+     * @param z
+     *             the scale in z
+     * @return this
+     */
+    public Matrix3f scaling(float x, float y, float z) {
+        m00 = x;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m10 = 0.0f;
+        m11 = y;
+        m12 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = z;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix which scales the base axes by <tt>xyz.x</tt>, <tt>xyz.y</tt> and <tt>xyz.z</tt> respectively.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional scaling.
+     * <p>
+     * In order to post-multiply a scaling transformation directly to a
+     * matrix use {@link #scale(Vector3f) scale()} instead.
+     * 
+     * @see #scale(Vector3f)
+     * 
+     * @param xyz
+     *             the scale in x, y and z respectively
+     * @return this
+     */
+    public Matrix3f scaling(Vector3f xyz) {
+        return scaling(xyz.x, xyz.y, xyz.z);
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to post-multiply a rotation transformation directly to a
+     * matrix, use {@link #rotate(float, Vector3f) rotate()} instead.
+     * 
+     * @see #rotate(float, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the axis to rotate about (needs to be {@link Vector3f#normalize() normalized})
+     * @return this
+     */
+    public Matrix3f rotation(float angle, Vector3f axis) {
+        return rotation(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation using the given {@link AxisAngle4f}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(AxisAngle4f) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     *
+     * @see #rotate(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @return this
+     */
+    public Matrix3f rotation(AxisAngle4f axisAngle) {
+        return rotation(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * <p>
+     * The axis described by the three components needs to be a unit vector.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(float, float, float, float) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param x
+     *          the x-component of the rotation axis
+     * @param y
+     *          the y-component of the rotation axis
+     * @param z
+     *          the z-component of the rotation axis
+     * @return this
+     */
+    public Matrix3f rotation(float angle, float x, float y, float z) {
+        float cos = (float) Math.cos(angle);
+        float sin = (float) Math.sin(angle);
+        float C = 1.0f - cos;
+        float xy = x * y, xz = x * z, yz = y * z;
+        m00 = cos + x * x * C;
+        m10 = xy * C - z * sin;
+        m20 = xz * C + y * sin;
+        m01 = xy * C + z * sin;
+        m11 = cos + y * y * C;
+        m21 = yz * C - x * sin;
+        m02 = xz * C - y * sin;
+        m12 = yz * C + x * sin;
+        m22 = cos + z * z * C;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the X axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3f rotationX(float ang) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        m00 = 1.0f;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m10 = 0.0f;
+        m11 = cos;
+        m12 = sin;
+        m20 = 0.0f;
+        m21 = -sin;
+        m22 = cos;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the Y axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3f rotationY(float ang) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        m00 = cos;
+        m01 = 0.0f;
+        m02 = -sin;
+        m10 = 0.0f;
+        m11 = 1.0f;
+        m12 = 0.0f;
+        m20 = sin;
+        m21 = 0.0f;
+        m22 = cos;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the Z axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3f rotationZ(float ang) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        m00 = cos;
+        m01 = sin;
+        m02 = 0.0f;
+        m10 = -sin;
+        m11 = cos;
+        m12 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleX</code> radians about the X axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix3f rotationXYZ(float angleX, float angleY, float angleZ) {
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinX = -sinX;
+        float m_sinY = -sinY;
+        float m_sinZ = -sinZ;
+
+        // rotateX
+        float nm11 = cosX;
+        float nm12 = sinX;
+        float nm21 = m_sinX;
+        float nm22 = cosX;
+        // rotateY
+        float nm00 = cosY;
+        float nm01 = nm21 * m_sinY;
+        float nm02 = nm22 * m_sinY;
+        m20 = sinY;
+        m21 = nm21 * cosY;
+        m22 = nm22 * cosY;
+        // rotateZ
+        m00 = nm00 * cosZ;
+        m01 = nm01 * cosZ + nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m10 = nm00 * m_sinZ;
+        m11 = nm01 * m_sinZ + nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix3f rotationZYX(float angleZ, float angleY, float angleX) {
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float m_sinZ = -sinZ;
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+
+        // rotateZ
+        float nm00 = cosZ;
+        float nm01 = sinZ;
+        float nm10 = m_sinZ;
+        float nm11 = cosZ;
+        // rotateY
+        float nm20 = nm00 * sinY;
+        float nm21 = nm01 * sinY;
+        float nm22 = cosY;
+        m00 = nm00 * cosY;
+        m01 = nm01 * cosY;
+        m02 = m_sinY;
+        // rotateX
+        m10 = nm10 * cosX + nm20 * sinX;
+        m11 = nm11 * cosX + nm21 * sinX;
+        m12 = nm22 * sinX;
+        m20 = nm10 * m_sinX + nm20 * cosX;
+        m21 = nm11 * m_sinX + nm21 * cosX;
+        m22 = nm22 * cosX;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleY</code> radians about the Y axis, followed by a rotation
+     * of <code>angleX</code> radians about the X axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix3f rotationYXZ(float angleY, float angleX, float angleZ) {
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+        float m_sinZ = -sinZ;
+
+        // rotateY
+        float nm00 = cosY;
+        float nm02 = m_sinY;
+        float nm20 = sinY;
+        float nm22 = cosY;
+        // rotateX
+        float nm10 = nm20 * sinX;
+        float nm11 = cosX;
+        float nm12 = nm22 * sinX;
+        m20 = nm20 * cosX;
+        m21 = m_sinX;
+        m22 = nm22 * cosX;
+        // rotateZ
+        m00 = nm00 * cosZ + nm10 * sinZ;
+        m01 = nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m10 = nm00 * m_sinZ + nm10 * cosZ;
+        m11 = nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return this;
+    }
+
+    /**
+     * Set this matrix to the rotation transformation of the given {@link Quaternionf}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(Quaternionf) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix3f rotation(Quaternionf quat) {
+        float dqx = 2.0f * quat.x;
+        float dqy = 2.0f * quat.y;
+        float dqz = 2.0f * quat.z;
+        float q00 = dqx * quat.x;
+        float q11 = dqy * quat.y;
+        float q22 = dqz * quat.z;
+        float q01 = dqx * quat.y;
+        float q02 = dqx * quat.z;
+        float q03 = dqx * quat.w;
+        float q12 = dqy * quat.z;
+        float q13 = dqy * quat.w;
+        float q23 = dqz * quat.w;
+
+        m00 = 1.0f - q11 - q22;
+        m01 = q01 + q23;
+        m02 = q02 - q13;
+        m10 = q01 - q23;
+        m11 = 1.0f - q22 - q00;
+        m12 = q12 + q03;
+        m20 = q02 + q13;
+        m21 = q12 - q03;
+        m22 = 1.0f - q11 - q00;
+
+        return this;
+    }
+
+    /**
+     * Transform the given vector by this matrix.
+     * 
+     * @param v
+     *          the vector to transform
+     * @return v
+     */
+    public Vector3f transform(Vector3f v) {
+        return v.mul(this);
+    }
+
+    /**
+     * Transform the given vector by this matrix and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f transform(Vector3f v, Vector3f dest) {
+        v.mul(this, dest);
+        return dest;
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeFloat(m00);
+        out.writeFloat(m01);
+        out.writeFloat(m02);
+        out.writeFloat(m10);
+        out.writeFloat(m11);
+        out.writeFloat(m12);
+        out.writeFloat(m20);
+        out.writeFloat(m21);
+        out.writeFloat(m22);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        m00 = in.readFloat();
+        m01 = in.readFloat();
+        m02 = in.readFloat();
+        m10 = in.readFloat();
+        m11 = in.readFloat();
+        m12 = in.readFloat();
+        m20 = in.readFloat();
+        m21 = in.readFloat();
+        m22 = in.readFloat();
+    }
+
+    /**
+     * Apply rotation about the X axis to this matrix by rotating the given amount of radians
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f rotateX(float ang, Matrix3f dest) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        float rm11 = cos;
+        float rm21 = -sin;
+        float rm12 = sin;
+        float rm22 = cos;
+
+        // add temporaries for dependent values
+        float nm10 = m10 * rm11 + m20 * rm12;
+        float nm11 = m11 * rm11 + m21 * rm12;
+        float nm12 = m12 * rm11 + m22 * rm12;
+        // set non-dependent values directly
+        dest.m20 = m10 * rm21 + m20 * rm22;
+        dest.m21 = m11 * rm21 + m21 * rm22;
+        dest.m22 = m12 * rm21 + m22 * rm22;
+        // set other values
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m00 = m00;
+        dest.m01 = m01;
+        dest.m02 = m02;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the X axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3f rotateX(float ang) {
+        return rotateX(ang, this);
+    }
+
+    /**
+     * Apply rotation about the Y axis to this matrix by rotating the given amount of radians
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f rotateY(float ang, Matrix3f dest) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        float rm00 = cos;
+        float rm20 = sin;
+        float rm02 = -sin;
+        float rm22 = cos;
+
+        // add temporaries for dependent values
+        float nm00 = m00 * rm00 + m20 * rm02;
+        float nm01 = m01 * rm00 + m21 * rm02;
+        float nm02 = m02 * rm00 + m22 * rm02;
+        // set non-dependent values directly
+        dest.m20 = m00 * rm20 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m22 * rm22;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m10 = m10;
+        dest.m11 = m11;
+        dest.m12 = m12;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the Y axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3f rotateY(float ang) {
+        return rotateY(ang, this);
+    }
+
+    /**
+     * Apply rotation about the Z axis to this matrix by rotating the given amount of radians
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f rotateZ(float ang, Matrix3f dest) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        float rm00 = cos;
+        float rm10 = -sin;
+        float rm01 = sin;
+        float rm11 = cos;
+
+        // add temporaries for dependent values
+        float nm00 = m00 * rm00 + m10 * rm01;
+        float nm01 = m01 * rm00 + m11 * rm01;
+        float nm02 = m02 * rm00 + m12 * rm01;
+        // set non-dependent values directly
+        dest.m10 = m00 * rm10 + m10 * rm11;
+        dest.m11 = m01 * rm10 + m11 * rm11;
+        dest.m12 = m02 * rm10 + m12 * rm11;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m20 = m20;
+        dest.m21 = m21;
+        dest.m22 = m22;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the Z axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix3f rotateZ(float ang) {
+        return rotateZ(ang, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix3f rotateXYZ(float angleX, float angleY, float angleZ) {
+        return rotateXYZ(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX, dest).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f rotateXYZ(float angleX, float angleY, float angleZ, Matrix3f dest) {
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinX = -sinX;
+        float m_sinY = -sinY;
+        float m_sinZ = -sinZ;
+
+        // rotateX
+        float nm10 = m10 * cosX + m20 * sinX;
+        float nm11 = m11 * cosX + m21 * sinX;
+        float nm12 = m12 * cosX + m22 * sinX;
+        float nm20 = m10 * m_sinX + m20 * cosX;
+        float nm21 = m11 * m_sinX + m21 * cosX;
+        float nm22 = m12 * m_sinX + m22 * cosX;
+        // rotateY
+        float nm00 = m00 * cosY + nm20 * m_sinY;
+        float nm01 = m01 * cosY + nm21 * m_sinY;
+        float nm02 = m02 * cosY + nm22 * m_sinY;
+        dest.m20 = m00 * sinY + nm20 * cosY;
+        dest.m21 = m01 * sinY + nm21 * cosY;
+        dest.m22 = m02 * sinY + nm22 * cosY;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix3f rotateZYX(float angleZ, float angleY, float angleX) {
+        return rotateZYX(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ, dest).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f rotateZYX(float angleZ, float angleY, float angleX, Matrix3f dest) {
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float m_sinZ = -sinZ;
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+
+        // rotateZ
+        float nm00 = m00 * cosZ + m10 * sinZ;
+        float nm01 = m01 * cosZ + m11 * sinZ;
+        float nm02 = m02 * cosZ + m12 * sinZ;
+        float nm10 = m00 * m_sinZ + m10 * cosZ;
+        float nm11 = m01 * m_sinZ + m11 * cosZ;
+        float nm12 = m02 * m_sinZ + m12 * cosZ;
+        // rotateY
+        float nm20 = nm00 * sinY + m20 * cosY;
+        float nm21 = nm01 * sinY + m21 * cosY;
+        float nm22 = nm02 * sinY + m22 * cosY;
+        dest.m00 = nm00 * cosY + m20 * m_sinY;
+        dest.m01 = nm01 * cosY + m21 * m_sinY;
+        dest.m02 = nm02 * cosY + m22 * m_sinY;
+        // rotateX
+        dest.m10 = nm10 * cosX + nm20 * sinX;
+        dest.m11 = nm11 * cosX + nm21 * sinX;
+        dest.m12 = nm12 * cosX + nm22 * sinX;
+        dest.m20 = nm10 * m_sinX + nm20 * cosX;
+        dest.m21 = nm11 * m_sinX + nm21 * cosX;
+        dest.m22 = nm12 * m_sinX + nm22 * cosX;
+        return dest;
+    }
+
+    /**
+     * Apply rotation to this matrix by rotating the given amount of radians
+     * about the given axis specified as x, y and z components.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param x
+     *            the x component of the axis
+     * @param y
+     *            the y component of the axis
+     * @param z
+     *            the z component of the axis
+     * @return this
+     */
+    public Matrix3f rotate(float ang, float x, float y, float z) {
+        return rotate(ang, x, y, z, this);
+    }
+
+    /**
+     * Apply rotation to this matrix by rotating the given amount of radians
+     * about the given axis specified as x, y and z components, and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param x
+     *            the x component of the axis
+     * @param y
+     *            the y component of the axis
+     * @param z
+     *            the z component of the axis
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f rotate(float ang, float x, float y, float z, Matrix3f dest) {
+        float s = (float) Math.sin(ang);
+        float c = (float) Math.cos(ang);
+        float C = 1.0f - c;
+
+        // rotation matrix elements:
+        // m30, m31, m32, m03, m13, m23 = 0
+        float xx = x * x, xy = x * y, xz = x * z;
+        float yy = y * y, yz = y * z;
+        float zz = z * z;
+        float rm00 = xx * C + c;
+        float rm01 = xy * C + z * s;
+        float rm02 = xz * C - y * s;
+        float rm10 = xy * C - z * s;
+        float rm11 = yy * C + c;
+        float rm12 = yz * C + x * s;
+        float rm20 = xz * C + y * s;
+        float rm21 = yz * C - x * s;
+        float rm22 = zz * C + c;
+
+        // add temporaries for dependent values
+        float nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        float nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        float nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        float nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        float nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        float nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        // set non-dependent values directly
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+
+        return dest;
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaternionf} to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaternionf)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix3f rotate(Quaternionf quat) {
+        return rotate(quat, this);
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaternionf} to this matrix and store
+     * the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaternionf)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3f rotate(Quaternionf quat, Matrix3f dest) {
+        float dqx = 2.0f * quat.x;
+        float dqy = 2.0f * quat.y;
+        float dqz = 2.0f * quat.z;
+        float q00 = dqx * quat.x;
+        float q11 = dqy * quat.y;
+        float q22 = dqz * quat.z;
+        float q01 = dqx * quat.y;
+        float q02 = dqx * quat.z;
+        float q03 = dqx * quat.w;
+        float q12 = dqy * quat.z;
+        float q13 = dqy * quat.w;
+        float q23 = dqz * quat.w;
+
+        float rm00 = 1.0f - q11 - q22;
+        float rm01 = q01 + q23;
+        float rm02 = q02 - q13;
+        float rm10 = q01 - q23;
+        float rm11 = 1.0f - q22 - q00;
+        float rm12 = q12 + q03;
+        float rm20 = q02 + q13;
+        float rm21 = q12 - q03;
+        float rm22 = 1.0f - q11 - q00;
+
+        float nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        float nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        float nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        float nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        float nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        float nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+
+        return dest;
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4f}, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4f},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4f} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * @see #rotation(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @return this
+     */
+    public Matrix3f rotate(AxisAngle4f axisAngle) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4f} and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4f},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4f} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * @see #rotation(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3f rotate(AxisAngle4f axisAngle, Matrix3f dest) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given angle and axis,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(float, Vector3f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * @see #rotation(float, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3f#normalize() normalized})
+     * @return this
+     */
+    public Matrix3f rotate(float angle, Vector3f axis) {
+        return rotate(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given angle and axis,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(float, Vector3f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * @see #rotation(float, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3f#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix3f rotate(float angle, Vector3f axis, Matrix3f dest) {
+        return rotate(angle, axis.x, axis.y, axis.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(Vector3f, Vector3f) setLookAlong()}.
+     * 
+     * @see #lookAlong(float, float, float, float, float, float)
+     * @see #setLookAlong(Vector3f, Vector3f)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix3f lookAlong(Vector3f dir, Vector3f up) {
+        return lookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z, this);
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>
+     * and store the result in <code>dest</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(Vector3f, Vector3f) setLookAlong()}.
+     * 
+     * @see #lookAlong(float, float, float, float, float, float)
+     * @see #setLookAlong(Vector3f, Vector3f)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix3f lookAlong(Vector3f dir, Vector3f up, Matrix3f dest) {
+        return lookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>
+     * and store the result in <code>dest</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(float, float, float, float, float, float) setLookAlong()}
+     * 
+     * @see #setLookAlong(float, float, float, float, float, float)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Matrix3f lookAlong(float dirX, float dirY, float dirZ,
+                              float upX, float upY, float upZ, Matrix3f dest) {
+        // Normalize direction
+        float invDirLength = (float) (1.0 / Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ));
+        float dirnX = dirX * invDirLength;
+        float dirnY = dirY * invDirLength;
+        float dirnZ = dirZ * invDirLength;
+        // right = direction x up
+        float rightX, rightY, rightZ;
+        rightX = dirnY * upZ - dirnZ * upY;
+        rightY = dirnZ * upX - dirnX * upZ;
+        rightZ = dirnX * upY - dirnY * upX;
+        // normalize right
+        float invRightLength = (float) (1.0 / Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ));
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        float upnX = rightY * dirnZ - rightZ * dirnY;
+        float upnY = rightZ * dirnX - rightX * dirnZ;
+        float upnZ = rightX * dirnY - rightY * dirnX;
+
+        // calculate right matrix elements
+        float rm00 = rightX;
+        float rm01 = upnX;
+        float rm02 = -dirnX;
+        float rm10 = rightY;
+        float rm11 = upnY;
+        float rm12 = -dirnY;
+        float rm20 = rightZ;
+        float rm21 = upnZ;
+        float rm22 = -dirnZ;
+
+        // perform optimized matrix multiplication
+        // introduce temporaries for dependent results
+        float nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        float nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        float nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        float nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        float nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        float nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        // set the rest of the matrix elements
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+
+        return dest;
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(float, float, float, float, float, float) setLookAlong()}
+     * 
+     * @see #setLookAlong(float, float, float, float, float, float)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix3f lookAlong(float dirX, float dirY, float dirZ,
+                              float upX, float upY, float upZ) {
+        return lookAlong(dirX, dirY, dirZ, upX, upY, upZ, this);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation to make <code>-z</code>
+     * point along <code>dir</code>.
+     * <p>
+     * In order to apply the lookalong transformation to any previous existing transformation,
+     * use {@link #lookAlong(Vector3f, Vector3f)}.
+     * 
+     * @see #setLookAlong(Vector3f, Vector3f)
+     * @see #lookAlong(Vector3f, Vector3f)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix3f setLookAlong(Vector3f dir, Vector3f up) {
+        return setLookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation to make <code>-z</code>
+     * point along <code>dir</code>.
+     * <p>
+     * In order to apply the lookalong transformation to any previous existing transformation,
+     * use {@link #lookAlong(float, float, float, float, float, float) lookAlong()}
+     * 
+     * @see #setLookAlong(float, float, float, float, float, float)
+     * @see #lookAlong(float, float, float, float, float, float)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix3f setLookAlong(float dirX, float dirY, float dirZ,
+                                 float upX, float upY, float upZ) {
+        // Normalize direction
+        float invDirLength = (float) (1.0 / Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ));
+        float dirnX = dirX * invDirLength;
+        float dirnY = dirY * invDirLength;
+        float dirnZ = dirZ * invDirLength;
+        // right = direction x up
+        float rightX, rightY, rightZ;
+        rightX = dirnY * upZ - dirnZ * upY;
+        rightY = dirnZ * upX - dirnX * upZ;
+        rightZ = dirnX * upY - dirnY * upX;
+        // normalize right
+        float invRightLength = (float) (1.0 / Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ));
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        float upnX = rightY * dirnZ - rightZ * dirnY;
+        float upnY = rightZ * dirnX - rightX * dirnZ;
+        float upnZ = rightX * dirnY - rightY * dirnX;
+
+        m00 = rightX;
+        m01 = upnX;
+        m02 = -dirnX;
+        m10 = rightY;
+        m11 = upnY;
+        m12 = -dirnY;
+        m20 = rightZ;
+        m21 = upnZ;
+        m22 = -dirnZ;
+
+        return this;
+    }
+
+    /**
+     * Get the row at the given <code>row</code> index, starting with <code>0</code>.
+     * 
+     * @param row
+     *          the row index in <tt>[0..2]</tt>
+     * @param dest
+     *          will hold the row components
+     * @return the passed in destination
+     * @throws IndexOutOfBoundsException if <code>row</code> is not in <tt>[0..2]</tt>
+     */
+    public Vector3f getRow(int row, Vector3f dest) throws IndexOutOfBoundsException {
+        switch (row) {
+        case 0:
+            dest.x = m00;
+            dest.y = m10;
+            dest.z = m20;
+            break;
+        case 1:
+            dest.x = m01;
+            dest.y = m11;
+            dest.z = m21;
+            break;
+        case 2:
+            dest.x = m02;
+            dest.y = m12;
+            dest.z = m22;
+            break;
+        default:
+            throw new IndexOutOfBoundsException();
+        }
+        
+        return dest;
+    }
+
+    /**
+     * Get the column at the given <code>column</code> index, starting with <code>0</code>.
+     * 
+     * @param column
+     *          the column index in <tt>[0..2]</tt>
+     * @param dest
+     *          will hold the column components
+     * @return the passed in destination
+     * @throws IndexOutOfBoundsException if <code>column</code> is not in <tt>[0..2]</tt>
+     */
+    public Vector3f getColumn(int column, Vector3f dest) throws IndexOutOfBoundsException {
+        switch (column) {
+        case 0:
+            dest.x = m00;
+            dest.y = m01;
+            dest.z = m02;
+            break;
+        case 1:
+            dest.x = m10;
+            dest.y = m11;
+            dest.z = m12;
+            break;
+        case 2:
+            dest.x = m20;
+            dest.y = m21;
+            dest.z = m22;
+            break;
+        default:
+            throw new IndexOutOfBoundsException();
+        }
+        return dest;
+    }
+
+    /**
+     * Compute a normal matrix from <code>this</code> matrix and store it into <code>dest</code>.
+     * <p>
+     * Please note that, if <code>this</code> is an orthogonal matrix or a matrix whose columns are orthogonal vectors, 
+     * then this method <i>need not</i> be invoked, since in that case <code>this</code> itself is its normal matrix.
+     * In this case, use {@link #set(Matrix3f)} to set a given Matrix3f to this matrix.
+     * 
+     * @see #set(Matrix3f)
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3f normal(Matrix3f dest) {
+        float det = determinant();
+        float s = 1.0f / det;
+        /* Invert and transpose in one go */
+        dest.set((m11 * m22 - m21 * m12) * s,
+                 (m20 * m12 - m10 * m22) * s,
+                 (m10 * m21 - m20 * m11) * s,
+                 (m21 * m02 - m01 * m22) * s,
+                 (m00 * m22 - m20 * m02) * s,
+                 (m20 * m01 - m00 * m21) * s,
+                 (m01 * m12 - m11 * m02) * s,
+                 (m10 * m02 - m00 * m12) * s,
+                 (m00 * m11 - m10 * m01) * s);
+        return dest;
+    }
+
+    /**
+     * Get the scaling factors of <code>this</code> matrix for the three base axes.
+     * 
+     * @param dest
+     *          will hold the scaling factors for <tt>x</tt>, <tt>y</tt> and <tt>z</tt>
+     * @return dest
+     */
+    public Vector3f getScale(Vector3f dest) {
+        dest.x = (float) Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02);
+        dest.y = (float) Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12);
+        dest.z = (float) Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22);
+        return dest;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Matrix4d.java
+++ b/GVRf/Framework/src/org/joml/Matrix4d.java
@@ -1,0 +1,7814 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Contains the definition of a 4x4 Matrix of doubles, and associated functions to transform
+ * it. The matrix is column-major to match OpenGL's interpretation, and it looks like this:
+ * <p>
+ *      m00  m10  m20  m30<br>
+ *      m01  m11  m21  m31<br>
+ *      m02  m12  m22  m32<br>
+ *      m03  m13  m23  m33<br>
+ * 
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Matrix4d implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4d)}
+     * identifying the plane with equation <tt>x=-1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_NX = 0;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4d)}
+     * identifying the plane with equation <tt>x=1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_PX = 1;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4d)}
+     * identifying the plane with equation <tt>y=-1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_NY= 2;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4d)}
+     * identifying the plane with equation <tt>y=1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_PY = 3;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4d)}
+     * identifying the plane with equation <tt>z=-1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_NZ = 4;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4d)}
+     * identifying the plane with equation <tt>z=1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_PZ = 5;
+
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3d)}
+     * identifying the corner <tt>(-1, -1, -1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_NXNYNZ = 0;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3d)}
+     * identifying the corner <tt>(1, -1, -1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_PXNYNZ = 1;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3d)}
+     * identifying the corner <tt>(1, 1, -1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_PXPYNZ = 2;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3d)}
+     * identifying the corner <tt>(-1, 1, -1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_NXPYNZ = 3;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3d)}
+     * identifying the corner <tt>(1, -1, 1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_PXNYPZ = 4;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3d)}
+     * identifying the corner <tt>(-1, -1, 1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_NXNYPZ = 5;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3d)}
+     * identifying the corner <tt>(-1, 1, 1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_NXPYPZ = 6;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3d)}
+     * identifying the corner <tt>(1, 1, 1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_PXPYPZ = 7;
+
+    public double m00, m10, m20, m30;
+    public double m01, m11, m21, m31;
+    public double m02, m12, m22, m32;
+    public double m03, m13, m23, m33;
+
+    /**
+     * Create a new {@link Matrix4d} and set it to {@link #identity() identity}.
+     */
+    public Matrix4d() {
+        m00 = 1.0;
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = 1.0;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = 1.0;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+    }
+
+    /**
+     * Create a new {@link Matrix4d} and make it a copy of the given matrix.
+     * 
+     * @param mat
+     *          the {@link Matrix4d} to copy the values from
+     */
+    public Matrix4d(Matrix4d mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m03 = mat.m03;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m13 = mat.m13;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m23 = mat.m23;
+        m30 = mat.m30;
+        m31 = mat.m31;
+        m32 = mat.m32;
+        m33 = mat.m33;
+    }
+
+    /**
+     * Create a new {@link Matrix4d} and make it a copy of the given matrix.
+     * 
+     * @param mat
+     *          the {@link Matrix4f} to copy the values from
+     */
+    public Matrix4d(Matrix4f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m03 = mat.m03;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m13 = mat.m13;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m23 = mat.m23;
+        m30 = mat.m30;
+        m31 = mat.m31;
+        m32 = mat.m32;
+        m33 = mat.m33;
+    }
+
+    /**
+     * Create a new {@link Matrix4d} by setting its uppper left 3x3 submatrix to the values of the given {@link Matrix3d}
+     * and the rest to identity.
+     * 
+     * @param mat
+     *          the {@link Matrix3d}
+     */
+    public Matrix4d(Matrix3d mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m33 = 1.0;
+    }
+
+    /**
+     * Create a new 4x4 matrix using the supplied double values.
+     * 
+     * @param m00
+     *          the value of m00
+     * @param m01
+     *          the value of m01
+     * @param m02
+     *          the value of m02
+     * @param m03
+     *          the value of m03
+     * @param m10
+     *          the value of m10
+     * @param m11
+     *          the value of m11
+     * @param m12
+     *          the value of m12
+     * @param m13
+     *          the value of m13
+     * @param m20
+     *          the value of m20
+     * @param m21
+     *          the value of m21
+     * @param m22
+     *          the value of m22
+     * @param m23
+     *          the value of m23
+     * @param m30
+     *          the value of m30
+     * @param m31
+     *          the value of m31
+     * @param m32
+     *          the value of m32
+     * @param m33
+     *          the value of m33
+     */
+    public Matrix4d(double m00, double m01, double m02, double m03,
+                    double m10, double m11, double m12, double m13, 
+                    double m20, double m21, double m22, double m23, 
+                    double m30, double m31, double m32, double m33) {
+        this.m00 = m00;
+        this.m01 = m01;
+        this.m02 = m02;
+        this.m03 = m03;
+        this.m10 = m10;
+        this.m11 = m11;
+        this.m12 = m12;
+        this.m13 = m13;
+        this.m20 = m20;
+        this.m21 = m21;
+        this.m22 = m22;
+        this.m23 = m23;
+        this.m30 = m30;
+        this.m31 = m31;
+        this.m32 = m32;
+        this.m33 = m33;
+    }
+    
+    /**
+     * Reset this matrix to the identity.
+     * <p>
+     * Please note that if a call to {@link #identity()} is immediately followed by a call to:
+     * {@link #translate(double, double, double) translate}, 
+     * {@link #rotate(double, double, double, double) rotate},
+     * {@link #scale(double, double, double) scale},
+     * {@link #perspective(double, double, double, double) perspective},
+     * {@link #frustum(double, double, double, double, double, double) frustum},
+     * {@link #ortho(double, double, double, double, double, double) ortho},
+     * {@link #ortho2D(double, double, double, double) ortho2D},
+     * {@link #lookAt(double, double, double, double, double, double, double, double, double) lookAt},
+     * {@link #lookAlong(double, double, double, double, double, double) lookAlong},
+     * or any of their overloads, then the call to {@link #identity()} can be omitted and the subsequent call replaced with:
+     * {@link #translation(double, double, double) translation},
+     * {@link #rotation(double, double, double, double) rotation},
+     * {@link #scaling(double, double, double) scaling},
+     * {@link #setPerspective(double, double, double, double) setPerspective},
+     * {@link #setFrustum(double, double, double, double, double, double) setFrustum},
+     * {@link #setOrtho(double, double, double, double, double, double) setOrtho},
+     * {@link #setOrtho2D(double, double, double, double) setOrtho2D},
+     * {@link #setLookAt(double, double, double, double, double, double, double, double, double) setLookAt},
+     * {@link #setLookAlong(double, double, double, double, double, double) setLookAlong},
+     * or any of their overloads.
+     * 
+     * @return this
+     */
+    public Matrix4d identity() {
+        m00 = 1.0;
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = 1.0;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = 1.0;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Store the values of the given matrix <code>m</code> into <code>this</code> matrix.
+     * 
+     * @see #Matrix4d(Matrix4d)
+     * @see #get(Matrix4d)
+     * 
+     * @param m
+     *          the matrix to copy the values from
+     * @return this
+     */
+    public Matrix4d set(Matrix4d m) {
+        m00 = m.m00;
+        m01 = m.m01;
+        m02 = m.m02;
+        m03 = m.m03;
+        m10 = m.m10;
+        m11 = m.m11;
+        m12 = m.m12;
+        m13 = m.m13;
+        m20 = m.m20;
+        m21 = m.m21;
+        m22 = m.m22;
+        m23 = m.m23;
+        m30 = m.m30;
+        m31 = m.m31;
+        m32 = m.m32;
+        m33 = m.m33;
+        return this;
+    }
+
+    /**
+     * Store the values of the given matrix <code>m</code> into <code>this</code> matrix.
+     * 
+     * @see #Matrix4d(Matrix4f)
+     * 
+     * @param m
+     *          the matrix to copy the values from
+     * @return this
+     */
+    public Matrix4d set(Matrix4f m) {
+        m00 = m.m00;
+        m01 = m.m01;
+        m02 = m.m02;
+        m03 = m.m03;
+        m10 = m.m10;
+        m11 = m.m11;
+        m12 = m.m12;
+        m13 = m.m13;
+        m20 = m.m20;
+        m21 = m.m21;
+        m22 = m.m22;
+        m23 = m.m23;
+        m30 = m.m30;
+        m31 = m.m31;
+        m32 = m.m32;
+        m33 = m.m33;
+        return this;
+    }
+
+    /**
+     * Set the upper left 3x3 submatrix of this {@link Matrix4d} to the given {@link Matrix3d} 
+     * and the rest to identity.
+     * 
+     * @see #Matrix4d(Matrix3d)
+     * 
+     * @param mat
+     *          the {@link Matrix3d}
+     * @return this
+     */
+    public Matrix4d set(Matrix3d mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m03 = 0.0;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m13 = 0.0;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set the upper left 3x3 submatrix of this {@link Matrix4d} to that of the given {@link Matrix4d} 
+     * and the rest to identity.
+     * 
+     * @param mat
+     *          the {@link Matrix4d}
+     * @return this
+     */
+    public Matrix4d set3x3(Matrix4d mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m03 = 0.0;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m13 = 0.0;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link AxisAngle4f}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f}
+     * @return this
+     */
+    public Matrix4d set(AxisAngle4f axisAngle) {
+        double x = axisAngle.x;
+        double y = axisAngle.y;
+        double z = axisAngle.z;
+        double angle = axisAngle.angle;
+        double invLength = 1.0 / Math.sqrt(x*x + y*y + z*z);
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        double c = Math.cos(angle);
+        double s = Math.sin(angle);
+        double omc = 1.0 - c;
+        m00 = c + x*x*omc;
+        m11 = c + y*y*omc;
+        m22 = c + z*z*omc;
+        double tmp1 = x*y*omc;
+        double tmp2 = z*s;
+        m10 = tmp1 - tmp2;
+        m01 = tmp1 + tmp2;
+        tmp1 = x*z*omc;
+        tmp2 = y*s;
+        m20 = tmp1 + tmp2;
+        m02 = tmp1 - tmp2;
+        tmp1 = y*z*omc;
+        tmp2 = x*s;
+        m21 = tmp1 - tmp2;
+        m12 = tmp1 + tmp2;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link AxisAngle4d}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d}
+     * @return this
+     */
+    public Matrix4d set(AxisAngle4d axisAngle) {
+        double x = axisAngle.x;
+        double y = axisAngle.y;
+        double z = axisAngle.z;
+        double angle = axisAngle.angle;
+        double invLength = 1.0 / Math.sqrt(x*x + y*y + z*z);
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        double c = Math.cos(angle);
+        double s = Math.sin(angle);
+        double omc = 1.0 - c;
+        m00 = c + x*x*omc;
+        m11 = c + y*y*omc;
+        m22 = c + z*z*omc;
+        double tmp1 = x*y*omc;
+        double tmp2 = z*s;
+        m10 = tmp1 - tmp2;
+        m01 = tmp1 + tmp2;
+        tmp1 = x*z*omc;
+        tmp2 = y*s;
+        m20 = tmp1 + tmp2;
+        m02 = tmp1 - tmp2;
+        tmp1 = y*z*omc;
+        tmp2 = x*s;
+        m21 = tmp1 - tmp2;
+        m12 = tmp1 + tmp2;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link Quaternionf}.
+     * 
+     * @see Quaternionf#get(Matrix4d)
+     * 
+     * @param q
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix4d set(Quaternionf q) {
+        return q.get(this);
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link Quaterniond}.
+     * 
+     * @see Quaterniond#get(Matrix4d)
+     * 
+     * @param q
+     *          the {@link Quaterniond}
+     * @return this
+     */
+    public Matrix4d set(Quaterniond q) {
+        return q.get(this);
+    }
+
+    /**
+     * Multiply this matrix by the supplied <code>right</code> matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand of the multiplication
+     * @return this
+     */
+    public Matrix4d mul(Matrix4d right) {
+        return mul(right, this);
+    }
+
+    /**
+     * Multiply this matrix by the supplied <code>right</code> matrix and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand of the multiplication
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d mul(Matrix4d right, Matrix4d dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02 + m30 * right.m03,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02 + m31 * right.m03,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02 + m32 * right.m03,
+                 m03 * right.m00 + m13 * right.m01 + m23 * right.m02 + m33 * right.m03,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12 + m30 * right.m13,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12 + m31 * right.m13,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12 + m32 * right.m13,
+                 m03 * right.m10 + m13 * right.m11 + m23 * right.m12 + m33 * right.m13,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22 + m30 * right.m23,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22 + m31 * right.m23,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22 + m32 * right.m23,
+                 m03 * right.m20 + m13 * right.m21 + m23 * right.m22 + m33 * right.m23,
+                 m00 * right.m30 + m10 * right.m31 + m20 * right.m32 + m30 * right.m33,
+                 m01 * right.m30 + m11 * right.m31 + m21 * right.m32 + m31 * right.m33,
+                 m02 * right.m30 + m12 * right.m31 + m22 * right.m32 + m32 * right.m33,
+                 m03 * right.m30 + m13 * right.m31 + m23 * right.m32 + m33 * right.m33);
+        return dest;
+    }
+
+    /**
+     * Multiply this matrix by the supplied parameter matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand of the multiplication
+     * @return this
+     */
+    public Matrix4d mul(Matrix4f right) {
+        return mul(right, this);
+    }
+
+    /**
+     * Multiply this matrix by the supplied parameter matrix and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param right
+     *          the right operand of the multiplication
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d mul(Matrix4f right, Matrix4d dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02 + m30 * right.m03,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02 + m31 * right.m03,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02 + m32 * right.m03,
+                 m03 * right.m00 + m13 * right.m01 + m23 * right.m02 + m33 * right.m03,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12 + m30 * right.m13,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12 + m31 * right.m13,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12 + m32 * right.m13,
+                 m03 * right.m10 + m13 * right.m11 + m23 * right.m12 + m33 * right.m13,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22 + m30 * right.m23,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22 + m31 * right.m23,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22 + m32 * right.m23,
+                 m03 * right.m20 + m13 * right.m21 + m23 * right.m22 + m33 * right.m23,
+                 m00 * right.m30 + m10 * right.m31 + m20 * right.m32 + m30 * right.m33,
+                 m01 * right.m30 + m11 * right.m31 + m21 * right.m32 + m31 * right.m33,
+                 m02 * right.m30 + m12 * right.m31 + m22 * right.m32 + m32 * right.m33,
+                 m03 * right.m30 + m13 * right.m31 + m23 * right.m32 + m33 * right.m33);
+        return dest;
+    }
+
+    /**
+     * Multiply the supplied <code>left</code> matrix by the <code>right</code> and store the result into <code>dest</code>.
+     * <p>
+     * If <code>L</code> is the <code>left</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>L * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>L * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     * 
+     * @param left
+     *          the left operand of the multiplication
+     * @param right
+     *          the right operand of the multiplication
+     * @param dest
+     *          will hold the result
+     */
+    public static void mul(Matrix4f left, Matrix4d right, Matrix4d dest) {
+        dest.set(left.m00 * right.m00 + left.m10 * right.m01 + left.m20 * right.m02 + left.m30 * right.m03,
+                 left.m01 * right.m00 + left.m11 * right.m01 + left.m21 * right.m02 + left.m31 * right.m03,
+                 left.m02 * right.m00 + left.m12 * right.m01 + left.m22 * right.m02 + left.m32 * right.m03,
+                 left.m03 * right.m00 + left.m13 * right.m01 + left.m23 * right.m02 + left.m33 * right.m03,
+                 left.m00 * right.m10 + left.m10 * right.m11 + left.m20 * right.m12 + left.m30 * right.m13,
+                 left.m01 * right.m10 + left.m11 * right.m11 + left.m21 * right.m12 + left.m31 * right.m13,
+                 left.m02 * right.m10 + left.m12 * right.m11 + left.m22 * right.m12 + left.m32 * right.m13,
+                 left.m03 * right.m10 + left.m13 * right.m11 + left.m23 * right.m12 + left.m33 * right.m13,
+                 left.m00 * right.m20 + left.m10 * right.m21 + left.m20 * right.m22 + left.m30 * right.m23,
+                 left.m01 * right.m20 + left.m11 * right.m21 + left.m21 * right.m22 + left.m31 * right.m23,
+                 left.m02 * right.m20 + left.m12 * right.m21 + left.m22 * right.m22 + left.m32 * right.m23,
+                 left.m03 * right.m20 + left.m13 * right.m21 + left.m23 * right.m22 + left.m33 * right.m23,
+                 left.m00 * right.m30 + left.m10 * right.m31 + left.m20 * right.m32 + left.m30 * right.m33,
+                 left.m01 * right.m30 + left.m11 * right.m31 + left.m21 * right.m32 + left.m31 * right.m33,
+                 left.m02 * right.m30 + left.m12 * right.m31 + left.m22 * right.m32 + left.m32 * right.m33,
+                 left.m03 * right.m30 + left.m13 * right.m31 + left.m23 * right.m32 + left.m33 * right.m33);
+    }
+
+    /**
+     * Multiply this matrix by the top 4x3 submatrix of the supplied <code>right</code> matrix and store the result in <code>this</code>.
+     * This method assumes that the last row of <code>right</code> is equal to <tt>(0, 0, 0, 1)</tt>.
+     * <p>
+     * This method can be used to speed up matrix multiplication if the <code>right</code> matrix only represents affine transformations, such as
+     * translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication (the last row is assumed to be <tt>(0, 0, 0, 1)</tt>)
+     * @return this
+     */
+    public Matrix4d mul4x3r(Matrix4d right) {
+       return mul4x3r(right, this);
+    }
+
+    /**
+     * Multiply this matrix by the top 4x3 submatrix of the supplied <code>right</code> matrix and store the result in <code>dest</code>.
+     * This method assumes that the last row of <code>right</code> is equal to <tt>(0, 0, 0, 1)</tt>.
+     * <p>
+     * This method can be used to speed up matrix multiplication if the <code>right</code> matrix only represents affine transformations, such as
+     * translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication (the last row is assumed to be <tt>(0, 0, 0, 1)</tt>)
+     * @param dest
+     *          the destination matrix, which will hold the result
+     * @return dest
+     */
+    public Matrix4d mul4x3r(Matrix4d right, Matrix4d dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02,
+                 m03 * right.m00 + m13 * right.m01 + m23 * right.m02,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12,
+                 m03 * right.m10 + m13 * right.m11 + m23 * right.m12,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22,
+                 m03 * right.m20 + m13 * right.m21 + m23 * right.m22,
+                 m00 * right.m30 + m10 * right.m31 + m20 * right.m32 + m30,
+                 m01 * right.m30 + m11 * right.m31 + m21 * right.m32 + m31,
+                 m02 * right.m30 + m12 * right.m31 + m22 * right.m32 + m32,
+                 m03 * right.m30 + m13 * right.m31 + m23 * right.m32 + m33);
+        return dest;
+    }
+
+    /**
+     * Multiply the top 4x3 submatrix of this matrix by the top 4x3 submatrix of the supplied <code>right</code> matrix and store the result in <code>this</code>.
+     * This method assumes that the last row of both <code>this</code> and <code>right</code> is equal to <tt>(0, 0, 0, 1)</tt>.
+     * <p>
+     * This method can be used to speed up matrix multiplication if both <code>this</code> and the <code>right</code> matrix only represent affine transformations,
+     * such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * This method will not modify either the last row of <code>this</code> or the last row of <code>right</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication (the last row is assumed to be <tt>(0, 0, 0, 1)</tt>)
+     * @return this
+     */
+    public Matrix4d mul4x3(Matrix4d right) {
+       return mul4x3(right, this);
+    }
+
+    /**
+     * Multiply the top 4x3 submatrix of this matrix by the top 4x3 submatrix of the supplied <code>right</code> matrix and store the result in <code>dest</code>.
+     * This method assumes that the last row of both <code>this</code> and <code>right</code> is equal to <tt>(0, 0, 0, 1)</tt>.
+     * <p>
+     * This method can be used to speed up matrix multiplication if both <code>this</code> and the <code>right</code> matrix only represent affine transformations,
+     * such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * This method will not modify either the last row of <code>this</code> or the last row of <code>right</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication (the last row is assumed to be <tt>(0, 0, 0, 1)</tt>)
+     * @param dest
+     *          the destination matrix, which will hold the result
+     * @return dest
+     */
+    public Matrix4d mul4x3(Matrix4d right, Matrix4d dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02,
+                 m03,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12,
+                 m13,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22,
+                 m23,
+                 m00 * right.m30 + m10 * right.m31 + m20 * right.m32 + m30,
+                 m01 * right.m30 + m11 * right.m31 + m21 * right.m32 + m31,
+                 m02 * right.m30 + m12 * right.m31 + m22 * right.m32 + m32,
+                 m33);
+        return dest;
+    }
+
+    /**
+     * Component-wise add the upper 4x3 submatrices of <code>this</code> and <code>other</code>
+     * by first multiplying each component of <code>other</code>'s 4x3 submatrix by <code>otherFactor</code> and
+     * adding that result to <code>this</code>.
+     * <p>
+     * The matrix <code>other</code> will not be changed.
+     * 
+     * @param other
+     *          the other matrix
+     * @param otherFactor
+     *          the factor to multiply each of the other matrix's 4x3 components
+     * @return this
+     */
+    public Matrix4d fma4x3(Matrix4d other, double otherFactor) {
+        return fma4x3(other, otherFactor, this);
+    }
+
+    /**
+     * Component-wise add the upper 4x3 submatrices of <code>this</code> and <code>other</code>
+     * by first multiplying each component of <code>other</code>'s 4x3 submatrix by <code>otherFactor</code>,
+     * adding that to <code>this</code> and storing the final result in <code>dest</code>.
+     * <p>
+     * The other components of <code>dest</code> will be set to the ones of <code>this</code>.
+     * <p>
+     * The matrices <code>this</code> and <code>other</code> will not be changed.
+     * 
+     * @param other
+     *          the other matrix
+     * @param otherFactor
+     *          the factor to multiply each of the other matrix's 4x3 components
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d fma4x3(Matrix4d other, double otherFactor, Matrix4d dest) {
+        dest.m00 = m00 + other.m00 * otherFactor;
+        dest.m01 = m01 + other.m01 * otherFactor;
+        dest.m02 = m02 + other.m02 * otherFactor;
+        dest.m03 = m03;
+        dest.m10 = m10 + other.m10 * otherFactor;
+        dest.m11 = m11 + other.m11 * otherFactor;
+        dest.m12 = m12 + other.m12 * otherFactor;
+        dest.m13 = m13;
+        dest.m20 = m20 + other.m20 * otherFactor;
+        dest.m21 = m21 + other.m21 * otherFactor;
+        dest.m22 = m22 + other.m22 * otherFactor;
+        dest.m23 = m23;
+        dest.m30 = m30 + other.m30 * otherFactor;
+        dest.m31 = m31 + other.m31 * otherFactor;
+        dest.m32 = m32 + other.m32 * otherFactor;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise add <code>this</code> and <code>other</code>.
+     * 
+     * @param other
+     *          the other addend
+     * @return this
+     */
+    public Matrix4d add(Matrix4d other) {
+        return add(other, this);
+    }
+
+    /**
+     * Component-wise add <code>this</code> and <code>other</code> and store the result in <code>dest</code>.
+     * 
+     * @param other
+     *          the other addend
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d add(Matrix4d other, Matrix4d dest) {
+        dest.m00 = m00 + other.m00;
+        dest.m01 = m01 + other.m01;
+        dest.m02 = m02 + other.m02;
+        dest.m03 = m03 + other.m03;
+        dest.m10 = m10 + other.m10;
+        dest.m11 = m11 + other.m11;
+        dest.m12 = m12 + other.m12;
+        dest.m13 = m13 + other.m13;
+        dest.m20 = m20 + other.m20;
+        dest.m21 = m21 + other.m21;
+        dest.m22 = m22 + other.m22;
+        dest.m23 = m23 + other.m23;
+        dest.m30 = m30 + other.m30;
+        dest.m31 = m31 + other.m31;
+        dest.m32 = m32 + other.m32;
+        dest.m33 = m33 + other.m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise subtract <code>subtrahend</code> from <code>this</code>.
+     * 
+     * @param subtrahend
+     *          the subtrahend
+     * @return this
+     */
+    public Matrix4d sub(Matrix4d subtrahend) {
+        return sub(subtrahend, this);
+    }
+
+    /**
+     * Component-wise subtract <code>subtrahend</code> from <code>this</code> and store the result in <code>dest</code>.
+     * 
+     * @param subtrahend
+     *          the subtrahend
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d sub(Matrix4d subtrahend, Matrix4d dest) {
+        dest.m00 = m00 - subtrahend.m00;
+        dest.m01 = m01 - subtrahend.m01;
+        dest.m02 = m02 - subtrahend.m02;
+        dest.m03 = m03 - subtrahend.m03;
+        dest.m10 = m10 - subtrahend.m10;
+        dest.m11 = m11 - subtrahend.m11;
+        dest.m12 = m12 - subtrahend.m12;
+        dest.m13 = m13 - subtrahend.m13;
+        dest.m20 = m20 - subtrahend.m20;
+        dest.m21 = m21 - subtrahend.m21;
+        dest.m22 = m22 - subtrahend.m22;
+        dest.m23 = m23 - subtrahend.m23;
+        dest.m30 = m30 - subtrahend.m30;
+        dest.m31 = m31 - subtrahend.m31;
+        dest.m32 = m32 - subtrahend.m32;
+        dest.m33 = m33 - subtrahend.m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise multiply <code>this</code> by <code>other</code>.
+     * 
+     * @param other
+     *          the other matrix
+     * @return this
+     */
+    public Matrix4d mulComponentWise(Matrix4d other) {
+        return mulComponentWise(other, this);
+    }
+
+    /**
+     * Component-wise multiply <code>this</code> by <code>other</code> and store the result in <code>dest</code>.
+     * 
+     * @param other
+     *          the other matrix
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d mulComponentWise(Matrix4d other, Matrix4d dest) {
+        dest.m00 = m00 * other.m00;
+        dest.m01 = m01 * other.m01;
+        dest.m02 = m02 * other.m02;
+        dest.m03 = m03 * other.m03;
+        dest.m10 = m10 * other.m10;
+        dest.m11 = m11 * other.m11;
+        dest.m12 = m12 * other.m12;
+        dest.m13 = m13 * other.m13;
+        dest.m20 = m20 * other.m20;
+        dest.m21 = m21 * other.m21;
+        dest.m22 = m22 * other.m22;
+        dest.m23 = m23 * other.m23;
+        dest.m30 = m30 * other.m30;
+        dest.m31 = m31 * other.m31;
+        dest.m32 = m32 * other.m32;
+        dest.m33 = m33 * other.m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise add the upper 4x3 submatrices of <code>this</code> and <code>other</code>.
+     * 
+     * @param other
+     *          the other addend
+     * @return this
+     */
+    public Matrix4d add4x3(Matrix4d other) {
+        return add4x3(other, this);
+    }
+
+    /**
+     * Component-wise add the upper 4x3 submatrices of <code>this</code> and <code>other</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * The other components of <code>dest</code> will be set to the ones of <code>this</code>.
+     * 
+     * @param other
+     *          the other addend
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d add4x3(Matrix4d other, Matrix4d dest) {
+        dest.m00 = m00 + other.m00;
+        dest.m01 = m01 + other.m01;
+        dest.m02 = m02 + other.m02;
+        dest.m03 = m03;
+        dest.m10 = m10 + other.m10;
+        dest.m11 = m11 + other.m11;
+        dest.m12 = m12 + other.m12;
+        dest.m13 = m13;
+        dest.m20 = m20 + other.m20;
+        dest.m21 = m21 + other.m21;
+        dest.m22 = m22 + other.m22;
+        dest.m23 = m23;
+        dest.m30 = m30 + other.m30;
+        dest.m31 = m31 + other.m31;
+        dest.m32 = m32 + other.m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise subtract the upper 4x3 submatrices of <code>subtrahend</code> from <code>this</code>.
+     * 
+     * @param subtrahend
+     *          the subtrahend
+     * @return this
+     */
+    public Matrix4d sub4x3(Matrix4d subtrahend) {
+        return sub4x3(subtrahend, this);
+    }
+
+    /**
+     * Component-wise subtract the upper 4x3 submatrices of <code>subtrahend</code> from <code>this</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * The other components of <code>dest</code> will be set to the ones of <code>this</code>.
+     * 
+     * @param subtrahend
+     *          the subtrahend
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d sub4x3(Matrix4d subtrahend, Matrix4d dest) {
+        dest.m00 = m00 - subtrahend.m00;
+        dest.m01 = m01 - subtrahend.m01;
+        dest.m02 = m02 - subtrahend.m02;
+        dest.m03 = m03;
+        dest.m10 = m10 - subtrahend.m10;
+        dest.m11 = m11 - subtrahend.m11;
+        dest.m12 = m12 - subtrahend.m12;
+        dest.m13 = m13;
+        dest.m20 = m20 - subtrahend.m20;
+        dest.m21 = m21 - subtrahend.m21;
+        dest.m22 = m22 - subtrahend.m22;
+        dest.m23 = m23;
+        dest.m30 = m30 - subtrahend.m30;
+        dest.m31 = m31 - subtrahend.m31;
+        dest.m32 = m32 - subtrahend.m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise multiply the upper 4x3 submatrices of <code>this</code> by <code>other</code>.
+     * 
+     * @param other
+     *          the other matrix
+     * @return this
+     */
+    public Matrix4d mul4x3ComponentWise(Matrix4d other) {
+        return mul4x3ComponentWise(other, this);
+    }
+
+    /**
+     * Component-wise multiply the upper 4x3 submatrices of <code>this</code> by <code>other</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * The other components of <code>dest</code> will be set to the ones of <code>this</code>.
+     * 
+     * @param other
+     *          the other matrix
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d mul4x3ComponentWise(Matrix4d other, Matrix4d dest) {
+        dest.m00 = m00 * other.m00;
+        dest.m01 = m01 * other.m01;
+        dest.m02 = m02 * other.m02;
+        dest.m03 = m03;
+        dest.m10 = m10 * other.m10;
+        dest.m11 = m11 * other.m11;
+        dest.m12 = m12 * other.m12;
+        dest.m13 = m13;
+        dest.m20 = m20 * other.m20;
+        dest.m21 = m21 * other.m21;
+        dest.m22 = m22 * other.m22;
+        dest.m23 = m23;
+        dest.m30 = m30 * other.m30;
+        dest.m31 = m31 * other.m31;
+        dest.m32 = m32 * other.m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /** Set the values within this matrix to the supplied double values. The matrix will look like this:<br><br>
+     *  
+     * m00, m10, m20, m30<br>
+     * m01, m11, m21, m31<br>
+     * m02, m12, m22, m32<br>
+     * m03, m13, m23, m33
+     *
+     * @param m00
+     *          the new value of m00
+     * @param m01
+     *          the new value of m01
+     * @param m02
+     *          the new value of m02
+     * @param m03
+     *          the new value of m03
+     * @param m10
+     *          the new value of m10
+     * @param m11
+     *          the new value of m11
+     * @param m12
+     *          the new value of m12
+     * @param m13
+     *          the new value of m13
+     * @param m20
+     *          the new value of m20
+     * @param m21
+     *          the new value of m21
+     * @param m22
+     *          the new value of m22
+     * @param m23
+     *          the new value of m23
+     * @param m30
+     *          the new value of m30
+     * @param m31
+     *          the new value of m31
+     * @param m32
+     *          the new value of m32
+     * @param m33
+     *          the new value of m33
+     * @return this
+     */
+    public Matrix4d set(double m00, double m01, double m02,double m03,
+                        double m10, double m11, double m12, double m13,
+                        double m20, double m21, double m22, double m23, 
+                        double m30, double m31, double m32, double m33) {
+        this.m00 = m00;
+        this.m01 = m01;
+        this.m02 = m02;
+        this.m03 = m03;
+        this.m10 = m10;
+        this.m11 = m11;
+        this.m12 = m12;
+        this.m13 = m13;
+        this.m20 = m20;
+        this.m21 = m21;
+        this.m22 = m22;
+        this.m23 = m23;
+        this.m30 = m30;
+        this.m31 = m31;
+        this.m32 = m32;
+        this.m33 = m33;
+        return this;
+    }
+
+    /**
+     * Set the values in the matrix using a double array that contains the matrix elements in column-major order.
+     * <p>
+     * The results will look like this:<br><br>
+     * 
+     * 0, 4, 8, 12<br>
+     * 1, 5, 9, 13<br>
+     * 2, 6, 10, 14<br>
+     * 3, 7, 11, 15<br>
+     * 
+     * @param m
+     *          the array to read the matrix values from
+     * @return this
+     */
+    public Matrix4d set(double m[]) {
+        m00 = m[0];
+        m01 = m[1];
+        m02 = m[2];
+        m03 = m[3];
+        m10 = m[4];
+        m11 = m[5];
+        m12 = m[6];
+        m13 = m[7];
+        m20 = m[8];
+        m21 = m[9];
+        m22 = m[10];
+        m23 = m[11];
+        m30 = m[12];
+        m31 = m[13];
+        m32 = m[14];
+        m33 = m[15];
+        return this;
+    }
+
+    /**
+     * Set the values in the matrix using a float array that contains the matrix elements in column-major order.
+     * <p>
+     * The results will look like this:<br><br>
+     * 
+     * 0, 4, 8, 12<br>
+     * 1, 5, 9, 13<br>
+     * 2, 6, 10, 14<br>
+     * 3, 7, 11, 15<br>
+     * 
+     * @param m
+     *          the array to read the matrix values from
+     * @return this
+     */
+    public Matrix4d set(float m[]) {
+        m00 = m[0];
+        m01 = m[1];
+        m02 = m[2];
+        m03 = m[3];
+        m10 = m[4];
+        m11 = m[5];
+        m12 = m[6];
+        m13 = m[7];
+        m20 = m[8];
+        m21 = m[9];
+        m22 = m[10];
+        m23 = m[11];
+        m30 = m[12];
+        m31 = m[13];
+        m32 = m[14];
+        m33 = m[15];
+        return this;
+    }
+
+    /**
+     * Set the values of this matrix by reading 16 double values from the given {@link DoubleBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The DoubleBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the DoubleBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the DoubleBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix4d set(DoubleBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.get(pos);
+        m01 = buffer.get(pos+1);
+        m02 = buffer.get(pos+2);
+        m03 = buffer.get(pos+3);
+        m10 = buffer.get(pos+4);
+        m11 = buffer.get(pos+5);
+        m12 = buffer.get(pos+6);
+        m13 = buffer.get(pos+7);
+        m20 = buffer.get(pos+8);
+        m21 = buffer.get(pos+9);
+        m22 = buffer.get(pos+10);
+        m23 = buffer.get(pos+11);
+        m30 = buffer.get(pos+12);
+        m31 = buffer.get(pos+13);
+        m32 = buffer.get(pos+14);
+        m33 = buffer.get(pos+15);
+        return this;
+    }
+
+    /**
+     * Set the values of this matrix by reading 16 float values from the given {@link FloatBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The FloatBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the FloatBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the FloatBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix4d set(FloatBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.get(pos);
+        m01 = buffer.get(pos+1);
+        m02 = buffer.get(pos+2);
+        m03 = buffer.get(pos+3);
+        m10 = buffer.get(pos+4);
+        m11 = buffer.get(pos+5);
+        m12 = buffer.get(pos+6);
+        m13 = buffer.get(pos+7);
+        m20 = buffer.get(pos+8);
+        m21 = buffer.get(pos+9);
+        m22 = buffer.get(pos+10);
+        m23 = buffer.get(pos+11);
+        m30 = buffer.get(pos+12);
+        m31 = buffer.get(pos+13);
+        m32 = buffer.get(pos+14);
+        m33 = buffer.get(pos+15);
+        return this;
+    }
+
+    /**
+     * Set the values of this matrix by reading 16 double values from the given {@link ByteBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The ByteBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the ByteBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the ByteBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix4d set(ByteBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.getDouble(pos);
+        m01 = buffer.getDouble(pos+8*1);
+        m02 = buffer.getDouble(pos+8*2);
+        m03 = buffer.getDouble(pos+8*3);
+        m10 = buffer.getDouble(pos+8*4);
+        m11 = buffer.getDouble(pos+8*5);
+        m12 = buffer.getDouble(pos+8*6);
+        m13 = buffer.getDouble(pos+8*7);
+        m20 = buffer.getDouble(pos+8*8);
+        m21 = buffer.getDouble(pos+8*9);
+        m22 = buffer.getDouble(pos+8*10);
+        m23 = buffer.getDouble(pos+8*11);
+        m30 = buffer.getDouble(pos+8*12);
+        m31 = buffer.getDouble(pos+8*13);
+        m32 = buffer.getDouble(pos+8*14);
+        m33 = buffer.getDouble(pos+8*15);
+        return this;
+    }
+
+    /**
+     * Set the values of this matrix by reading 16 float values from the given {@link ByteBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The ByteBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the ByteBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the ByteBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix4d setFloats(ByteBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.getFloat(pos);
+        m01 = buffer.getFloat(pos+4*1);
+        m02 = buffer.getFloat(pos+4*2);
+        m03 = buffer.getFloat(pos+4*3);
+        m10 = buffer.getFloat(pos+4*4);
+        m11 = buffer.getFloat(pos+4*5);
+        m12 = buffer.getFloat(pos+4*6);
+        m13 = buffer.getFloat(pos+4*7);
+        m20 = buffer.getFloat(pos+4*8);
+        m21 = buffer.getFloat(pos+4*9);
+        m22 = buffer.getFloat(pos+4*10);
+        m23 = buffer.getFloat(pos+4*11);
+        m30 = buffer.getFloat(pos+4*12);
+        m31 = buffer.getFloat(pos+4*13);
+        m32 = buffer.getFloat(pos+4*14);
+        m33 = buffer.getFloat(pos+4*15);
+        return this;
+    }
+
+    /**
+     * Return the determinant of this matrix.
+     * <p>
+     * If <code>this</code> matrix is only composed of affine transformations, such as translation, rotation, scaling and shearing,
+     * and thus its last row is equal to <tt>(0, 0, 0, 1)</tt>, then {@link #determinant4x3()} can be used instead of this method.
+     * 
+     * @see #determinant4x3()
+     * 
+     * @return the determinant
+     */
+    public double determinant() {
+        return (m00 * m11 - m01 * m10) * (m22 * m33 - m23 * m32)
+             + (m02 * m10 - m00 * m12) * (m21 * m33 - m23 * m31)
+             + (m00 * m13 - m03 * m10) * (m21 * m32 - m22 * m31) 
+             + (m01 * m12 - m02 * m11) * (m20 * m33 - m23 * m30)
+             + (m03 * m11 - m01 * m13) * (m20 * m32 - m22 * m30) 
+             + (m02 * m13 - m03 * m12) * (m20 * m31 - m21 * m30);
+    }
+
+    /**
+     * Return the determinant of the upper left 3x3 submatrix of this matrix.
+     * 
+     * @return the determinant
+     */
+    public double determinant3x3() {
+        return (m00 * m11 - m01 * m10) * m22
+             + (m02 * m10 - m00 * m12) * m21
+             + (m01 * m12 - m02 * m11) * m20;
+    }
+
+    /**
+     * Return the determinant of this matrix by assuming that its last row is equal to <tt>(0, 0, 0, 1)</tt>.
+     * 
+     * @return the determinant
+     */
+    public double determinant4x3() {
+        return (m00 * m11 - m01 * m10) * m22
+             + (m02 * m10 - m00 * m12) * m21
+             + (m01 * m12 - m02 * m11) * m20;
+    }
+
+    /**
+     * Invert this matrix.
+     * <p>
+     * If <code>this</code> matrix is only composed of affine transformations, such as translation, rotation, scaling and shearing,
+     * and thus its last row is equal to <tt>(0, 0, 0, 1)</tt>, then {@link #invert4x3()} can be used instead of this method.
+     * 
+     * @see #invert4x3()
+     * 
+     * @return this
+     */
+    public Matrix4d invert() {
+        return invert(this);
+    }
+
+    /**
+     * Invert <code>this</code> matrix and store the result in <code>dest</code>.
+     * <p>
+     * If <code>this</code> matrix is only composed of affine transformations, such as translation, rotation, scaling and shearing,
+     * and thus its last row is equal to <tt>(0, 0, 0, 1)</tt>, then {@link #invert4x3(Matrix4d)} can be used instead of this method.
+     * 
+     * @see #invert4x3(Matrix4d)
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix4d invert(Matrix4d dest) {
+        double a = m00 * m11 - m01 * m10;
+        double b = m00 * m12 - m02 * m10;
+        double c = m00 * m13 - m03 * m10;
+        double d = m01 * m12 - m02 * m11;
+        double e = m01 * m13 - m03 * m11;
+        double f = m02 * m13 - m03 * m12;
+        double g = m20 * m31 - m21 * m30;
+        double h = m20 * m32 - m22 * m30;
+        double i = m20 * m33 - m23 * m30;
+        double j = m21 * m32 - m22 * m31;
+        double k = m21 * m33 - m23 * m31;
+        double l = m22 * m33 - m23 * m32;
+        double det = a * l - b * k + c * j + d * i - e * h + f * g;
+        det = 1.0 / det;
+        dest.set(( m11 * l - m12 * k + m13 * j) * det,
+                 (-m01 * l + m02 * k - m03 * j) * det,
+                 ( m31 * f - m32 * e + m33 * d) * det,
+                 (-m21 * f + m22 * e - m23 * d) * det,
+                 (-m10 * l + m12 * i - m13 * h) * det,
+                 ( m00 * l - m02 * i + m03 * h) * det,
+                 (-m30 * f + m32 * c - m33 * b) * det,
+                 ( m20 * f - m22 * c + m23 * b) * det,
+                 ( m10 * k - m11 * i + m13 * g) * det,
+                 (-m00 * k + m01 * i - m03 * g) * det,
+                 ( m30 * e - m31 * c + m33 * a) * det,
+                 (-m20 * e + m21 * c - m23 * a) * det,
+                 (-m10 * j + m11 * h - m12 * g) * det,
+                 ( m00 * j - m01 * h + m02 * g) * det,
+                 (-m30 * d + m31 * b - m32 * a) * det,
+                 ( m20 * d - m21 * b + m22 * a) * det);
+        return dest;
+    }
+
+    /**
+     * Invert this matrix by assuming that its last row is equal to <tt>(0, 0, 0, 1)</tt> and write the result into <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d invert4x3(Matrix4d dest) {
+        double s = determinant4x3();
+        s = 1.0 / s;
+        double m10m22 = m10 * m22;
+        double m10m21 = m10 * m21;
+        double m10m02 = m10 * m02;
+        double m10m01 = m10 * m01;
+        double m11m22 = m11 * m22;
+        double m11m20 = m11 * m20;
+        double m11m02 = m11 * m02;
+        double m11m00 = m11 * m00;
+        double m12m21 = m12 * m21;
+        double m12m20 = m12 * m20;
+        double m12m01 = m12 * m01;
+        double m12m00 = m12 * m00;
+        double m20m02 = m20 * m02;
+        double m20m01 = m20 * m01;
+        double m21m02 = m21 * m02;
+        double m21m00 = m21 * m00;
+        double m22m01 = m22 * m01;
+        double m22m00 = m22 * m00;
+        dest.set((m11m22 - m12m21) * s,
+                 (m21m02 - m22m01) * s,
+                 (m12m01 - m11m02) * s,
+                 0.0,
+                 (m12m20 - m10m22) * s,
+                 (m22m00 - m20m02) * s,
+                 (m10m02 - m12m00) * s,
+                 0.0,
+                 (m10m21 - m11m20) * s,
+                 (m20m01 - m21m00) * s,
+                 (m11m00 - m10m01) * s,
+                 0.0,
+                 (m10m22 * m31 - m10m21 * m32 + m11m20 * m32 - m11m22 * m30 + m12m21 * m30 - m12m20 * m31) * s,
+                 (m20m02 * m31 - m20m01 * m32 + m21m00 * m32 - m21m02 * m30 + m22m01 * m30 - m22m00 * m31) * s,
+                 (m11m02 * m30 - m12m01 * m30 + m12m00 * m31 - m10m02 * m31 + m10m01 * m32 - m11m00 * m32) * s,
+                 1.0);
+        return dest;
+    }
+
+    /**
+     * Invert this matrix by assuming that its last row is equal to <tt>(0, 0, 0, 1)</tt>.
+     * 
+     * @return this
+     */
+    public Matrix4d invert4x3() {
+        return invert4x3(this);
+    }
+
+    /**
+     * Transpose this matrix.
+     * 
+     * @return this
+     */
+    public Matrix4d transpose() {
+        return transpose(this);
+    }
+
+    /**
+     * Transpose <code>this</code> matrix and store the result into <code>dest</code>.
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix4d transpose(Matrix4d dest) {
+        dest.set(m00, m10, m20, m30,
+                 m01, m11, m21, m31,
+                 m02, m12, m22, m32,
+                 m03, m13, m23, m33);
+        return dest;
+    }
+
+    /**
+     * Transpose only the upper left 3x3 submatrix of this matrix and set the rest of the matrix elements to identity.
+     * 
+     * @return this
+     */
+    public Matrix4d transpose3x3() {
+        return transpose3x3(this);
+    }
+
+    /**
+     * Transpose only the upper left 3x3 submatrix of this matrix and store the result in <code>dest</code>.
+     * <p>
+     * All other matrix elements of <code>dest</code> will be set to identity.
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix4d transpose3x3(Matrix4d dest) {
+        dest.set(m00, m10, m20, 0.0,
+                 m01, m11, m21, 0.0,
+                 m02, m12, m22, 0.0,
+                 0.0, 0.0, 0.0, 1.0);
+        return dest;
+    }
+
+    /**
+     * Transpose only the upper left 3x3 submatrix of this matrix and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3d transpose3x3(Matrix3d dest) {
+        dest.m00 = m00;
+        dest.m01 = m10;
+        dest.m02 = m20;
+        dest.m10 = m01;
+        dest.m11 = m11;
+        dest.m12 = m21;
+        dest.m20 = m02;
+        dest.m21 = m12;
+        dest.m22 = m22;
+        return dest;
+    }
+
+    /**
+     * Set this matrix to be a simple translation matrix.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional translation.
+     * 
+     * @param x
+     *          the offset to translate in x
+     * @param y
+     *          the offset to translate in y
+     * @param z
+     *          the offset to translate in z
+     * @return this
+     */
+    public Matrix4d translation(double x, double y, double z) {
+        m00 = 1.0;
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = 1.0;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = 1.0;
+        m23 = 0.0;
+        m30 = x;
+        m31 = y;
+        m32 = z;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple translation matrix.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional translation.
+     * 
+     * @param offset
+     *              the offsets in x, y and z to translate
+     * @return this
+     */
+    public Matrix4d translation(Vector3f offset) {
+        return translation(offset.x, offset.y, offset.z);
+    }
+
+    /**
+     * Set this matrix to be a simple translation matrix.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional translation.
+     *
+     * @param offset
+     *              the offsets in x, y and z to translate
+     * @return this
+     */
+    public Matrix4d translation(Vector3d offset) {
+        return translation(offset.x, offset.y, offset.z);
+    }
+
+    /**
+     * Set only the translation components of this matrix <tt>(m30, m31, m32)</tt> to the given values <tt>(x, y, z)</tt>.
+     * <p>
+     * To build a translation matrix instead, use {@link #translation(double, double, double)}.
+     * To apply a translation to another matrix, use {@link #translate(double, double, double)}.
+     * 
+     * @see #translation(double, double, double)
+     * @see #translate(double, double, double)
+     * 
+     * @param x
+     *          the units to translate in x
+     * @param y
+     *          the units to translate in y
+     * @param z
+     *          the units to translate in z
+     * @return this
+     */
+    public Matrix4d setTranslation(double x, double y, double z) {
+        m30 = x;
+        m31 = y;
+        m32 = z;
+        return this;
+    }
+
+    /**
+     * Set only the translation components of this matrix <tt>(m30, m31, m32)</tt> to the given values <tt>(xyz.x, xyz.y, xyz.z)</tt>.
+     * <p>
+     * To build a translation matrix instead, use {@link #translation(Vector3d)}.
+     * To apply a translation to another matrix, use {@link #translate(Vector3d)}.
+     * 
+     * @see #translation(Vector3d)
+     * @see #translate(Vector3d)
+     * 
+     * @param xyz
+     *          the units to translate in <tt>(x, y, z)</tt>
+     * @return this
+     */
+    public Matrix4d setTranslation(Vector3d xyz) {
+        m30 = xyz.x;
+        m31 = xyz.y;
+        m32 = xyz.z;
+        return this;
+    }
+
+    /**
+     * Get only the translation components of this matrix <tt>(m30, m31, m32)</tt> and store them in the given vector <code>xyz</code>.
+     * 
+     * @param dest
+     *          will hold the translation components of this matrix
+     * @return dest
+     */
+    public Vector3d getTranslation(Vector3d dest) {
+        dest.x = m30;
+        dest.y = m31;
+        dest.z = m32;
+        return dest;
+    }
+
+    /**
+     * Get the scaling factors of <code>this</code> matrix for the three base axes.
+     * 
+     * @param dest
+     *          will hold the scaling factors for <tt>x</tt>, <tt>y</tt> and <tt>z</tt>
+     * @return dest
+     */
+    public Vector3d getScale(Vector3d dest) {
+        dest.x = Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02);
+        dest.y = Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12);
+        dest.z = Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22);
+        return dest;
+    }
+
+    /**
+     * Return a string representation of this matrix.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt>  0.000E0; -</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat("  0.000E0; -"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this matrix by formatting the matrix elements with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the matrix values with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return formatter.format(m00) + formatter.format(m10) + formatter.format(m20) + formatter.format(m30) + "\n" //$NON-NLS-1$
+             + formatter.format(m01) + formatter.format(m11) + formatter.format(m21) + formatter.format(m31) + "\n" //$NON-NLS-1$
+             + formatter.format(m02) + formatter.format(m12) + formatter.format(m22) + formatter.format(m32) + "\n" //$NON-NLS-1$
+             + formatter.format(m03) + formatter.format(m13) + formatter.format(m23) + formatter.format(m33) + "\n"; //$NON-NLS-1$
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store them into
+     * <code>dest</code>.
+     * <p>
+     * This is the reverse method of {@link #set(Matrix4d)} and allows to obtain
+     * intermediate calculation results when chaining multiple transformations.
+     * 
+     * @see #set(Matrix4d)
+     * 
+     * @param dest
+     *          the destination matrix
+     * @return the passed in destination
+     */
+    public Matrix4d get(Matrix4d dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of the upper left 3x3 submatrix of <code>this</code> matrix and store them into
+     * <code>dest</code>.
+     * 
+     * @param dest
+     *            the destination matrix
+     * @return the passed in destination
+     */
+    public Matrix3d get3x3(Matrix3d dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaternionf}.
+     * <p>
+     * This method assumes that the first three column vectors of the upper left 3x3 submatrix are not normalized and
+     * thus allows to ignore any additional scaling factor that is applied to the matrix.
+     * 
+     * @see Quaternionf#setFromUnnormalized(Matrix4d)
+     * 
+     * @param dest
+     *          the destination {@link Quaternionf}
+     * @return the passed in destination
+     */
+    public Quaternionf getUnnormalizedRotation(Quaternionf dest) {
+        return dest.setFromUnnormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaternionf}.
+     * <p>
+     * This method assumes that the first three column vectors of the upper left 3x3 submatrix are normalized.
+     * 
+     * @see Quaternionf#setFromNormalized(Matrix4d)
+     * 
+     * @param dest
+     *          the destination {@link Quaternionf}
+     * @return the passed in destination
+     */
+    public Quaternionf getNormalizedRotation(Quaternionf dest) {
+        return dest.setFromNormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaterniond}.
+     * <p>
+     * This method assumes that the first three column vectors of the upper left 3x3 submatrix are not normalized and
+     * thus allows to ignore any additional scaling factor that is applied to the matrix.
+     * 
+     * @see Quaterniond#setFromUnnormalized(Matrix4d)
+     * 
+     * @param dest
+     *          the destination {@link Quaterniond}
+     * @return the passed in destination
+     */
+    public Quaterniond getUnnormalizedRotation(Quaterniond dest) {
+        return dest.setFromUnnormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaterniond}.
+     * <p>
+     * This method assumes that the first three column vectors of the upper left 3x3 submatrix are normalized.
+     * 
+     * @see Quaterniond#setFromNormalized(Matrix4d)
+     * 
+     * @param dest
+     *          the destination {@link Quaterniond}
+     * @return the passed in destination
+     */
+    public Quaterniond getNormalizedRotation(Quaterniond dest) {
+        return dest.setFromNormalized(this);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the matrix is stored, use {@link #get(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, DoubleBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public DoubleBuffer get(DoubleBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given {@link DoubleBuffer}.
+     * 
+     * @param index
+     *            the absolute position into the {@link DoubleBuffer}
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public DoubleBuffer get(int index, DoubleBuffer buffer) {
+        buffer.put(index, m00);
+        buffer.put(index+1, m01);
+        buffer.put(index+2, m02);
+        buffer.put(index+3, m03);
+        buffer.put(index+4, m10);
+        buffer.put(index+5, m11);
+        buffer.put(index+6, m12);
+        buffer.put(index+7, m13);
+        buffer.put(index+8, m20);
+        buffer.put(index+9, m21);
+        buffer.put(index+10, m22);
+        buffer.put(index+11, m23);
+        buffer.put(index+12, m30);
+        buffer.put(index+13, m31);
+        buffer.put(index+14, m32);
+        buffer.put(index+15, m33);
+        return buffer;
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given
+     * FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the matrix is stored, use {@link #get(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     * <p>
+     * Please note that due to this matrix storing double values those values will potentially
+     * lose precision when they are converted to float values before being put into the given FloatBuffer.
+     * 
+     * @see #get(int, FloatBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(FloatBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * Please note that due to this matrix storing double values those values will potentially
+     * lose precision when they are converted to float values before being put into the given FloatBuffer.
+     * 
+     * @param index
+     *            the absolute position into the FloatBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(int index, FloatBuffer buffer) {
+        buffer.put(index,    (float) m00);
+        buffer.put(index+1,  (float) m01);
+        buffer.put(index+2,  (float) m02);
+        buffer.put(index+3,  (float) m03);
+        buffer.put(index+4,  (float) m10);
+        buffer.put(index+5,  (float) m11);
+        buffer.put(index+6,  (float) m12);
+        buffer.put(index+7,  (float) m13);
+        buffer.put(index+8,  (float) m20);
+        buffer.put(index+9,  (float) m21);
+        buffer.put(index+10, (float) m22);
+        buffer.put(index+11, (float) m23);
+        buffer.put(index+12, (float) m30);
+        buffer.put(index+13, (float) m31);
+        buffer.put(index+14, (float) m32);
+        buffer.put(index+15, (float) m33);
+        return buffer;
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the matrix is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, ByteBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * 
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putDouble(index+8*0,  m00);
+        buffer.putDouble(index+8*1,  m01);
+        buffer.putDouble(index+8*2,  m02);
+        buffer.putDouble(index+8*3,  m03);
+        buffer.putDouble(index+8*4,  m10);
+        buffer.putDouble(index+8*5,  m11);
+        buffer.putDouble(index+8*6,  m12);
+        buffer.putDouble(index+8*7,  m13);
+        buffer.putDouble(index+8*8,  m20);
+        buffer.putDouble(index+8*9,  m21);
+        buffer.putDouble(index+8*10, m22);
+        buffer.putDouble(index+8*11, m23);
+        buffer.putDouble(index+8*12, m30);
+        buffer.putDouble(index+8*13, m31);
+        buffer.putDouble(index+8*14, m32);
+        buffer.putDouble(index+8*15, m33);
+        return buffer;
+    }
+
+    /**
+     * Store the elements of this matrix as float values in column-major order into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * Please note that due to this matrix storing double values those values will potentially
+     * lose precision when they are converted to float values before being put into the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the matrix is stored, use {@link #getFloats(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #getFloats(int, ByteBuffer)
+     * 
+     * @param buffer
+     *            will receive the elements of this matrix as float values in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public ByteBuffer getFloats(ByteBuffer buffer) {
+        return getFloats(buffer.position(), buffer);
+    }
+
+    /**
+     * Store the elements of this matrix as float values in column-major order into the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * Please note that due to this matrix storing double values those values will potentially
+     * lose precision when they are converted to float values before being put into the given ByteBuffer.
+     * 
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            will receive the elements of this matrix as float values in column-major order
+     * @return the passed in buffer
+     */
+    public ByteBuffer getFloats(int index, ByteBuffer buffer) {
+        buffer.putFloat(index+4*0,  (float)m00);
+        buffer.putFloat(index+4*1,  (float)m01);
+        buffer.putFloat(index+4*2,  (float)m02);
+        buffer.putFloat(index+4*3,  (float)m03);
+        buffer.putFloat(index+4*4,  (float)m10);
+        buffer.putFloat(index+4*5,  (float)m11);
+        buffer.putFloat(index+4*6,  (float)m12);
+        buffer.putFloat(index+4*7,  (float)m13);
+        buffer.putFloat(index+4*8,  (float)m20);
+        buffer.putFloat(index+4*9,  (float)m21);
+        buffer.putFloat(index+4*10, (float)m22);
+        buffer.putFloat(index+4*11, (float)m23);
+        buffer.putFloat(index+4*12, (float)m30);
+        buffer.putFloat(index+4*13, (float)m31);
+        buffer.putFloat(index+4*14, (float)m32);
+        buffer.putFloat(index+4*15, (float)m33);
+        return buffer;
+    }
+
+    /**
+     * Store this matrix into the supplied double array in column-major order at the given offset.
+     * 
+     * @param arr
+     *          the array to write the matrix values into
+     * @param offset
+     *          the offset into the array
+     * @return the passed in array
+     */
+    public double[] get(double[] arr, int offset) {
+        arr[offset+0] = m00;
+        arr[offset+1] = m01;
+        arr[offset+2] = m02;
+        arr[offset+3] = m03;
+        arr[offset+4] = m10;
+        arr[offset+5] = m11;
+        arr[offset+6] = m12;
+        arr[offset+7] = m13;
+        arr[offset+8] = m20;
+        arr[offset+9] = m21;
+        arr[offset+10] = m22;
+        arr[offset+11] = m23;
+        arr[offset+12] = m30;
+        arr[offset+13] = m31;
+        arr[offset+14] = m32;
+        arr[offset+15] = m33;
+        return arr;
+    }
+
+    /**
+     * Store this matrix into the supplied double array in column-major order.
+     * <p>
+     * In order to specify an explicit offset into the array, use the method {@link #get(double[], int)}.
+     * 
+     * @see #get(double[], int)
+     * 
+     * @param arr
+     *          the array to write the matrix values into
+     * @return the passed in array
+     */
+    public double[] get(double[] arr) {
+        arr[0] =  m00;
+        arr[1] =  m01;
+        arr[2] =  m02;
+        arr[3] =  m03;
+        arr[4] =  m10;
+        arr[5] =  m11;
+        arr[6] =  m12;
+        arr[7] =  m13;
+        arr[8] =  m20;
+        arr[9] =  m21;
+        arr[10] = m22;
+        arr[11] = m23;
+        arr[12] = m30;
+        arr[13] = m31;
+        arr[14] = m32;
+        arr[15] = m33;
+        return arr;
+    }
+
+    /**
+     * Set all the values within this matrix to 0.
+     * 
+     * @return this
+     */
+    public Matrix4d zero() {
+        m00 = 0.0;
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = 0.0;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = 0.0;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 0.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix, which scales all axes uniformly by the given factor.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional scaling.
+     * <p>
+     * In order to post-multiply a scaling transformation directly to a
+     * matrix, use {@link #scale(double) scale()} instead.
+     * 
+     * @see #scale(double)
+     * 
+     * @param factor
+     *             the scale factor in x, y and z
+     * @return this
+     */
+    public Matrix4d scaling(double factor) {
+        m00 = factor;
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = factor;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = factor;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix.
+     * 
+     * @param x
+     *          the scale in x
+     * @param y
+     *          the scale in y
+     * @param z
+     *          the scale in z         
+     * @return this
+     */
+    public Matrix4d scaling(double x, double y, double z) {
+        m00 = x;
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = y;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = z;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix which scales the base axes by
+     * <tt>xyz.x</tt>, <tt>xyz.y</tt> and <tt>xyz.z</tt>, respectively.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional scaling.
+     * <p>
+     * In order to post-multiply a scaling transformation directly to a
+     * matrix use {@link #scale(Vector3d) scale()} instead.
+     * 
+     * @see #scale(Vector3d)
+     * 
+     * @param xyz
+     *             the scale in x, y and z, respectively
+     * @return this
+     */
+    public Matrix4d scaling(Vector3d xyz) {
+        return scaling(xyz.x, xyz.y, xyz.z);
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * <p>
+     * From <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">Wikipedia</a>
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param x
+     *          the x-coordinate of the axis to rotate about
+     * @param y
+     *          the y-coordinate of the axis to rotate about
+     * @param z
+     *          the z-coordinate of the axis to rotate about
+     * @return this
+     */
+    public Matrix4d rotation(double angle, double x, double y, double z) {
+        double cos = Math.cos(angle);
+        double sin = Math.sin(angle);
+        double C = 1.0 - cos;
+        double xy = x * y, xz = x * z, yz = y * z;
+        m00 = cos + x * x * C;
+        m10 = xy * C - z * sin;
+        m20 = xz * C + y * sin;
+        m30 = 0.0;
+        m01 = xy * C + z * sin;
+        m11 = cos + y * y * C;
+        m21 = yz * C - x * sin;
+        m31 = 0.0;
+        m02 = xz * C - y * sin;
+        m12 = yz * C + x * sin;
+        m22 = cos + z * z * C;
+        m32 = 0.0;
+        m03 = 0.0;
+        m13 = 0.0;
+        m23 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the X axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4d rotationX(double ang) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        m00 = 1.0;
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = cos;
+        m12 = sin;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = -sin;
+        m22 = cos;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the Y axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4d rotationY(double ang) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        m00 = cos;
+        m01 = 0.0;
+        m02 = -sin;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = 1.0;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = sin;
+        m21 = 0.0;
+        m22 = cos;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the Z axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4d rotationZ(double ang) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        m00 = cos;
+        m01 = sin;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = -sin;
+        m11 = cos;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = 1.0;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleX</code> radians about the X axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4d rotationXYZ(double angleX, double angleY, double angleZ) {
+        double cosX =  Math.cos(angleX);
+        double sinX =  Math.sin(angleX);
+        double cosY =  Math.cos(angleY);
+        double sinY =  Math.sin(angleY);
+        double cosZ =  Math.cos(angleZ);
+        double sinZ =  Math.sin(angleZ);
+        double m_sinX = -sinX;
+        double m_sinY = -sinY;
+        double m_sinZ = -sinZ;
+
+        // rotateX
+        double nm11 = cosX;
+        double nm12 = sinX;
+        double nm21 = m_sinX;
+        double nm22 = cosX;
+        // rotateY
+        double nm00 = cosY;
+        double nm01 = nm21 * m_sinY;
+        double nm02 = nm22 * m_sinY;
+        m20 = sinY;
+        m21 = nm21 * cosY;
+        m22 = nm22 * cosY;
+        m23 = 0.0;
+        // rotateZ
+        m00 = nm00 * cosZ;
+        m01 = nm01 * cosZ + nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m03 = 0.0;
+        m10 = nm00 * m_sinZ;
+        m11 = nm01 * m_sinZ + nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        m13 = 0.0;
+        // set last column to identity
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix4d rotationZYX(double angleZ, double angleY, double angleX) {
+        double cosZ =  Math.cos(angleZ);
+        double sinZ =  Math.sin(angleZ);
+        double cosY =  Math.cos(angleY);
+        double sinY =  Math.sin(angleY);
+        double cosX =  Math.cos(angleX);
+        double sinX =  Math.sin(angleX);
+        double m_sinZ = -sinZ;
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+
+        // rotateZ
+        double nm00 = cosZ;
+        double nm01 = sinZ;
+        double nm10 = m_sinZ;
+        double nm11 = cosZ;
+        // rotateY
+        double nm20 = nm00 * sinY;
+        double nm21 = nm01 * sinY;
+        double nm22 = cosY;
+        m00 = nm00 * cosY;
+        m01 = nm01 * cosY;
+        m02 = m_sinY;
+        m03 = 0.0;
+        // rotateX
+        m10 = nm10 * cosX + nm20 * sinX;
+        m11 = nm11 * cosX + nm21 * sinX;
+        m12 = nm22 * sinX;
+        m13 = 0.0;
+        m20 = nm10 * m_sinX + nm20 * cosX;
+        m21 = nm11 * m_sinX + nm21 * cosX;
+        m22 = nm22 * cosX;
+        m23 = 0.0;
+        // set last column to identity
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleY</code> radians about the Y axis, followed by a rotation
+     * of <code>angleX</code> radians about the X axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4d rotationYXZ(double angleY, double angleX, double angleZ) {
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+        double m_sinZ = -sinZ;
+
+        // rotateY
+        double nm00 = cosY;
+        double nm02 = m_sinY;
+        double nm20 = sinY;
+        double nm22 = cosY;
+        // rotateX
+        double nm10 = nm20 * sinX;
+        double nm11 = cosX;
+        double nm12 = nm22 * sinX;
+        m20 = nm20 * cosX;
+        m21 = m_sinX;
+        m22 = nm22 * cosX;
+        m23 = 0.0;
+        // rotateZ
+        m00 = nm00 * cosZ + nm10 * sinZ;
+        m01 = nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m03 = 0.0;
+        m10 = nm00 * m_sinZ + nm10 * cosZ;
+        m11 = nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        m13 = 0.0;
+        // set last column to identity
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set only the upper left 3x3 submatrix of this matrix to a rotation of <code>angleX</code> radians about the X axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4d setRotationXYZ(double angleX, double angleY, double angleZ) {
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double m_sinX = -sinX;
+        double m_sinY = -sinY;
+        double m_sinZ = -sinZ;
+
+        // rotateX
+        double nm11 = cosX;
+        double nm12 = sinX;
+        double nm21 = m_sinX;
+        double nm22 = cosX;
+        // rotateY
+        double nm00 = cosY;
+        double nm01 = nm21 * m_sinY;
+        double nm02 = nm22 * m_sinY;
+        m20 = sinY;
+        m21 = nm21 * cosY;
+        m22 = nm22 * cosY;
+        // rotateZ
+        m00 = nm00 * cosZ;
+        m01 = nm01 * cosZ + nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m10 = nm00 * m_sinZ;
+        m11 = nm01 * m_sinZ + nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return this;
+    }
+
+    /**
+     * Set only the upper left 3x3 submatrix of this matrix to a rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleX</code> radians about the X axis.
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix4d setRotationZYX(double angleZ, double angleY, double angleX) {
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double m_sinZ = -sinZ;
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+
+        // rotateZ
+        double nm00 = cosZ;
+        double nm01 = sinZ;
+        double nm10 = m_sinZ;
+        double nm11 = cosZ;
+        // rotateY
+        double nm20 = nm00 * sinY;
+        double nm21 = nm01 * sinY;
+        double nm22 = cosY;
+        m00 = nm00 * cosY;
+        m01 = nm01 * cosY;
+        m02 = m_sinY;
+        // rotateX
+        m10 = nm10 * cosX + nm20 * sinX;
+        m11 = nm11 * cosX + nm21 * sinX;
+        m12 = nm22 * sinX;
+        m20 = nm10 * m_sinX + nm20 * cosX;
+        m21 = nm11 * m_sinX + nm21 * cosX;
+        m22 = nm22 * cosX;
+        return this;
+    }
+
+    /**
+     * Set only the upper left 3x3 submatrix of this matrix to a rotation of <code>angleY</code> radians about the Y axis, followed by a rotation
+     * of <code>angleX</code> radians about the X axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4d setRotationYXZ(double angleY, double angleX, double angleZ) {
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+        double m_sinZ = -sinZ;
+
+        // rotateY
+        double nm00 = cosY;
+        double nm02 = m_sinY;
+        double nm20 = sinY;
+        double nm22 = cosY;
+        // rotateX
+        double nm10 = nm20 * sinX;
+        double nm11 = cosX;
+        double nm12 = nm22 * sinX;
+        m20 = nm20 * cosX;
+        m21 = m_sinX;
+        m22 = nm22 * cosX;
+        // rotateZ
+        m00 = nm00 * cosZ + nm10 * sinZ;
+        m01 = nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m10 = nm00 * m_sinZ + nm10 * cosZ;
+        m11 = nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the axis to rotate about
+     * @return this
+     */
+    public Matrix4d rotation(double angle, Vector3d axis) {
+        return rotation(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the axis to rotate about
+     * @return this
+     */
+    public Matrix4d rotation(double angle, Vector3f axis) {
+        return rotation(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix and store the result in that vector.
+     * 
+     * @see Vector4d#mul(Matrix4d)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector4d transform(Vector4d v) {
+        return v.mul(this);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix and store the result in <code>dest</code>.
+     * 
+     * @see Vector4d#mul(Matrix4d, Vector4d)
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will contain the result
+     * @return dest
+     */
+    public Vector4d transform(Vector4d v, Vector4d dest) {
+        return v.mul(this, dest);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix, perform perspective divide and store the result in that vector.
+     * 
+     * @see Vector4d#mulProject(Matrix4d)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector4d transformProject(Vector4d v) {
+        return v.mulProject(this);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix, perform perspective divide and store the result in <code>dest</code>.
+     * 
+     * @see Vector4d#mulProject(Matrix4d, Vector4d)
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will contain the result
+     * @return dest
+     */
+    public Vector4d transformProject(Vector4d v, Vector4d dest) {
+        return v.mulProject(this, dest);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix, perform perspective divide and store the result in that vector.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @see Vector3d#mulProject(Matrix4d)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector3d transformProject(Vector3d v) {
+        return v.mulProject(this);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix, perform perspective divide and store the result in <code>dest</code>.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @see Vector3d#mulProject(Matrix4d, Vector3d)
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will contain the result
+     * @return dest
+     */
+    public Vector3d transformProject(Vector3d v, Vector3d dest) {
+        return v.mulProject(this, dest);
+    }
+
+    /**
+     * Transform/multiply the given 3D-vector, as if it was a 4D-vector with w=1, by
+     * this matrix and store the result in that vector.
+     * <p>
+     * The given 3D-vector is treated as a 4D-vector with its w-component being 1.0, so it
+     * will represent a point/location in 3D-space rather than a direction. This method is therefore
+     * not suited for perspective projection transformations as it will not save the
+     * <tt>w</tt> component of the transformed vector.
+     * For perspective projection use {@link #transform(Vector4d)}.
+     * <p>
+     * In order to store the result in another vector, use {@link #transformPoint(Vector3d, Vector3d)}.
+     * 
+     * @see #transformPoint(Vector3d, Vector3d)
+     * @see #transform(Vector4d)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector3d transformPoint(Vector3d v) {
+        v.set(m00 * v.x + m10 * v.y + m20 * v.z + m30,
+              m01 * v.x + m11 * v.y + m21 * v.z + m31,
+              m02 * v.x + m12 * v.y + m22 * v.z + m32);
+        return v;
+    }
+
+    /**
+     * Transform/multiply the given 3D-vector, as if it was a 4D-vector with w=1, by
+     * this matrix and store the result in <code>dest</code>.
+     * <p>
+     * The given 3D-vector is treated as a 4D-vector with its w-component being 1.0, so it
+     * will represent a point/location in 3D-space rather than a direction. This method is therefore
+     * not suited for perspective projection transformations as it will not save the
+     * <tt>w</tt> component of the transformed vector.
+     * For perspective projection use {@link #transform(Vector4d, Vector4d)}.
+     * <p>
+     * In order to store the result in the same vector, use {@link #transformPoint(Vector3d)}.
+     * 
+     * @see #transformPoint(Vector3d)
+     * @see #transform(Vector4d, Vector4d)
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d transformPoint(Vector3d v, Vector3d dest) {
+        dest.set(m00 * v.x + m10 * v.y + m20 * v.z + m30,
+                 m01 * v.x + m11 * v.y + m21 * v.z + m31,
+                 m02 * v.x + m12 * v.y + m22 * v.z + m32);
+        return dest;
+    }
+
+    /**
+     * Transform/multiply the given 3D-vector, as if it was a 4D-vector with w=0, by
+     * this matrix and store the result in that vector.
+     * <p>
+     * The given 3D-vector is treated as a 4D-vector with its w-component being <tt>0.0</tt>, so it
+     * will represent a direction in 3D-space rather than a point. This method will therefore
+     * not take the translation part of the matrix into account.
+     * <p>
+     * In order to store the result in another vector, use {@link #transformDirection(Vector3d, Vector3d)}.
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector3d transformDirection(Vector3d v) {
+        v.set(m00 * v.x + m10 * v.y + m20 * v.z,
+              m01 * v.x + m11 * v.y + m21 * v.z,
+              m02 * v.x + m12 * v.y + m22 * v.z);
+        return v;
+    }
+
+    /**
+     * Transform/multiply the given 3D-vector, as if it was a 4D-vector with w=0, by
+     * this matrix and store the result in <code>dest</code>.
+     * <p>
+     * The given 3D-vector is treated as a 4D-vector with its w-component being <tt>0.0</tt>, so it
+     * will represent a direction in 3D-space rather than a point. This method will therefore
+     * not take the translation part of the matrix into account.
+     * <p>
+     * In order to store the result in the same vector, use {@link #transformDirection(Vector3d)}.
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d transformDirection(Vector3d v, Vector3d dest) {
+        dest.set(m00 * v.x + m10 * v.y + m20 * v.z,
+                 m01 * v.x + m11 * v.y + m21 * v.z,
+                 m02 * v.x + m12 * v.y + m22 * v.z);
+        return dest;
+    }
+
+    /**
+     * Set the upper 3x3 matrix of this {@link Matrix4d} to the given {@link Matrix3d} and the rest to the identity.
+     * 
+     * @param mat
+     *          the 3x3 matrix
+     * @return this
+     */
+    public Matrix4d set3x3(Matrix3d mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m03 = 0.0;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m13 = 0.0;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Apply scaling to the this matrix by scaling the base axes by the given <tt>xyz.x</tt>,
+     * <tt>xyz.y</tt> and <tt>xyz.z</tt> factors, respectively and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param xyz
+     *            the factors of the x, y and z component, respectively
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d scale(Vector3d xyz, Matrix4d dest) {
+        return scale(xyz.x, xyz.y, xyz.z, dest);
+    }
+
+    /**
+     * Apply scaling to this matrix by scaling the base axes by the given <tt>xyz.x</tt>,
+     * <tt>xyz.y</tt> and <tt>xyz.z</tt> factors, respectively.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * scaling will be applied first!
+     * 
+     * @param xyz
+     *            the factors of the x, y and z component, respectively
+     * @return this
+     */
+    public Matrix4d scale(Vector3d xyz) {
+        return scale(xyz.x, xyz.y, xyz.z, this);
+    }
+
+    /**
+     * Apply scaling to the this matrix by scaling the base axes by the given x,
+     * y and z factors and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param x
+     *            the factor of the x component
+     * @param y
+     *            the factor of the y component
+     * @param z
+     *            the factor of the z component
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d scale(double x, double y, double z, Matrix4d dest) {
+        // scale matrix elements:
+        // m00 = x, m11 = y, m22 = z
+        // m33 = 1
+        // all others = 0
+        dest.m00 = m00 * x;
+        dest.m01 = m01 * x;
+        dest.m02 = m02 * x;
+        dest.m03 = m03 * x;
+        dest.m10 = m10 * y;
+        dest.m11 = m11 * y;
+        dest.m12 = m12 * y;
+        dest.m13 = m13 * y;
+        dest.m20 = m20 * z;
+        dest.m21 = m21 * z;
+        dest.m22 = m22 * z;
+        dest.m23 = m23 * z;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply scaling to the this matrix by scaling the base axes by the given x,
+     * y and z factors.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param x
+     *            the factor of the x component
+     * @param y
+     *            the factor of the y component
+     * @param z
+     *            the factor of the z component
+     * @return this
+     */
+    public Matrix4d scale(double x, double y, double z) {
+        return scale(x, y, z, this);
+    }
+
+    /**
+     * Apply scaling to this matrix by uniformly scaling all base axes by the given xyz factor
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @see #scale(double, double, double, Matrix4d)
+     * 
+     * @param xyz
+     *            the factor for all components
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d scale(double xyz, Matrix4d dest) {
+        return scale(xyz, xyz, xyz, dest);
+    }
+
+    /**
+     * Apply scaling to this matrix by uniformly scaling all base axes by the given xyz factor.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @see #scale(double, double, double)
+     * 
+     * @param xyz
+     *            the factor for all components
+     * @return this
+     */
+    public Matrix4d scale(double xyz) {
+        return scale(xyz, xyz, xyz);
+    }
+
+    /**
+     * Apply rotation to this matrix by rotating the given amount of radians
+     * about the given axis specified as x, y and z components and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * 
+     * @param ang
+     *            the angle is in radians
+     * @param x
+     *            the x component of the axis
+     * @param y
+     *            the y component of the axis
+     * @param z
+     *            the z component of the axis
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotate(double ang, double x, double y, double z, Matrix4d dest) {
+        double s = Math.sin(ang);
+        double c = Math.cos(ang);
+        double C = 1.0 - c;
+
+        // rotation matrix elements:
+        // m30, m31, m32, m03, m13, m23 = 0
+        // m33 = 1
+        double xx = x * x, xy = x * y, xz = x * z;
+        double yy = y * y, yz = y * z;
+        double zz = z * z;
+        double rm00 = xx * C + c;
+        double rm01 = xy * C + z * s;
+        double rm02 = xz * C - y * s;
+        double rm10 = xy * C - z * s;
+        double rm11 = yy * C + c;
+        double rm12 = yz * C + x * s;
+        double rm20 = xz * C + y * s;
+        double rm21 = yz * C - x * s;
+        double rm22 = zz * C + c;
+
+        // add temporaries for dependent values
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        double nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        // set non-dependent values directly
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation to this matrix by rotating the given amount of radians
+     * about the given axis specified as x, y and z components.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>
+     * , the rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation matrix without post-multiplying the rotation
+     * transformation, use {@link #rotation(double, double, double, double) rotation()}.
+     * 
+     * @see #rotation(double, double, double, double)
+     *  
+     * @param ang
+     *            the angle is in radians
+     * @param x
+     *            the x component of the axis
+     * @param y
+     *            the y component of the axis
+     * @param z
+     *            the z component of the axis
+     * @return this
+     */
+    public Matrix4d rotate(double ang, double x, double y, double z) {
+        return rotate(ang, x, y, z, this);
+    }
+
+    /**
+     * Apply a translation to this matrix by translating by the given number of
+     * units in x, y and z.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>T</code> the translation
+     * matrix, then the new current matrix will be <code>M * T</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>M * T * v</code>, the translation will be applied first!
+     * <p>
+     * In order to set the matrix to a translation transformation without post-multiplying
+     * it, use {@link #translation(double, double, double)}.
+     * 
+     * @see #translation(double, double, double)
+     * 
+     * @param x
+     *            the offset in x
+     * @param y
+     *            the offset in y
+     * @param z
+     *            the offset in z
+     * @return this
+     */
+    public Matrix4d translate(double x, double y, double z) {
+        // translation matrix elements:
+        // m00, m11, m22, m33 = 1
+        // m30 = x, m31 = y, m32 = z
+        // all others = 0
+        m30 = m00 * x + m10 * y + m20 * z + m30;
+        m31 = m01 * x + m11 * y + m21 * z + m31;
+        m32 = m02 * x + m12 * y + m22 * z + m32;
+        m33 = m03 * x + m13 * y + m23 * z + m33;
+        return this;
+    }
+
+    /**
+     * Apply a translation to this matrix by translating by the given number of
+     * units in x, y and z.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>T</code> the translation
+     * matrix, then the new matrix will be <code>M * T</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>M * T * v</code>, the translation will be applied first!
+     * <p>
+     * In order to set the matrix to a translation transformation without post-multiplying
+     * it, use {@link #translation(Vector3f)}.
+     * 
+     * @see #translation(Vector3d)
+     * 
+     * @param point
+     *          the point by which to translate
+     * @return this
+     */
+    public Matrix4d translate(Vector3d point) {
+        return translate(point.x, point.y, point.z);
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeDouble(m00);
+        out.writeDouble(m01);
+        out.writeDouble(m02);
+        out.writeDouble(m03);
+        out.writeDouble(m10);
+        out.writeDouble(m11);
+        out.writeDouble(m12);
+        out.writeDouble(m13);
+        out.writeDouble(m20);
+        out.writeDouble(m21);
+        out.writeDouble(m22);
+        out.writeDouble(m23);
+        out.writeDouble(m30);
+        out.writeDouble(m31);
+        out.writeDouble(m32);
+        out.writeDouble(m33);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        m00 = in.readDouble();
+        m01 = in.readDouble();
+        m02 = in.readDouble();
+        m03 = in.readDouble();
+        m10 = in.readDouble();
+        m11 = in.readDouble();
+        m12 = in.readDouble();
+        m13 = in.readDouble();
+        m20 = in.readDouble();
+        m21 = in.readDouble();
+        m22 = in.readDouble();
+        m23 = in.readDouble();
+        m30 = in.readDouble();
+        m31 = in.readDouble();
+        m32 = in.readDouble();
+        m33 = in.readDouble();
+    }
+    
+
+    /**
+     * Apply rotation about the X axis to this matrix by rotating the given amount of radians 
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotateX(double ang, Matrix4d dest) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        double rm11 = cos;
+        double rm12 = sin;
+        double rm21 = -sin;
+        double rm22 = cos;
+
+        // add temporaries for dependent values
+        double nm10 = m10 * rm11 + m20 * rm12;
+        double nm11 = m11 * rm11 + m21 * rm12;
+        double nm12 = m12 * rm11 + m22 * rm12;
+        double nm13 = m13 * rm11 + m23 * rm12;
+        // set non-dependent values directly
+        dest.m20 = m10 * rm21 + m20 * rm22;
+        dest.m21 = m11 * rm21 + m21 * rm22;
+        dest.m22 = m12 * rm21 + m22 * rm22;
+        dest.m23 = m13 * rm21 + m23 * rm22;
+        // set other values
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m00 = m00;
+        dest.m01 = m01;
+        dest.m02 = m02;
+        dest.m03 = m03;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the X axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4d rotateX(double ang) {
+        return rotateX(ang, this);
+    }
+
+    /**
+     * Apply rotation about the Y axis to this matrix by rotating the given amount of radians 
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotateY(double ang, Matrix4d dest) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        double rm00 = cos;
+        double rm02 = -sin;
+        double rm20 = sin;
+        double rm22 = cos;
+
+        // add temporaries for dependent values
+        double nm00 = m00 * rm00 + m20 * rm02;
+        double nm01 = m01 * rm00 + m21 * rm02;
+        double nm02 = m02 * rm00 + m22 * rm02;
+        double nm03 = m03 * rm00 + m23 * rm02;
+        // set non-dependent values directly
+        dest.m20 = m00 * rm20 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m23 * rm22;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = m10;
+        dest.m11 = m11;
+        dest.m12 = m12;
+        dest.m13 = m13;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the Y axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4d rotateY(double ang) {
+        return rotateY(ang, this);
+    }
+
+    /**
+     * Apply rotation about the Z axis to this matrix by rotating the given amount of radians 
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotateZ(double ang, Matrix4d dest) {
+        double cos = Math.cos(ang);
+        double sin = Math.sin(ang);
+        double rm00 = cos;
+        double rm01 = sin;
+        double rm10 = -sin;
+        double rm11 = cos;
+
+        // add temporaries for dependent values
+        double nm00 = m00 * rm00 + m10 * rm01;
+        double nm01 = m01 * rm00 + m11 * rm01;
+        double nm02 = m02 * rm00 + m12 * rm01;
+        double nm03 = m03 * rm00 + m13 * rm01;
+        // set non-dependent values directly
+        dest.m10 = m00 * rm10 + m10 * rm11;
+        dest.m11 = m01 * rm10 + m11 * rm11;
+        dest.m12 = m02 * rm10 + m12 * rm11;
+        dest.m13 = m03 * rm10 + m13 * rm11;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m20 = m20;
+        dest.m21 = m21;
+        dest.m22 = m22;
+        dest.m23 = m23;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the Z axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4d rotateZ(double ang) {
+        return rotateZ(ang, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4d rotateXYZ(double angleX, double angleY, double angleZ) {
+        return rotateXYZ(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX, dest).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotateXYZ(double angleX, double angleY, double angleZ, Matrix4d dest) {
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double m_sinX = -sinX;
+        double m_sinY = -sinY;
+        double m_sinZ = -sinZ;
+
+        // rotateX
+        double nm10 = m10 * cosX + m20 * sinX;
+        double nm11 = m11 * cosX + m21 * sinX;
+        double nm12 = m12 * cosX + m22 * sinX;
+        double nm13 = m13 * cosX + m23 * sinX;
+        double nm20 = m10 * m_sinX + m20 * cosX;
+        double nm21 = m11 * m_sinX + m21 * cosX;
+        double nm22 = m12 * m_sinX + m22 * cosX;
+        double nm23 = m13 * m_sinX + m23 * cosX;
+        // rotateY
+        double nm00 = m00 * cosY + nm20 * m_sinY;
+        double nm01 = m01 * cosY + nm21 * m_sinY;
+        double nm02 = m02 * cosY + nm22 * m_sinY;
+        double nm03 = m03 * cosY + nm23 * m_sinY;
+        dest.m20 = m00 * sinY + nm20 * cosY;
+        dest.m21 = m01 * sinY + nm21 * cosY;
+        dest.m22 = m02 * sinY + nm22 * cosY;
+        dest.m23 = m03 * sinY + nm23 * cosY;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m03 = nm03 * cosZ + nm13 * sinZ;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        dest.m13 = nm03 * m_sinZ + nm13 * cosZ;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4d rotateXYZ4x3(double angleX, double angleY, double angleZ) {
+        return rotateXYZ4x3(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotateXYZ4x3(double angleX, double angleY, double angleZ, Matrix4d dest) {
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double m_sinX = -sinX;
+        double m_sinY = -sinY;
+        double m_sinZ = -sinZ;
+
+        // rotateX
+        double nm10 = m10 * cosX + m20 * sinX;
+        double nm11 = m11 * cosX + m21 * sinX;
+        double nm12 = m12 * cosX + m22 * sinX;
+        double nm20 = m10 * m_sinX + m20 * cosX;
+        double nm21 = m11 * m_sinX + m21 * cosX;
+        double nm22 = m12 * m_sinX + m22 * cosX;
+        // rotateY
+        double nm00 = m00 * cosY + nm20 * m_sinY;
+        double nm01 = m01 * cosY + nm21 * m_sinY;
+        double nm02 = m02 * cosY + nm22 * m_sinY;
+        dest.m20 = m00 * sinY + nm20 * cosY;
+        dest.m21 = m01 * sinY + nm21 * cosY;
+        dest.m22 = m02 * sinY + nm22 * cosY;
+        dest.m23 = 0.0;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m03 = 0.0;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        dest.m13 = 0.0;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix4d rotateZYX(double angleZ, double angleY, double angleX) {
+        return rotateZYX(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ, dest).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotateZYX(double angleZ, double angleY, double angleX, Matrix4d dest) {
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double m_sinZ = -sinZ;
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+
+        // rotateZ
+        double nm00 = m00 * cosZ + m10 * sinZ;
+        double nm01 = m01 * cosZ + m11 * sinZ;
+        double nm02 = m02 * cosZ + m12 * sinZ;
+        double nm03 = m03 * cosZ + m13 * sinZ;
+        double nm10 = m00 * m_sinZ + m10 * cosZ;
+        double nm11 = m01 * m_sinZ + m11 * cosZ;
+        double nm12 = m02 * m_sinZ + m12 * cosZ;
+        double nm13 = m03 * m_sinZ + m13 * cosZ;
+        // rotateY
+        double nm20 = nm00 * sinY + m20 * cosY;
+        double nm21 = nm01 * sinY + m21 * cosY;
+        double nm22 = nm02 * sinY + m22 * cosY;
+        double nm23 = nm03 * sinY + m23 * cosY;
+        dest.m00 = nm00 * cosY + m20 * m_sinY;
+        dest.m01 = nm01 * cosY + m21 * m_sinY;
+        dest.m02 = nm02 * cosY + m22 * m_sinY;
+        dest.m03 = nm03 * cosY + m23 * m_sinY;
+        // rotateX
+        dest.m10 = nm10 * cosX + nm20 * sinX;
+        dest.m11 = nm11 * cosX + nm21 * sinX;
+        dest.m12 = nm12 * cosX + nm22 * sinX;
+        dest.m13 = nm13 * cosX + nm23 * sinX;
+        dest.m20 = nm10 * m_sinX + nm20 * cosX;
+        dest.m21 = nm11 * m_sinX + nm21 * cosX;
+        dest.m22 = nm12 * m_sinX + nm22 * cosX;
+        dest.m23 = nm13 * m_sinX + nm23 * cosX;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix4d rotateZYX4x3(double angleZ, double angleY, double angleX) {
+        return rotateZYX4x3(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis and store the result in <code>dest</code>.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotateZYX4x3(double angleZ, double angleY, double angleX, Matrix4d dest) {
+        double cosZ = Math.cos(angleZ);
+        double sinZ = Math.sin(angleZ);
+        double cosY = Math.cos(angleY);
+        double sinY = Math.sin(angleY);
+        double cosX = Math.cos(angleX);
+        double sinX = Math.sin(angleX);
+        double m_sinZ = -sinZ;
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+
+        // rotateZ
+        double nm00 = m00 * cosZ + m10 * sinZ;
+        double nm01 = m01 * cosZ + m11 * sinZ;
+        double nm02 = m02 * cosZ + m12 * sinZ;
+        double nm10 = m00 * m_sinZ + m10 * cosZ;
+        double nm11 = m01 * m_sinZ + m11 * cosZ;
+        double nm12 = m02 * m_sinZ + m12 * cosZ;
+        // rotateY
+        double nm20 = nm00 * sinY + m20 * cosY;
+        double nm21 = nm01 * sinY + m21 * cosY;
+        double nm22 = nm02 * sinY + m22 * cosY;
+        dest.m00 = nm00 * cosY + m20 * m_sinY;
+        dest.m01 = nm01 * cosY + m21 * m_sinY;
+        dest.m02 = nm02 * cosY + m22 * m_sinY;
+        dest.m03 = 0.0;
+        // rotateX
+        dest.m10 = nm10 * cosX + nm20 * sinX;
+        dest.m11 = nm11 * cosX + nm21 * sinX;
+        dest.m12 = nm12 * cosX + nm22 * sinX;
+        dest.m13 = 0.0;
+        dest.m20 = nm10 * m_sinX + nm20 * cosX;
+        dest.m21 = nm11 * m_sinX + nm21 * cosX;
+        dest.m22 = nm12 * m_sinX + nm22 * cosX;
+        dest.m23 = 0.0;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleY</code> radians about the Y axis, followed by a rotation of <code>angleX</code> radians about the X axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4d rotateYXZ(double angleY, double angleX, double angleZ) {
+        return rotateYXZ(angleY, angleX, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleY</code> radians about the Y axis, followed by a rotation of <code>angleX</code> radians about the X axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateY(angleY, dest).rotateX(angleX).rotateZ(angleZ)</tt>
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotateYXZ(double angleY, double angleX, double angleZ, Matrix4d dest) {
+        double cosY =  Math.cos(angleY);
+        double sinY =  Math.sin(angleY);
+        double cosX =  Math.cos(angleX);
+        double sinX =  Math.sin(angleX);
+        double cosZ =  Math.cos(angleZ);
+        double sinZ =  Math.sin(angleZ);
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+        double m_sinZ = -sinZ;
+
+        // rotateY
+        double nm20 = m00 * sinY + m20 * cosY;
+        double nm21 = m01 * sinY + m21 * cosY;
+        double nm22 = m02 * sinY + m22 * cosY;
+        double nm23 = m03 * sinY + m23 * cosY;
+        double nm00 = m00 * cosY + m20 * m_sinY;
+        double nm01 = m01 * cosY + m21 * m_sinY;
+        double nm02 = m02 * cosY + m22 * m_sinY;
+        double nm03 = m03 * cosY + m23 * m_sinY;
+        // rotateX
+        double nm10 = m10 * cosX + nm20 * sinX;
+        double nm11 = m11 * cosX + nm21 * sinX;
+        double nm12 = m12 * cosX + nm22 * sinX;
+        double nm13 = m13 * cosX + nm23 * sinX;
+        dest.m20 = m10 * m_sinX + nm20 * cosX;
+        dest.m21 = m11 * m_sinX + nm21 * cosX;
+        dest.m22 = m12 * m_sinX + nm22 * cosX;
+        dest.m23 = m13 * m_sinX + nm23 * cosX;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m03 = nm03 * cosZ + nm13 * sinZ;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        dest.m13 = nm03 * m_sinZ + nm13 * cosZ;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleY</code> radians about the Y axis, followed by a rotation of <code>angleX</code> radians about the X axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4d rotateYXZ4x3(double angleY, double angleX, double angleZ) {
+        return rotateYXZ4x3(angleY, angleX, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleY</code> radians about the Y axis, followed by a rotation of <code>angleX</code> radians about the X axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d rotateYXZ4x3(double angleY, double angleX, double angleZ, Matrix4d dest) {
+        double cosY =  Math.cos(angleY);
+        double sinY =  Math.sin(angleY);
+        double cosX =  Math.cos(angleX);
+        double sinX =  Math.sin(angleX);
+        double cosZ =  Math.cos(angleZ);
+        double sinZ =  Math.sin(angleZ);
+        double m_sinY = -sinY;
+        double m_sinX = -sinX;
+        double m_sinZ = -sinZ;
+
+        // rotateY
+        double nm20 = m00 * sinY + m20 * cosY;
+        double nm21 = m01 * sinY + m21 * cosY;
+        double nm22 = m02 * sinY + m22 * cosY;
+        double nm00 = m00 * cosY + m20 * m_sinY;
+        double nm01 = m01 * cosY + m21 * m_sinY;
+        double nm02 = m02 * cosY + m22 * m_sinY;
+        // rotateX
+        double nm10 = m10 * cosX + nm20 * sinX;
+        double nm11 = m11 * cosX + nm21 * sinX;
+        double nm12 = m12 * cosX + nm22 * sinX;
+        dest.m20 = m10 * m_sinX + nm20 * cosX;
+        dest.m21 = m11 * m_sinX + nm21 * cosX;
+        dest.m22 = m12 * m_sinX + nm22 * cosX;
+        dest.m23 = 0.0;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m03 = 0.0;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        dest.m13 = 0.0;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation using the given {@link AxisAngle4f}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(AxisAngle4f) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     *
+     * @see #rotate(AxisAngle4f)
+     * 
+     * @param angleAxis
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @return this
+     */
+    public Matrix4d rotation(AxisAngle4f angleAxis) {
+        return rotation(angleAxis.angle, angleAxis.x, angleAxis.y, angleAxis.z);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation using the given {@link AxisAngle4d}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(AxisAngle4d) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     *
+     * @see #rotate(AxisAngle4d)
+     * 
+     * @param angleAxis
+     *          the {@link AxisAngle4d} (needs to be {@link AxisAngle4d#normalize() normalized})
+     * @return this
+     */
+    public Matrix4d rotation(AxisAngle4d angleAxis) {
+        return rotation(angleAxis.angle, angleAxis.x, angleAxis.y, angleAxis.z);
+    }
+
+    /**
+     * Set this matrix to the rotation transformation of the given {@link Quaterniond}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(Quaterniond) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(Quaterniond)
+     * 
+     * @param quat
+     *          the {@link Quaterniond}
+     * @return this
+     */
+    public Matrix4d rotation(Quaterniond quat) {
+        double dqx = 2.0 * quat.x;
+        double dqy = 2.0 * quat.y;
+        double dqz = 2.0 * quat.z;
+        double q00 = dqx * quat.x;
+        double q11 = dqy * quat.y;
+        double q22 = dqz * quat.z;
+        double q01 = dqx * quat.y;
+        double q02 = dqx * quat.z;
+        double q03 = dqx * quat.w;
+        double q12 = dqy * quat.z;
+        double q13 = dqy * quat.w;
+        double q23 = dqz * quat.w;
+
+        m00 = 1.0 - q11 - q22;
+        m01 = q01 + q23;
+        m02 = q02 - q13;
+        m03 = 0.0;
+        m10 = q01 - q23;
+        m11 = 1.0 - q22 - q00;
+        m12 = q12 + q03;
+        m13 = 0.0;
+        m20 = q02 + q13;
+        m21 = q12 - q03;
+        m22 = 1.0 - q11 - q00;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+
+        return this;
+    }
+
+    /**
+     * Set this matrix to the rotation transformation of the given {@link Quaternionf}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(Quaternionf) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix4d rotation(Quaternionf quat) {
+        double dqx = 2.0 * quat.x;
+        double dqy = 2.0 * quat.y;
+        double dqz = 2.0 * quat.z;
+        double q00 = dqx * quat.x;
+        double q11 = dqy * quat.y;
+        double q22 = dqz * quat.z;
+        double q01 = dqx * quat.y;
+        double q02 = dqx * quat.z;
+        double q03 = dqx * quat.w;
+        double q12 = dqy * quat.z;
+        double q13 = dqy * quat.w;
+        double q23 = dqz * quat.w;
+
+        m00 = 1.0 - q11 - q22;
+        m01 = q01 + q23;
+        m02 = q02 - q13;
+        m03 = 0.0;
+        m10 = q01 - q23;
+        m11 = 1.0 - q22 - q00;
+        m12 = q12 + q03;
+        m13 = 0.0;
+        m20 = q02 + q13;
+        m21 = q12 - q03;
+        m22 = 1.0 - q11 - q00;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+
+        return this;
+    }
+
+    /**
+     * Set <code>this</code> matrix to <tt>T * R * S</tt>, where <tt>T</tt> is a translation by the given <tt>(tx, ty, tz)</tt>,
+     * <tt>R</tt> is a rotation transformation specified by the quaternion <tt>(qx, qy, qz, qw)</tt>, and <tt>S</tt> is a scaling transformation
+     * which scales the three axes x, y and z by <tt>(sx, sy, sz)</tt>.
+     * <p>
+     * When transforming a vector by the resulting matrix the scaling transformation will be applied first, then the rotation and
+     * at last the translation.
+     * <p>
+     * This method is equivalent to calling: <tt>translation(tx, ty, tz).rotate(quat).scale(sx, sy, sz)</tt>
+     * 
+     * @see #translation(double, double, double)
+     * @see #rotate(Quaterniond)
+     * @see #scale(double, double, double)
+     * 
+     * @param tx
+     *          the number of units by which to translate the x-component
+     * @param ty
+     *          the number of units by which to translate the y-component
+     * @param tz
+     *          the number of units by which to translate the z-component
+     * @param qx
+     *          the x-coordinate of the vector part of the quaternion
+     * @param qy
+     *          the y-coordinate of the vector part of the quaternion
+     * @param qz
+     *          the z-coordinate of the vector part of the quaternion
+     * @param qw
+     *          the scalar part of the quaternion
+     * @param sx
+     *          the scaling factor for the x-axis
+     * @param sy
+     *          the scaling factor for the y-axis
+     * @param sz
+     *          the scaling factor for the z-axis
+     * @return this
+     */
+    public Matrix4d translationRotateScale(double tx, double ty, double tz, 
+                                           double qx, double qy, double qz, double qw, 
+                                           double sx, double sy, double sz) {
+        double dqx = 2.0 * qx, dqy = 2.0 * qy, dqz = 2.0 * qz;
+        double q00 = dqx * qx;
+        double q11 = dqy * qy;
+        double q22 = dqz * qz;
+        double q01 = dqx * qy;
+        double q02 = dqx * qz;
+        double q03 = dqx * qw;
+        double q12 = dqy * qz;
+        double q13 = dqy * qw;
+        double q23 = dqz * qw;
+        m00 = sx - (q11 + q22) * sx;
+        m01 = (q01 + q23) * sx;
+        m02 = (q02 - q13) * sx;
+        m03 = 0.0;
+        m10 = (q01 - q23) * sy;
+        m11 = sy - (q22 + q00) * sy;
+        m12 = (q12 + q03) * sy;
+        m13 = 0.0;
+        m20 = (q02 + q13) * sz;
+        m21 = (q12 - q03) * sz;
+        m22 = sz - (q11 + q00) * sz;
+        m23 = 0.0;
+        m30 = tx;
+        m31 = ty;
+        m32 = tz;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set <code>this</code> matrix to <tt>T * R * S</tt>, where <tt>T</tt> is the given <code>translation</code>,
+     * <tt>R</tt> is a rotation transformation specified by the given quaternion, and <tt>S</tt> is a scaling transformation
+     * which scales the axes by <code>scale</code>.
+     * <p>
+     * When transforming a vector by the resulting matrix the scaling transformation will be applied first, then the rotation and
+     * at last the translation.
+     * <p>
+     * This method is equivalent to calling: <tt>translation(translation).rotate(quat).scale(scale)</tt>
+     * 
+     * @see #translation(Vector3f)
+     * @see #rotate(Quaternionf)
+     * 
+     * @param translation
+     *          the translation
+     * @param quat
+     *          the quaternion representing a rotation
+     * @param scale
+     *          the scaling factors
+     * @return this
+     */
+    public Matrix4d translationRotateScale(Vector3f translation, 
+                                           Quaternionf quat, 
+                                           Vector3f scale) {
+        return translationRotateScale(translation.x, translation.y, translation.z, quat.x, quat.y, quat.z, quat.w, scale.x, scale.y, scale.z);
+    }
+
+    /**
+     * Set <code>this</code> matrix to <tt>T * R * S</tt>, where <tt>T</tt> is the given <code>translation</code>,
+     * <tt>R</tt> is a rotation transformation specified by the given quaternion, and <tt>S</tt> is a scaling transformation
+     * which scales the axes by <code>scale</code>.
+     * <p>
+     * When transforming a vector by the resulting matrix the scaling transformation will be applied first, then the rotation and
+     * at last the translation.
+     * <p>
+     * This method is equivalent to calling: <tt>translation(translation).rotate(quat).scale(scale)</tt>
+     * 
+     * @see #translation(Vector3d)
+     * @see #rotate(Quaterniond)
+     * 
+     * @param translation
+     *          the translation
+     * @param quat
+     *          the quaternion representing a rotation
+     * @param scale
+     *          the scaling factors
+     * @return this
+     */
+    public Matrix4d translationRotateScale(Vector3d translation, 
+                                           Quaterniond quat, 
+                                           Vector3d scale) {
+        return translationRotateScale(translation.x, translation.y, translation.z, quat.x, quat.y, quat.z, quat.w, scale.x, scale.y, scale.z);
+    }
+
+    /**
+     * Set <code>this</code> matrix to <tt>T * R</tt>, where <tt>T</tt> is a translation by the given <tt>(tx, ty, tz)</tt> and
+     * <tt>R</tt> is a rotation transformation specified by the given quaternion.
+     * <p>
+     * When transforming a vector by the resulting matrix the rotation transformation will be applied first and then the translation.
+     * <p>
+     * This method is equivalent to calling: <tt>translation(tx, ty, tz).rotate(quat)</tt>
+     * 
+     * @see #translation(double, double, double)
+     * @see #rotate(Quaterniond)
+     * 
+     * @param tx
+     *          the number of units by which to translate the x-component
+     * @param ty
+     *          the number of units by which to translate the y-component
+     * @param tz
+     *          the number of units by which to translate the z-component
+     * @param quat
+     *          the quaternion representing a rotation
+     * @return this
+     */
+    public Matrix4d translationRotate(double tx, double ty, double tz, Quaterniond quat) {
+        double dqx = 2.0 * quat.x, dqy = 2.0 * quat.y, dqz = 2.0 * quat.z;
+        double q00 = dqx * quat.x;
+        double q11 = dqy * quat.y;
+        double q22 = dqz * quat.z;
+        double q01 = dqx * quat.y;
+        double q02 = dqx * quat.z;
+        double q03 = dqx * quat.w;
+        double q12 = dqy * quat.z;
+        double q13 = dqy * quat.w;
+        double q23 = dqz * quat.w;
+        m00 = 1.0 - (q11 + q22);
+        m01 = q01 + q23;
+        m02 = q02 - q13;
+        m03 = 0.0;
+        m10 = q01 - q23;
+        m11 = 1.0 - (q22 + q00);
+        m12 = q12 + q03;
+        m13 = 0.0;
+        m20 = q02 + q13;
+        m21 = q12 - q03;
+        m22 = 1.0 - (q11 + q00);
+        m23 = 0.0;
+        m30 = tx;
+        m31 = ty;
+        m32 = tz;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaterniond} to this matrix and store
+     * the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaterniond)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaterniond)
+     * 
+     * @param quat
+     *          the {@link Quaterniond}
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d rotate(Quaterniond quat, Matrix4d dest) {
+        double dqx = 2.0 * quat.x;
+        double dqy = 2.0 * quat.y;
+        double dqz = 2.0 * quat.z;
+        double q00 = dqx * quat.x;
+        double q11 = dqy * quat.y;
+        double q22 = dqz * quat.z;
+        double q01 = dqx * quat.y;
+        double q02 = dqx * quat.z;
+        double q03 = dqx * quat.w;
+        double q12 = dqy * quat.z;
+        double q13 = dqy * quat.w;
+        double q23 = dqz * quat.w;
+
+        double rm00 = 1.0 - q11 - q22;
+        double rm01 = q01 + q23;
+        double rm02 = q02 - q13;
+        double rm10 = q01 - q23;
+        double rm11 = 1.0 - q22 - q00;
+        double rm12 = q12 + q03;
+        double rm20 = q02 + q13;
+        double rm21 = q12 - q03;
+        double rm22 = 1.0 - q11 - q00;
+
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        double nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaternionf} to this matrix and store
+     * the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaternionf)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d rotate(Quaternionf quat, Matrix4d dest) {
+        double dqx = 2.0 * quat.x;
+        double dqy = 2.0 * quat.y;
+        double dqz = 2.0 * quat.z;
+        double q00 = dqx * quat.x;
+        double q11 = dqy * quat.y;
+        double q22 = dqz * quat.z;
+        double q01 = dqx * quat.y;
+        double q02 = dqx * quat.z;
+        double q03 = dqx * quat.w;
+        double q12 = dqy * quat.z;
+        double q13 = dqy * quat.w;
+        double q23 = dqz * quat.w;
+
+        double rm00 = 1.0 - q11 - q22;
+        double rm01 = q01 + q23;
+        double rm02 = q02 - q13;
+        double rm10 = q01 - q23;
+        double rm11 = 1.0 - q22 - q00;
+        double rm12 = q12 + q03;
+        double rm20 = q02 + q13;
+        double rm21 = q12 - q03;
+        double rm22 = 1.0 - q11 - q00;
+
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        double nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaterniond} to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaterniond)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaterniond)
+     * 
+     * @param quat
+     *          the {@link Quaterniond}
+     * @return this
+     */
+    public Matrix4d rotate(Quaterniond quat) {
+        return rotate(quat, this);
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaternionf} to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaternionf)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix4d rotate(Quaternionf quat) {
+        return rotate(quat, this);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4f}, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4f},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4f} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @return this
+     */
+    public Matrix4d rotate(AxisAngle4f axisAngle) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4f} and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4f},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4f} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d rotate(AxisAngle4f axisAngle, Matrix4d dest) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4d}, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4d},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4d} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4d)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(AxisAngle4d)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d} (needs to be {@link AxisAngle4d#normalize() normalized})
+     * @return this
+     */
+    public Matrix4d rotate(AxisAngle4d axisAngle) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4d} and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4d},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4d} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4d)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(AxisAngle4d)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d} (needs to be {@link AxisAngle4d#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d rotate(AxisAngle4d axisAngle, Matrix4d dest) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given angle and axis,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(double, Vector3d)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(double, Vector3d)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3d#normalize() normalized})
+     * @return this
+     */
+    public Matrix4d rotate(double angle, Vector3d axis) {
+        return rotate(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given angle and axis,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(double, Vector3d)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(double, Vector3d)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3d#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d rotate(double angle, Vector3d axis, Matrix4d dest) {
+        return rotate(angle, axis.x, axis.y, axis.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given angle and axis,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(double, Vector3f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(double, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3f#normalize() normalized})
+     * @return this
+     */
+    public Matrix4d rotate(double angle, Vector3f axis) {
+        return rotate(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given angle and axis,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(double, Vector3f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(double, double, double, double)
+     * @see #rotation(double, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3f#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d rotate(double angle, Vector3f axis, Matrix4d dest) {
+        return rotate(angle, axis.x, axis.y, axis.z, dest);
+    }
+
+    /**
+     * Get the row at the given <code>row</code> index, starting with <code>0</code>.
+     * 
+     * @param row
+     *          the row index in <tt>[0..3]</tt>
+     * @param dest
+     *          will hold the row components
+     * @return the passed in destination
+     * @throws IndexOutOfBoundsException if <code>row</code> is not in <tt>[0..3]</tt>
+     */
+    public Vector4d getRow(int row, Vector4d dest) throws IndexOutOfBoundsException {
+        switch (row) {
+        case 0:
+            dest.x = m00;
+            dest.y = m10;
+            dest.z = m20;
+            dest.w = m30;
+            break;
+        case 1:
+            dest.x = m01;
+            dest.y = m11;
+            dest.z = m21;
+            dest.w = m31;
+            break;
+        case 2:
+            dest.x = m02;
+            dest.y = m12;
+            dest.z = m22;
+            dest.w = m32;
+            break;
+        case 3:
+            dest.x = m03;
+            dest.y = m13;
+            dest.z = m23;
+            dest.w = m33;
+            break;
+        default:
+            throw new IndexOutOfBoundsException();
+        }
+        
+        return dest;
+    }
+
+    /**
+     * Get the column at the given <code>column</code> index, starting with <code>0</code>.
+     * 
+     * @param column
+     *          the column index in <tt>[0..3]</tt>
+     * @param dest
+     *          will hold the column components
+     * @return the passed in destination
+     * @throws IndexOutOfBoundsException if <code>column</code> is not in <tt>[0..3]</tt>
+     */
+    public Vector4d getColumn(int column, Vector4d dest) throws IndexOutOfBoundsException {
+        switch (column) {
+        case 0:
+            dest.x = m00;
+            dest.y = m01;
+            dest.z = m02;
+            dest.w = m03;
+            break;
+        case 1:
+            dest.x = m10;
+            dest.y = m11;
+            dest.z = m12;
+            dest.w = m13;
+            break;
+        case 2:
+            dest.x = m20;
+            dest.y = m21;
+            dest.z = m22;
+            dest.w = m23;
+            break;
+        case 3:
+            dest.x = m30;
+            dest.y = m31;
+            dest.z = m32;
+            dest.w = m32;
+            break;
+        default:
+            throw new IndexOutOfBoundsException();
+        }
+        
+        return dest;
+    }
+
+    /**
+     * Compute a normal matrix from the upper left 3x3 submatrix of <code>this</code>
+     * and store it into the upper left 3x3 submatrix of <code>dest</code>.
+     * All other values of <code>dest</code> will be set to {@link #identity() identity}.
+     * <p>
+     * The normal matrix of <tt>m</tt> is the transpose of the inverse of <tt>m</tt>.
+     * <p>
+     * Please note that, if <code>this</code> is an orthogonal matrix or a matrix whose columns are orthogonal vectors, 
+     * then this method <i>need not</i> be invoked, since in that case <code>this</code> itself is its normal matrix.
+     * In that case, use {@link #set3x3(Matrix4d)} to set a given Matrix4d to only the upper left 3x3 submatrix
+     * of a given matrix.
+     * 
+     * @see #set3x3(Matrix4d)
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix4d normal(Matrix4d dest) {
+        double det = determinant3x3();
+        double s = 1.0 / det;
+        /* Invert and transpose in one go */
+        dest.set((m11 * m22 - m21 * m12) * s,
+                 (m20 * m12 - m10 * m22) * s,
+                 (m10 * m21 - m20 * m11) * s,
+                 0.0f,
+                 (m21 * m02 - m01 * m22) * s,
+                 (m00 * m22 - m20 * m02) * s,
+                 (m20 * m01 - m00 * m21) * s,
+                 0.0f,
+                 (m01 * m12 - m11 * m02) * s,
+                 (m10 * m02 - m00 * m12) * s,
+                 (m00 * m11 - m10 * m01) * s,
+                 0.0f,
+                 0.0f, 0.0f, 0.0f, 1.0f);
+        return dest;
+    }
+
+    /**
+     * Compute a normal matrix from the upper left 3x3 submatrix of <code>this</code>
+     * and store it into <code>dest</code>.
+     * <p>
+     * The normal matrix of <tt>m</tt> is the transpose of the inverse of <tt>m</tt>.
+     * <p>
+     * Please note that, if <code>this</code> is an orthogonal matrix or a matrix whose columns are orthogonal vectors, 
+     * then this method <i>need not</i> be invoked, since in that case <code>this</code> itself is its normal matrix.
+     * In that case, use {@link Matrix3d#set(Matrix4d)} to set a given Matrix3d to only the upper left 3x3 submatrix
+     * of this matrix.
+     * 
+     * @see Matrix3d#set(Matrix4d)
+     * @see #get3x3(Matrix3d)
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3d normal(Matrix3d dest) {
+        double det = determinant3x3();
+        double s = 1.0 / det;
+        /* Invert and transpose in one go */
+        dest.m00 = (m11 * m22 - m21 * m12) * s;
+        dest.m01 = (m20 * m12 - m10 * m22) * s;
+        dest.m02 = (m10 * m21 - m20 * m11) * s;
+        dest.m10 = (m21 * m02 - m01 * m22) * s;
+        dest.m11 = (m00 * m22 - m20 * m02) * s;
+        dest.m12 = (m20 * m01 - m00 * m21) * s;
+        dest.m20 = (m01 * m12 - m11 * m02) * s;
+        dest.m21 = (m10 * m02 - m00 * m12) * s;
+        dest.m22 = (m00 * m11 - m10 * m01) * s;
+        return dest;
+    }
+
+    /**
+     * Normalize the upper left 3x3 submatrix of this matrix.
+     * <p>
+     * The resulting matrix will map unit vectors to unit vectors, though a pair of orthogonal input unit
+     * vectors need not be mapped to a pair of orthogonal output vectors if the original matrix was not orthogonal itself
+     * (i.e. had <i>skewing</i>).
+     * 
+     * @return this
+     */
+    public Matrix4d normalize3x3() {
+        return normalize3x3(this);
+    }
+
+    /**
+     * Normalize the upper left 3x3 submatrix of this matrix and store the result in <code>dest</code>.
+     * <p>
+     * The resulting matrix will map unit vectors to unit vectors, though a pair of orthogonal input unit
+     * vectors need not be mapped to a pair of orthogonal output vectors if the original matrix was not orthogonal itself
+     * (i.e. had <i>skewing</i>).
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix4d normalize3x3(Matrix4d dest) {
+        double invXlen = 1.0 / Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02);
+        double invYlen = 1.0 / Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12);
+        double invZlen = 1.0 / Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22);
+        dest.m00 = m00 * invXlen; dest.m01 = m01 * invXlen; dest.m02 = m02 * invXlen;
+        dest.m10 = m10 * invYlen; dest.m11 = m11 * invYlen; dest.m12 = m12 * invYlen;
+        dest.m20 = m20 * invZlen; dest.m21 = m21 * invZlen; dest.m22 = m22 * invZlen;
+        return dest;
+    }
+
+    /**
+     * Normalize the upper left 3x3 submatrix of this matrix and store the result in <code>dest</code>.
+     * <p>
+     * The resulting matrix will map unit vectors to unit vectors, though a pair of orthogonal input unit
+     * vectors need not be mapped to a pair of orthogonal output vectors if the original matrix was not orthogonal itself
+     * (i.e. had <i>skewing</i>).
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3d normalize3x3(Matrix3d dest) {
+        double invXlen = 1.0 / Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02);
+        double invYlen = 1.0 / Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12);
+        double invZlen = 1.0 / Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22);
+        dest.m00 = m00 * invXlen; dest.m01 = m01 * invXlen; dest.m02 = m02 * invXlen;
+        dest.m10 = m10 * invYlen; dest.m11 = m11 * invYlen; dest.m12 = m12 * invYlen;
+        dest.m20 = m20 * invZlen; dest.m21 = m21 * invZlen; dest.m22 = m22 * invZlen;
+        return dest;
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>this</code> matrix.
+     * In order to avoid computing the matrix inverse with every invocation, the inverse of <code>this</code> matrix can be built
+     * once outside using {@link #invert(Matrix4d)} and then the method {@link #unprojectInv(double, double, double, int[], Vector4d) unprojectInv()} can be invoked on it.
+     * 
+     * @see #unprojectInv(double, double, double, int[], Vector4d)
+     * @see #invert(Matrix4d)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector4d unproject(double winX, double winY, double winZ, int[] viewport, Vector4d dest) {
+        double a = m00 * m11 - m01 * m10;
+        double b = m00 * m12 - m02 * m10;
+        double c = m00 * m13 - m03 * m10;
+        double d = m01 * m12 - m02 * m11;
+        double e = m01 * m13 - m03 * m11;
+        double f = m02 * m13 - m03 * m12;
+        double g = m20 * m31 - m21 * m30;
+        double h = m20 * m32 - m22 * m30;
+        double i = m20 * m33 - m23 * m30;
+        double j = m21 * m32 - m22 * m31;
+        double k = m21 * m33 - m23 * m31;
+        double l = m22 * m33 - m23 * m32;
+        double det = a * l - b * k + c * j + d * i - e * h + f * g;
+        det = 1.0 / det;
+        double im00 = ( m11 * l - m12 * k + m13 * j) * det;
+        double im01 = (-m01 * l + m02 * k - m03 * j) * det;
+        double im02 = ( m31 * f - m32 * e + m33 * d) * det;
+        double im03 = (-m21 * f + m22 * e - m23 * d) * det;
+        double im10 = (-m10 * l + m12 * i - m13 * h) * det;
+        double im11 = ( m00 * l - m02 * i + m03 * h) * det;
+        double im12 = (-m30 * f + m32 * c - m33 * b) * det;
+        double im13 = ( m20 * f - m22 * c + m23 * b) * det;
+        double im20 = ( m10 * k - m11 * i + m13 * g) * det;
+        double im21 = (-m00 * k + m01 * i - m03 * g) * det;
+        double im22 = ( m30 * e - m31 * c + m33 * a) * det;
+        double im23 = (-m20 * e + m21 * c - m23 * a) * det;
+        double im30 = (-m10 * j + m11 * h - m12 * g) * det;
+        double im31 = ( m00 * j - m01 * h + m02 * g) * det;
+        double im32 = (-m30 * d + m31 * b - m32 * a) * det;
+        double im33 = ( m20 * d - m21 * b + m22 * a) * det;
+        double ndcX = (winX-viewport[0])/viewport[2]*2.0-1.0;
+        double ndcY = (winY-viewport[1])/viewport[3]*2.0-1.0;
+        double ndcZ = 2.0*winZ-1.0;
+        dest.x = im00 * ndcX + im10 * ndcY + im20 * ndcZ + im30;
+        dest.y = im01 * ndcX + im11 * ndcY + im21 * ndcZ + im31;
+        dest.z = im02 * ndcX + im12 * ndcY + im22 * ndcZ + im32;
+        dest.w = im03 * ndcX + im13 * ndcY + im23 * ndcZ + im33;
+        dest.div(dest.w);
+        return dest;
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>this</code> matrix.
+     * In order to avoid computing the matrix inverse with every invocation, the inverse of <code>this</code> matrix can be built
+     * once outside using {@link #invert(Matrix4d)} and then the method {@link #unprojectInv(double, double, double, int[], Vector3d) unprojectInv()} can be invoked on it.
+     * 
+     * @see #unprojectInv(double, double, double, int[], Vector3d)
+     * @see #invert(Matrix4d)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector3d unproject(double winX, double winY, double winZ, int[] viewport, Vector3d dest) {
+        double a = m00 * m11 - m01 * m10;
+        double b = m00 * m12 - m02 * m10;
+        double c = m00 * m13 - m03 * m10;
+        double d = m01 * m12 - m02 * m11;
+        double e = m01 * m13 - m03 * m11;
+        double f = m02 * m13 - m03 * m12;
+        double g = m20 * m31 - m21 * m30;
+        double h = m20 * m32 - m22 * m30;
+        double i = m20 * m33 - m23 * m30;
+        double j = m21 * m32 - m22 * m31;
+        double k = m21 * m33 - m23 * m31;
+        double l = m22 * m33 - m23 * m32;
+        double det = a * l - b * k + c * j + d * i - e * h + f * g;
+        det = 1.0 / det;
+        double im00 = ( m11 * l - m12 * k + m13 * j) * det;
+        double im01 = (-m01 * l + m02 * k - m03 * j) * det;
+        double im02 = ( m31 * f - m32 * e + m33 * d) * det;
+        double im03 = (-m21 * f + m22 * e - m23 * d) * det;
+        double im10 = (-m10 * l + m12 * i - m13 * h) * det;
+        double im11 = ( m00 * l - m02 * i + m03 * h) * det;
+        double im12 = (-m30 * f + m32 * c - m33 * b) * det;
+        double im13 = ( m20 * f - m22 * c + m23 * b) * det;
+        double im20 = ( m10 * k - m11 * i + m13 * g) * det;
+        double im21 = (-m00 * k + m01 * i - m03 * g) * det;
+        double im22 = ( m30 * e - m31 * c + m33 * a) * det;
+        double im23 = (-m20 * e + m21 * c - m23 * a) * det;
+        double im30 = (-m10 * j + m11 * h - m12 * g) * det;
+        double im31 = ( m00 * j - m01 * h + m02 * g) * det;
+        double im32 = (-m30 * d + m31 * b - m32 * a) * det;
+        double im33 = ( m20 * d - m21 * b + m22 * a) * det;
+        double ndcX = (winX-viewport[0])/viewport[2]*2.0-1.0;
+        double ndcY = (winY-viewport[1])/viewport[3]*2.0-1.0;
+        double ndcZ = 2.0*winZ-1.0;
+        dest.x = im00 * ndcX + im10 * ndcY + im20 * ndcZ + im30;
+        dest.y = im01 * ndcX + im11 * ndcY + im21 * ndcZ + im31;
+        dest.z = im02 * ndcX + im12 * ndcY + im22 * ndcZ + im32;
+        double w = im03 * ndcX + im13 * ndcY + im23 * ndcZ + im33;
+        dest.div(w);
+        return dest;
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>this</code> matrix.
+     * In order to avoid computing the matrix inverse with every invocation, the inverse of <code>this</code> matrix can be built
+     * once outside using {@link #invert(Matrix4d)} and then the method {@link #unprojectInv(double, double, double, int[], Vector4d) unprojectInv()} can be invoked on it.
+     * 
+     * @see #unprojectInv(double, double, double, int[], Vector4d)
+     * @see #unproject(double, double, double, int[], Vector4d)
+     * @see #invert(Matrix4d)
+     * 
+     * @param winCoords
+     *          the window coordinates to unproject
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector4d unproject(Vector3d winCoords, int[] viewport, Vector4d dest) {
+        return unproject(winCoords.x, winCoords.y, winCoords.z, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>this</code> matrix.
+     * In order to avoid computing the matrix inverse with every invocation, the inverse of <code>this</code> matrix can be built
+     * once outside using {@link #invert(Matrix4d)} and then the method {@link #unprojectInv(double, double, double, int[], Vector4d) unprojectInv()} can be invoked on it.
+     * 
+     * @see #unprojectInv(double, double, double, int[], Vector4d)
+     * @see #unproject(double, double, double, int[], Vector4d)
+     * @see #invert(Matrix4d)
+     * 
+     * @param winCoords
+     *          the window coordinates to unproject
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector3d unproject(Vector3d winCoords, int[] viewport, Vector3d dest) {
+        return unproject(winCoords.x, winCoords.y, winCoords.z, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method differs from {@link #unproject(Vector3d, int[], Vector4d) unproject()} 
+     * in that it assumes that <code>this</code> is already the inverse matrix of the original projection matrix.
+     * It exists to avoid recomputing the matrix inverse with every invocation.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * 
+     * @see #unproject(Vector3d, int[], Vector4d)
+     * 
+     * @param winCoords
+     *          the window coordinates to unproject
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector4d unprojectInv(Vector3d winCoords, int[] viewport, Vector4d dest) {
+        return unprojectInv(winCoords.x, winCoords.y, winCoords.z, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method differs from {@link #unproject(double, double, double, int[], Vector4d) unproject()} 
+     * in that it assumes that <code>this</code> is already the inverse matrix of the original projection matrix.
+     * It exists to avoid recomputing the matrix inverse with every invocation.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * 
+     * @see #unproject(double, double, double, int[], Vector4d)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector4d unprojectInv(double winX, double winY, double winZ, int[] viewport, Vector4d dest) {
+        double ndcX = (winX-viewport[0])/viewport[2]*2.0-1.0;
+        double ndcY = (winY-viewport[1])/viewport[3]*2.0-1.0;
+        double ndcZ = 2.0*winZ-1.0;
+        dest.x = m00 * ndcX + m10 * ndcY + m20 * ndcZ + m30;
+        dest.y = m01 * ndcX + m11 * ndcY + m21 * ndcZ + m31;
+        dest.z = m02 * ndcX + m12 * ndcY + m22 * ndcZ + m32;
+        dest.w = m03 * ndcX + m13 * ndcY + m23 * ndcZ + m33;
+        dest.div(dest.w);
+        return dest;
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method differs from {@link #unproject(Vector3d, int[], Vector3d) unproject()} 
+     * in that it assumes that <code>this</code> is already the inverse matrix of the original projection matrix.
+     * It exists to avoid recomputing the matrix inverse with every invocation.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * 
+     * @see #unproject(Vector3d, int[], Vector3d)
+     * 
+     * @param winCoords
+     *          the window coordinates to unproject
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector3d unprojectInv(Vector3d winCoords, int[] viewport, Vector3d dest) {
+        return unprojectInv(winCoords.x, winCoords.y, winCoords.z, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method differs from {@link #unproject(double, double, double, int[], Vector3d) unproject()} 
+     * in that it assumes that <code>this</code> is already the inverse matrix of the original projection matrix.
+     * It exists to avoid recomputing the matrix inverse with every invocation.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * 
+     * @see #unproject(double, double, double, int[], Vector3d)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector3d unprojectInv(double winX, double winY, double winZ, int[] viewport, Vector3d dest) {
+        double ndcX = (winX-viewport[0])/viewport[2]*2.0-1.0;
+        double ndcY = (winY-viewport[1])/viewport[3]*2.0-1.0;
+        double ndcZ = 2.0*winZ-1.0;
+        dest.x = m00 * ndcX + m10 * ndcY + m20 * ndcZ + m30;
+        dest.y = m01 * ndcX + m11 * ndcY + m21 * ndcZ + m31;
+        dest.z = m02 * ndcX + m12 * ndcY + m22 * ndcZ + m32;
+        double w = m03 * ndcX + m13 * ndcY + m23 * ndcZ + m33;
+        dest.div(w);
+        return dest;
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by the given <code>view</code> and <code>projection</code> matrices using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>projection * view</code>.
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>projection * view</code> and stores
+     * it into the <code>inverseOut</code> parameter matrix. In order to avoid computing the matrix inverse with every
+     * invocation, the inverse of both matrices can be built once outside and then the method {@link #unprojectInv(double, double, double, int[], Vector4d) unprojectInv()}
+     * can be invoked on it.
+     * 
+     * @see #unprojectInv(double, double, double, int[], Vector4d)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param projection
+     *          the projection matrix
+     * @param view
+     *          the view matrix
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param inverseOut
+     *          will hold the inverse of <code>projection * view</code> after the method returns
+     * @param dest
+     *          will hold the unprojected position
+     */
+    public static void unproject(double winX, double winY, double winZ, Matrix4d projection, Matrix4d view, int[] viewport, Matrix4d inverseOut, Vector4d dest) {
+        inverseOut.set(projection).mul(view).invert().unprojectInv(winX, winY, winZ, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by the given <code>view</code> and <code>projection</code> matrices using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>projection * view</code>.
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>projection * view</code> and stores
+     * it into the <code>inverseOut</code> parameter matrix. In order to avoid computing the matrix inverse with every
+     * invocation, the inverse of both matrices can be built once outside and then the method {@link #unprojectInv(double, double, double, int[], Vector4d) unprojectInv()}
+     * can be invoked on it.
+     * 
+     * @see #unprojectInv(double, double, double, int[], Vector4d)
+     * 
+     * @param winCoords
+     *          the window coordinate to unproject
+     * @param projection
+     *          the projection matrix
+     * @param view
+     *          the view matrix
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param inverseOut
+     *          will hold the inverse of <code>projection * view</code> after the method returns
+     * @param dest
+     *          will hold the unprojected position
+     */
+    public static void unproject(Vector3d winCoords, Matrix4d projection, Matrix4d view, int[] viewport, Matrix4d inverseOut, Vector4d dest) {
+        unproject(winCoords.x, winCoords.y, winCoords.z, projection, view, viewport, inverseOut, dest);
+    }
+
+    /**
+     * Project the given <tt>(x, y, z)</tt> position via <code>this</code> matrix using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>this</code> matrix including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @param x
+     *          the x-coordinate of the position to project
+     * @param y
+     *          the y-coordinate of the position to project
+     * @param z
+     *          the z-coordinate of the position to project
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     * @return winCoordsDest
+     */
+    public Vector4d project(double x, double y, double z, int[] viewport, Vector4d winCoordsDest) {
+        winCoordsDest.x = m00 * x + m10 * y + m20 * z + m30;
+        winCoordsDest.y = m01 * x + m11 * y + m21 * z + m31;
+        winCoordsDest.z = m02 * x + m12 * y + m22 * z + m32;
+        winCoordsDest.w = m03 * x + m13 * y + m23 * z + m33;
+        winCoordsDest.div(winCoordsDest.w);
+        winCoordsDest.x = (winCoordsDest.x*0.5+0.5) * viewport[2] + viewport[0];
+        winCoordsDest.y = (winCoordsDest.y*0.5+0.5) * viewport[3] + viewport[1];
+        winCoordsDest.z = (1.0+winCoordsDest.z)*0.5;
+        return winCoordsDest;
+    }
+
+    /**
+     * Project the given <tt>(x, y, z)</tt> position via <code>this</code> matrix using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>this</code> matrix including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @param x
+     *          the x-coordinate of the position to project
+     * @param y
+     *          the y-coordinate of the position to project
+     * @param z
+     *          the z-coordinate of the position to project
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     * @return winCoordsDest
+     */
+    public Vector3d project(double x, double y, double z, int[] viewport, Vector3d winCoordsDest) {
+        winCoordsDest.x = m00 * x + m10 * y + m20 * z + m30;
+        winCoordsDest.y = m01 * x + m11 * y + m21 * z + m31;
+        winCoordsDest.z = m02 * x + m12 * y + m22 * z + m32;
+        double w = m03 * x + m13 * y + m23 * z + m33;
+        winCoordsDest.div(w);
+        winCoordsDest.x = (winCoordsDest.x*0.5+0.5) * viewport[2] + viewport[0];
+        winCoordsDest.y = (winCoordsDest.y*0.5+0.5) * viewport[3] + viewport[1];
+        winCoordsDest.z = (1.0+winCoordsDest.z)*0.5;
+        return winCoordsDest;
+    }
+
+    /**
+     * Project the given <code>position</code> via <code>this</code> matrix using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>this</code> matrix including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @see #project(double, double, double, int[], Vector4d)
+     * 
+     * @param position
+     *          the position to project into window coordinates
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     * @return winCoordsDest
+     */
+    public Vector4d project(Vector3d position, int[] viewport, Vector4d winCoordsDest) {
+        return project(position.x, position.y, position.z, viewport, winCoordsDest);
+    }
+
+    /**
+     * Project the given <code>position</code> via <code>this</code> matrix using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>this</code> matrix including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @see #project(double, double, double, int[], Vector4d)
+     * 
+     * @param position
+     *          the position to project into window coordinates
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     * @return winCoordsDest
+     */
+    public Vector3d project(Vector3d position, int[] viewport, Vector3d winCoordsDest) {
+        return project(position.x, position.y, position.z, viewport, winCoordsDest);
+    }
+
+    /**
+     * Project the given <tt>(x, y, z)</tt> position via the given <code>view</code> and <code>projection</code> matrices using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>projection * view</code> including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @param x
+     *          the x-coordinate of the position to project
+     * @param y
+     *          the y-coordinate of the position to project
+     * @param z
+     *          the z-coordinate of the position to project
+     * @param projection
+     *          the projection matrix
+     * @param view
+     *          the view matrix
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     */
+    public static void project(double x, double y, double z, Matrix4d projection, Matrix4d view, int[] viewport, Vector4d winCoordsDest) {
+        winCoordsDest.set(x, y, z, 1.0);
+        view.transform(winCoordsDest);
+        projection.transform(winCoordsDest);
+        winCoordsDest.div(winCoordsDest.w);
+        winCoordsDest.x = (winCoordsDest.x*0.5+0.5) * viewport[2] + viewport[0];
+        winCoordsDest.y = (winCoordsDest.y*0.5+0.5) * viewport[3] + viewport[1];
+        winCoordsDest.z = (1.0+winCoordsDest.z)*0.5;
+    }
+
+    /**
+     * Project the given <code>position</code> via the given <code>view</code> and <code>projection</code> matrices using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>projection * view</code> including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @see #project(double, double, double, Matrix4d, Matrix4d, int[], Vector4d)
+     * 
+     * @param position
+     *          the position to project into window coordinates
+     * @param projection
+     *          the projection matrix
+     * @param view
+     *          the view matrix
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     */
+    public static void project(Vector3d position, Matrix4d projection, Matrix4d view, int[] viewport, Vector4d winCoordsDest) {
+        project(position.x, position.y, position.z, projection, view, viewport, winCoordsDest);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the equation <tt>x*a + y*b + z*c + d = 0</tt> and store the result in <code>dest</code>.
+     * <p>
+     * The vector <tt>(a, b, c)</tt> must be a unit vector.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb281733(v=vs.85).aspx">msdn.microsoft.com</a>
+     * 
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d reflect(double a, double b, double c, double d, Matrix4d dest) {
+        double da = 2.0 * a, db = 2.0 * b, dc = 2.0 * c, dd = 2.0 * d;
+        double rm00 = 1.0 - da * a;
+        double rm01 = -da * b;
+        double rm02 = -da * c;
+        double rm10 = -db * a;
+        double rm11 = 1.0 - db * b;
+        double rm12 = -db * c;
+        double rm20 = -dc * a;
+        double rm21 = -dc * b;
+        double rm22 = 1.0 - dc * c;
+        double rm30 = -dd * a;
+        double rm31 = -dd * b;
+        double rm32 = -dd * c;
+
+        // matrix multiplication
+        dest.m30 = m00 * rm30 + m10 * rm31 + m20 * rm32 + m30;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m21 * rm32 + m31;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m22 * rm32 + m32;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m23 * rm32 + m33;
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        double nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+
+        return dest;
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the equation <tt>x*a + y*b + z*c + d = 0</tt>.
+     * <p>
+     * The vector <tt>(a, b, c)</tt> must be a unit vector.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb281733(v=vs.85).aspx">msdn.microsoft.com</a>
+     * 
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return this
+     */
+    public Matrix4d reflect(double a, double b, double c, double d) {
+        return reflect(a, b, c, d, this);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param nx
+     *          the x-coordinate of the plane normal
+     * @param ny
+     *          the y-coordinate of the plane normal
+     * @param nz
+     *          the z-coordinate of the plane normal
+     * @param px
+     *          the x-coordinate of a point on the plane
+     * @param py
+     *          the y-coordinate of a point on the plane
+     * @param pz
+     *          the z-coordinate of a point on the plane
+     * @return this
+     */
+    public Matrix4d reflect(double nx, double ny, double nz, double px, double py, double pz) {
+        return reflect(nx, ny, nz, px, py, pz, this);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane, and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param nx
+     *          the x-coordinate of the plane normal
+     * @param ny
+     *          the y-coordinate of the plane normal
+     * @param nz
+     *          the z-coordinate of the plane normal
+     * @param px
+     *          the x-coordinate of a point on the plane
+     * @param py
+     *          the y-coordinate of a point on the plane
+     * @param pz
+     *          the z-coordinate of a point on the plane
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d reflect(double nx, double ny, double nz, double px, double py, double pz, Matrix4d dest) {
+        double invLength = 1.0 / Math.sqrt(nx * nx + ny * ny + nz * nz);
+        double nnx = nx * invLength;
+        double nny = ny * invLength;
+        double nnz = nz * invLength;
+        /* See: http://mathworld.wolfram.com/Plane.html */
+        return reflect(nnx, nny, nnz, -nnx * px - nny * py - nnz * pz, dest);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param normal
+     *          the plane normal
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public Matrix4d reflect(Vector3d normal, Vector3d point) {
+        return reflect(normal.x, normal.y, normal.z, point.x, point.y, point.z);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about a plane
+     * specified via the plane orientation and a point on the plane.
+     * <p>
+     * This method can be used to build a reflection transformation based on the orientation of a mirror object in the scene.
+     * It is assumed that the default mirror plane's normal is <tt>(0, 0, 1)</tt>. So, if the given {@link Quaterniond} is
+     * the identity (does not apply any additional rotation), the reflection plane will be <tt>z=0</tt>, offset by the given <code>point</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param orientation
+     *          the plane orientation relative to an implied normal vector of <tt>(0, 0, 1)</tt>
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public Matrix4d reflect(Quaterniond orientation, Vector3d point) {
+        return reflect(orientation, point, this);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about a plane
+     * specified via the plane orientation and a point on the plane, and store the result in <code>dest</code>.
+     * <p>
+     * This method can be used to build a reflection transformation based on the orientation of a mirror object in the scene.
+     * It is assumed that the default mirror plane's normal is <tt>(0, 0, 1)</tt>. So, if the given {@link Quaterniond} is
+     * the identity (does not apply any additional rotation), the reflection plane will be <tt>z=0</tt>, offset by the given <code>point</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param orientation
+     *          the plane orientation
+     * @param point
+     *          a point on the plane
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d reflect(Quaterniond orientation, Vector3d point, Matrix4d dest) {
+        double num1 = orientation.x * 2.0;
+        double num2 = orientation.y * 2.0;
+        double num3 = orientation.z * 2.0;
+        double normalX = orientation.x * num3 + orientation.w * num2;
+        double normalY = orientation.y * num3 - orientation.w * num1;
+        double normalZ = 1.0 - (orientation.x * num1 + orientation.y * num2);
+        return reflect(normalX, normalY, normalZ, point.x, point.y, point.z, dest);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane, and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param normal
+     *          the plane normal
+     * @param point
+     *          a point on the plane
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d reflect(Vector3d normal, Vector3d point, Matrix4d dest) {
+        return reflect(normal.x, normal.y, normal.z, point.x, point.y, point.z, dest);
+    }
+
+    /**
+     * Set this matrix to a mirror/reflection transformation that reflects about the given plane
+     * specified via the equation <tt>x*a + y*b + z*c + d = 0</tt>.
+     * <p>
+     * The vector <tt>(a, b, c)</tt> must be a unit vector.
+     * <p>
+     * Reference: <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb281733(v=vs.85).aspx">msdn.microsoft.com</a>
+     * 
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return this
+     */
+    public Matrix4d reflection(double a, double b, double c, double d) {
+        double da = 2.0 * a, db = 2.0 * b, dc = 2.0 * c, dd = 2.0 * d;
+        m00 = 1.0 - da * a;
+        m01 = -da * b;
+        m02 = -da * c;
+        m03 = 0.0;
+        m10 = -db * a;
+        m11 = 1.0 - db * b;
+        m12 = -db * c;
+        m13 = 0.0;
+        m20 = -dc * a;
+        m21 = -dc * b;
+        m22 = 1.0 - dc * c;
+        m23 = 0.0;
+        m30 = -dd * a;
+        m31 = -dd * b;
+        m32 = -dd * c;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a mirror/reflection transformation that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * 
+     * @param nx
+     *          the x-coordinate of the plane normal
+     * @param ny
+     *          the y-coordinate of the plane normal
+     * @param nz
+     *          the z-coordinate of the plane normal
+     * @param px
+     *          the x-coordinate of a point on the plane
+     * @param py
+     *          the y-coordinate of a point on the plane
+     * @param pz
+     *          the z-coordinate of a point on the plane
+     * @return this
+     */
+    public Matrix4d reflection(double nx, double ny, double nz, double px, double py, double pz) {
+        double invLength = 1.0 / Math.sqrt(nx * nx + ny * ny + nz * nz);
+        double nnx = nx * invLength;
+        double nny = ny * invLength;
+        double nnz = nz * invLength;
+        /* See: http://mathworld.wolfram.com/Plane.html */
+        return reflection(nnx, nny, nnz, -nnx * px - nny * py - nnz * pz);
+    }
+
+    /**
+     * Set this matrix to a mirror/reflection transformation that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * 
+     * @param normal
+     *          the plane normal
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public Matrix4d reflection(Vector3d normal, Vector3d point) {
+        return reflection(normal.x, normal.y, normal.z, point.x, point.y, point.z);
+    }
+
+    /**
+     * Set this matrix to a mirror/reflection transformation that reflects about a plane
+     * specified via the plane orientation and a point on the plane.
+     * <p>
+     * This method can be used to build a reflection transformation based on the orientation of a mirror object in the scene.
+     * It is assumed that the default mirror plane's normal is <tt>(0, 0, 1)</tt>. So, if the given {@link Quaterniond} is
+     * the identity (does not apply any additional rotation), the reflection plane will be <tt>z=0</tt>, offset by the given <code>point</code>.
+     * 
+     * @param orientation
+     *          the plane orientation
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public Matrix4d reflection(Quaterniond orientation, Vector3d point) {
+        double num1 = orientation.x * 2.0;
+        double num2 = orientation.y * 2.0;
+        double num3 = orientation.z * 2.0;
+        double normalX = orientation.x * num3 + orientation.w * num2;
+        double normalY = orientation.y * num3 - orientation.w * num1;
+        double normalZ = 1.0 - (orientation.x * num1 + orientation.y * num2);
+        return reflection(normalX, normalY, normalZ, point.x, point.y, point.z);
+    }
+    
+
+    /**
+     * Apply an orthographic projection transformation to this matrix and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to an orthographic projection without post-multiplying it,
+     * use {@link #setOrtho(double, double, double, double, double, double) setOrtho()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrtho(double, double, double, double, double, double)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d ortho(double left, double right, double bottom, double top, double zNear, double zFar, Matrix4d dest) {
+        // calculate right matrix elements
+        double rm00 = 2.0 / (right - left);
+        double rm11 = 2.0 / (top - bottom);
+        double rm22 = -2.0 / (zFar - zNear);
+        double rm30 = -(right + left) / (right - left);
+        double rm31 = -(top + bottom) / (top - bottom);
+        double rm32 = -(zFar + zNear) / (zFar - zNear);
+
+        // perform optimized multiplication
+        // compute the last column first, because other columns do not depend on it
+        dest.m30 = m00 * rm30 + m10 * rm31 + m20 * rm32 + m30;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m21 * rm32 + m31;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m22 * rm32 + m32;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m23 * rm32 + m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m20 = m20 * rm22;
+        dest.m21 = m21 * rm22;
+        dest.m22 = m22 * rm22;
+        dest.m23 = m23 * rm22;
+
+        return dest;
+    }
+
+    /**
+     * Apply an orthographic projection transformation to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to an orthographic projection without post-multiplying it,
+     * use {@link #setOrtho(double, double, double, double, double, double) setOrtho()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrtho(double, double, double, double, double, double)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4d ortho(double left, double right, double bottom, double top, double zNear, double zFar) {
+        return ortho(left, right, bottom, top, zNear, zFar, this);
+    }
+
+    /**
+     * Set this matrix to be an orthographic projection transformation.
+     * <p>
+     * In order to apply the orthographic projection to an already existing transformation,
+     * use {@link #ortho(double, double, double, double, double, double) ortho()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #ortho(double, double, double, double, double, double)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4d setOrtho(double left, double right, double bottom, double top, double zNear, double zFar) {
+        m00 = 2.0 / (right - left);
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = 2.0 / (top - bottom);
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = -2.0 / (zFar - zNear);
+        m23 = 0.0;
+        m30 = -(right + left) / (right - left);
+        m31 = -(top + bottom) / (top - bottom);
+        m32 = -(zFar + zNear) / (zFar - zNear);
+        m33 = 1.0;
+        return this;
+    }
+    
+
+    /**
+     * Apply a symmetric orthographic projection transformation to this matrix and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling {@link #ortho(double, double, double, double, double, double, Matrix4d) ortho()} with
+     * <code>left=-width/2</code>, <code>right=+width/2</code>, <code>bottom=-height/2</code> and <code>top=+height/2</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a symmetric orthographic projection without post-multiplying it,
+     * use {@link #setOrthoSymmetric(double, double, double, double) setOrthoSymmetric()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrthoSymmetric(double, double, double, double)
+     * 
+     * @param width
+     *            the distance between the right and left frustum edges
+     * @param height
+     *            the distance between the top and bottom frustum edges
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d orthoSymmetric(double width, double height, double zNear, double zFar, Matrix4d dest) {
+        // calculate right matrix elements
+        double rm00 = 2.0 / width;
+        double rm11 = 2.0 / height;
+        double rm22 = -2.0 / (zFar - zNear);
+        double rm32 = -(zFar + zNear) / (zFar - zNear);
+
+        // perform optimized multiplication
+        // compute the last column first, because other columns do not depend on it
+        dest.m30 = m20 * rm32 + m30;
+        dest.m31 = m21 * rm32 + m31;
+        dest.m32 = m22 * rm32 + m32;
+        dest.m33 = m23 * rm32 + m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m20 = m20 * rm22;
+        dest.m21 = m21 * rm22;
+        dest.m22 = m22 * rm22;
+        dest.m23 = m23 * rm22;
+
+        return dest;
+    }
+
+    /**
+     * Apply a symmetric orthographic projection transformation to this matrix.
+     * <p>
+     * This method is equivalent to calling {@link #ortho(double, double, double, double, double, double) ortho()} with
+     * <code>left=-width/2</code>, <code>right=+width/2</code>, <code>bottom=-height/2</code> and <code>top=+height/2</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a symmetric orthographic projection without post-multiplying it,
+     * use {@link #setOrthoSymmetric(double, double, double, double) setOrthoSymmetric()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrthoSymmetric(double, double, double, double)
+     * 
+     * @param width
+     *            the distance between the right and left frustum edges
+     * @param height
+     *            the distance between the top and bottom frustum edges
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4d orthoSymmetric(double width, double height, double zNear, double zFar) {
+        return orthoSymmetric(width, height, zNear, zFar, this);
+    }
+
+    /**
+     * Set this matrix to be a symmetric orthographic projection transformation.
+     * <p>
+     * This method is equivalent to calling {@link #setOrtho(double, double, double, double, double, double) setOrtho()} with
+     * <code>left=-width/2</code>, <code>right=+width/2</code>, <code>bottom=-height/2</code> and <code>top=+height/2</code>.
+     * <p>
+     * In order to apply the symmetric orthographic projection to an already existing transformation,
+     * use {@link #orthoSymmetric(double, double, double, double) orthoSymmetric()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #orthoSymmetric(double, double, double, double)
+     * 
+     * @param width
+     *            the distance between the right and left frustum edges
+     * @param height
+     *            the distance between the top and bottom frustum edges
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4d setOrthoSymmetric(double width, double height, double zNear, double zFar) {
+        m00 = 2.0 / width;
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = 2.0 / height;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = -2.0 / (zFar - zNear);
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = -(zFar + zNear) / (zFar - zNear);
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Apply an orthographic projection transformation to this matrix and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling {@link #ortho(double, double, double, double, double, double, Matrix4d) ortho()} with
+     * <code>zNear=-1</code> and <code>zFar=+1</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to an orthographic projection without post-multiplying it,
+     * use {@link #setOrtho2D(double, double, double, double) setOrtho()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #ortho(double, double, double, double, double, double, Matrix4d)
+     * @see #setOrtho2D(double, double, double, double)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d ortho2D(double left, double right, double bottom, double top, Matrix4d dest) {
+        // calculate right matrix elements
+        double rm00 = 2.0 / (right - left);
+        double rm11 = 2.0 / (top - bottom);
+        double rm30 = -(right + left) / (right - left);
+        double rm31 = -(top + bottom) / (top - bottom);
+
+        // perform optimized multiplication
+        // compute the last column first, because other columns do not depend on it
+        dest.m30 = m00 * rm30 + m10 * rm31 + m30;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m31;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m32;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m20 = -m20;
+        dest.m21 = -m21;
+        dest.m22 = -m22;
+        dest.m23 = -m23;
+
+        return dest;
+    }
+
+    /**
+     * Apply an orthographic projection transformation to this matrix.
+     * <p>
+     * This method is equivalent to calling {@link #ortho(double, double, double, double, double, double) ortho()} with
+     * <code>zNear=-1</code> and <code>zFar=+1</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to an orthographic projection without post-multiplying it,
+     * use {@link #setOrtho2D(double, double, double, double) setOrtho2D()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #ortho(double, double, double, double, double, double)
+     * @see #setOrtho2D(double, double, double, double)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @return this
+     */
+    public Matrix4d ortho2D(double left, double right, double bottom, double top) {
+        return ortho2D(left, right, bottom, top, this);
+    }
+
+    /**
+     * Set this matrix to be an orthographic projection transformation.
+     * <p>
+     * This method is equivalent to calling {@link #setOrtho(double, double, double, double, double, double) setOrtho()} with
+     * <code>zNear=-1</code> and <code>zFar=+1</code>.
+     * <p>
+     * In order to apply the orthographic projection to an already existing transformation,
+     * use {@link #ortho2D(double, double, double, double) ortho2D()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrtho(double, double, double, double, double, double)
+     * @see #ortho2D(double, double, double, double)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @return this
+     */
+    public Matrix4d setOrtho2D(double left, double right, double bottom, double top) {
+        m00 = 2.0 / (right - left);
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = 2.0 / (top - bottom);
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = -1.0;
+        m23 = 0.0;
+        m30 = -(right + left) / (right - left);
+        m31 = -(top + bottom) / (top - bottom);
+        m32 = 0.0;
+        m33 = 1.0;
+        return this;
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(Vector3d, Vector3d, Vector3d) lookAt}
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(Vector3d, Vector3d) setLookAlong()}.
+     * 
+     * @see #lookAlong(double, double, double, double, double, double)
+     * @see #lookAt(Vector3d, Vector3d, Vector3d)
+     * @see #setLookAlong(Vector3d, Vector3d)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix4d lookAlong(Vector3d dir, Vector3d up) {
+        return lookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z, this);
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>
+     * and store the result in <code>dest</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(Vector3d, Vector3d, Vector3d) lookAt}
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(Vector3d, Vector3d) setLookAlong()}.
+     * 
+     * @see #lookAlong(double, double, double, double, double, double)
+     * @see #lookAt(Vector3d, Vector3d, Vector3d)
+     * @see #setLookAlong(Vector3d, Vector3d)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d lookAlong(Vector3d dir, Vector3d up, Matrix4d dest) {
+        return lookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>
+     * and store the result in <code>dest</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(double, double, double, double, double, double, double, double, double) lookAt()}
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(double, double, double, double, double, double) setLookAlong()}
+     * 
+     * @see #lookAt(double, double, double, double, double, double, double, double, double)
+     * @see #setLookAlong(double, double, double, double, double, double)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Matrix4d lookAlong(double dirX, double dirY, double dirZ,
+                              double upX, double upY, double upZ, Matrix4d dest) {
+        // Normalize direction
+        double invDirLength = 1.0 / Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
+        double dirnX = dirX * invDirLength;
+        double dirnY = dirY * invDirLength;
+        double dirnZ = dirZ * invDirLength;
+        // right = direction x up
+        double rightX, rightY, rightZ;
+        rightX = dirnY * upZ - dirnZ * upY;
+        rightY = dirnZ * upX - dirnX * upZ;
+        rightZ = dirnX * upY - dirnY * upX;
+        // normalize right
+        double invRightLength = 1.0 / Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        double upnX = rightY * dirnZ - rightZ * dirnY;
+        double upnY = rightZ * dirnX - rightX * dirnZ;
+        double upnZ = rightX * dirnY - rightY * dirnX;
+
+        // calculate right matrix elements
+        double rm00 = rightX;
+        double rm01 = upnX;
+        double rm02 = -dirnX;
+        double rm10 = rightY;
+        double rm11 = upnY;
+        double rm12 = -dirnY;
+        double rm20 = rightZ;
+        double rm21 = upnZ;
+        double rm22 = -dirnZ;
+
+        // perform optimized matrix multiplication
+        // introduce temporaries for dependent results
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        double nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        // set the rest of the matrix elements
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(double, double, double, double, double, double, double, double, double) lookAt()}
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(double, double, double, double, double, double) setLookAlong()}
+     * 
+     * @see #lookAt(double, double, double, double, double, double, double, double, double)
+     * @see #setLookAlong(double, double, double, double, double, double)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix4d lookAlong(double dirX, double dirY, double dirZ,
+                              double upX, double upY, double upZ) {
+        return lookAlong(dirX, dirY, dirZ, upX, upY, upZ, this);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation to make <code>-z</code>
+     * point along <code>dir</code>.
+     * <p>
+     * This is equivalent to calling
+     * {@link #setLookAt(Vector3d, Vector3d, Vector3d) setLookAt()} 
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to apply the lookalong transformation to any previous existing transformation,
+     * use {@link #lookAlong(Vector3d, Vector3d)}.
+     * 
+     * @see #setLookAlong(Vector3d, Vector3d)
+     * @see #lookAlong(Vector3d, Vector3d)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix4d setLookAlong(Vector3d dir, Vector3d up) {
+        return setLookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation to make <code>-z</code>
+     * point along <code>dir</code>.
+     * <p>
+     * This is equivalent to calling
+     * {@link #setLookAt(double, double, double, double, double, double, double, double, double)
+     * setLookAt()} with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to apply the lookalong transformation to any previous existing transformation,
+     * use {@link #lookAlong(double, double, double, double, double, double) lookAlong()}
+     * 
+     * @see #setLookAlong(double, double, double, double, double, double)
+     * @see #lookAlong(double, double, double, double, double, double)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix4d setLookAlong(double dirX, double dirY, double dirZ,
+                                 double upX, double upY, double upZ) {
+        // Normalize direction
+        double invDirLength = 1.0 / Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
+        double dirnX = dirX * invDirLength;
+        double dirnY = dirY * invDirLength;
+        double dirnZ = dirZ * invDirLength;
+        // right = direction x up
+        double rightX, rightY, rightZ;
+        rightX = dirnY * upZ - dirnZ * upY;
+        rightY = dirnZ * upX - dirnX * upZ;
+        rightZ = dirnX * upY - dirnY * upX;
+        // normalize right
+        double invRightLength = 1.0 / Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        double upnX = rightY * dirnZ - rightZ * dirnY;
+        double upnY = rightZ * dirnX - rightX * dirnZ;
+        double upnZ = rightX * dirnY - rightY * dirnX;
+
+        m00 = rightX;
+        m01 = upnX;
+        m02 = -dirnX;
+        m03 = 0.0;
+        m10 = rightY;
+        m11 = upnY;
+        m12 = -dirnY;
+        m13 = 0.0;
+        m20 = rightZ;
+        m21 = upnZ;
+        m22 = -dirnZ;
+        m23 = 0.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = 0.0;
+        m33 = 1.0;
+
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a "lookat" transformation for a right-handed coordinate system, that aligns
+     * <code>-z</code> with <code>center - eye</code>.
+     * <p>
+     * In order to not make use of vectors to specify <code>eye</code>, <code>center</code> and <code>up</code> but use primitives,
+     * like in the GLU function, use {@link #setLookAt(double, double, double, double, double, double, double, double, double) setLookAt()}
+     * instead.
+     * <p>
+     * In order to apply the lookat transformation to a previous existing transformation,
+     * use {@link #lookAt(Vector3d, Vector3d, Vector3d) lookAt()}.
+     * 
+     * @see #setLookAt(double, double, double, double, double, double, double, double, double)
+     * @see #lookAt(Vector3d, Vector3d, Vector3d)
+     * 
+     * @param eye
+     *            the position of the camera
+     * @param center
+     *            the point in space to look at
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix4d setLookAt(Vector3d eye, Vector3d center, Vector3d up) {
+        return setLookAt(eye.x, eye.y, eye.z, center.x, center.y, center.z, up.x, up.y, up.z);
+    }
+
+    /**
+     * Set this matrix to be a "lookat" transformation for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code>.
+     * <p>
+     * In order to apply the lookat transformation to a previous existing transformation,
+     * use {@link #lookAt(double, double, double, double, double, double, double, double, double) lookAt}.
+     * 
+     * @see #setLookAt(Vector3d, Vector3d, Vector3d)
+     * @see #lookAt(double, double, double, double, double, double, double, double, double)
+     * 
+     * @param eyeX
+     *              the x-coordinate of the eye/camera location
+     * @param eyeY
+     *              the y-coordinate of the eye/camera location
+     * @param eyeZ
+     *              the z-coordinate of the eye/camera location
+     * @param centerX
+     *              the x-coordinate of the point to look at
+     * @param centerY
+     *              the y-coordinate of the point to look at
+     * @param centerZ
+     *              the z-coordinate of the point to look at
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix4d setLookAt(double eyeX, double eyeY, double eyeZ,
+                              double centerX, double centerY, double centerZ,
+                              double upX, double upY, double upZ) {
+        // Compute direction from position to lookAt
+        double dirX, dirY, dirZ;
+        dirX = centerX - eyeX;
+        dirY = centerY - eyeY;
+        dirZ = centerZ - eyeZ;
+        // Normalize direction
+        double invDirLength = 1.0 / Math.sqrt(
+                  (eyeX - centerX) * (eyeX - centerX)
+                + (eyeY - centerY) * (eyeY - centerY)
+                + (eyeZ - centerZ) * (eyeZ - centerZ));
+        dirX *= invDirLength;
+        dirY *= invDirLength;
+        dirZ *= invDirLength;
+        // right = direction x up
+        double rightX, rightY, rightZ;
+        rightX = dirY * upZ - dirZ * upY;
+        rightY = dirZ * upX - dirX * upZ;
+        rightZ = dirX * upY - dirY * upX;
+        // normalize right
+        double invRightLength = 1.0 / Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        double upnX = rightY * dirZ - rightZ * dirY;
+        double upnY = rightZ * dirX - rightX * dirZ;
+        double upnZ = rightX * dirY - rightY * dirX;
+
+        m00 = rightX;
+        m01 = upnX;
+        m02 = -dirX;
+        m03 = 0.0;
+        m10 = rightY;
+        m11 = upnY;
+        m12 = -dirY;
+        m13 = 0.0;
+        m20 = rightZ;
+        m21 = upnZ;
+        m22 = -dirZ;
+        m23 = 0.0;
+        m30 = -rightX * eyeX - rightY * eyeY - rightZ * eyeZ;
+        m31 = -upnX * eyeX - upnY * eyeY - upnZ * eyeZ;
+        m32 = dirX * eyeX + dirY * eyeY + dirZ * eyeZ;
+        m33 = 1.0;
+
+        return this;
+    }
+
+    /**
+     * Apply a "lookat" transformation to this matrix for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code> and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookat matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>,
+     * the lookat transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookat transformation without post-multiplying it,
+     * use {@link #setLookAt(Vector3d, Vector3d, Vector3d)}.
+     * 
+     * @see #lookAt(double, double, double, double, double, double, double, double, double)
+     * @see #setLookAlong(Vector3d, Vector3d)
+     * 
+     * @param eye
+     *            the position of the camera
+     * @param center
+     *            the point in space to look at
+     * @param up
+     *            the direction of 'up'
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d lookAt(Vector3d eye, Vector3d center, Vector3d up, Matrix4d dest) {
+        return lookAt(eye.x, eye.y, eye.z, center.x, center.y, center.z, up.x, up.y, up.z, dest);
+    }
+
+    /**
+     * Apply a "lookat" transformation to this matrix for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookat matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>,
+     * the lookat transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookat transformation without post-multiplying it,
+     * use {@link #setLookAt(Vector3d, Vector3d, Vector3d)}.
+     * 
+     * @see #lookAt(double, double, double, double, double, double, double, double, double)
+     * @see #setLookAlong(Vector3d, Vector3d)
+     * 
+     * @param eye
+     *            the position of the camera
+     * @param center
+     *            the point in space to look at
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix4d lookAt(Vector3d eye, Vector3d center, Vector3d up) {
+        return lookAt(eye.x, eye.y, eye.z, center.x, center.y, center.z, up.x, up.y, up.z, this);
+    }
+
+    /**
+     * Apply a "lookat" transformation to this matrix for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code> and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookat matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>,
+     * the lookat transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookat transformation without post-multiplying it,
+     * use {@link #setLookAt(double, double, double, double, double, double, double, double, double) setLookAt()}.
+     * 
+     * @see #lookAt(Vector3d, Vector3d, Vector3d)
+     * @see #setLookAt(double, double, double, double, double, double, double, double, double)
+     * 
+     * @param eyeX
+     *              the x-coordinate of the eye/camera location
+     * @param eyeY
+     *              the y-coordinate of the eye/camera location
+     * @param eyeZ
+     *              the z-coordinate of the eye/camera location
+     * @param centerX
+     *              the x-coordinate of the point to look at
+     * @param centerY
+     *              the y-coordinate of the point to look at
+     * @param centerZ
+     *              the z-coordinate of the point to look at
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d lookAt(double eyeX, double eyeY, double eyeZ,
+                           double centerX, double centerY, double centerZ,
+                           double upX, double upY, double upZ, Matrix4d dest) {
+        // Compute direction from position to lookAt
+        double dirX, dirY, dirZ;
+        dirX = centerX - eyeX;
+        dirY = centerY - eyeY;
+        dirZ = centerZ - eyeZ;
+        // Normalize direction
+        double invDirLength = 1.0 / Math.sqrt(
+                  (eyeX - centerX) * (eyeX - centerX)
+                + (eyeY - centerY) * (eyeY - centerY)
+                + (eyeZ - centerZ) * (eyeZ - centerZ));
+        dirX *= invDirLength;
+        dirY *= invDirLength;
+        dirZ *= invDirLength;
+        // right = direction x up
+        double rightX, rightY, rightZ;
+        rightX = dirY * upZ - dirZ * upY;
+        rightY = dirZ * upX - dirX * upZ;
+        rightZ = dirX * upY - dirY * upX;
+        // normalize right
+        double invRightLength = 1.0 / Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        double upnX = rightY * dirZ - rightZ * dirY;
+        double upnY = rightZ * dirX - rightX * dirZ;
+        double upnZ = rightX * dirY - rightY * dirX;
+
+        // calculate right matrix elements
+        double rm00 = rightX;
+        double rm01 = upnX;
+        double rm02 = -dirX;
+        double rm10 = rightY;
+        double rm11 = upnY;
+        double rm12 = -dirY;
+        double rm20 = rightZ;
+        double rm21 = upnZ;
+        double rm22 = -dirZ;
+        double rm30 = -rightX * eyeX - rightY * eyeY - rightZ * eyeZ;
+        double rm31 = -upnX * eyeX - upnY * eyeY - upnZ * eyeZ;
+        double rm32 = dirX * eyeX + dirY * eyeY + dirZ * eyeZ;
+
+        // perform optimized matrix multiplication
+        // compute last column first, because others do not depend on it
+        dest.m30 = m00 * rm30 + m10 * rm31 + m20 * rm32 + m30;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m21 * rm32 + m31;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m22 * rm32 + m32;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m23 * rm32 + m33;
+        // introduce temporaries for dependent results
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        double nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        double nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        // set the rest of the matrix elements
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+
+        return dest;
+    }
+
+    /**
+     * Apply a "lookat" transformation to this matrix for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookat matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>,
+     * the lookat transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookat transformation without post-multiplying it,
+     * use {@link #setLookAt(double, double, double, double, double, double, double, double, double) setLookAt()}.
+     * 
+     * @see #lookAt(Vector3d, Vector3d, Vector3d)
+     * @see #setLookAt(double, double, double, double, double, double, double, double, double)
+     * 
+     * @param eyeX
+     *              the x-coordinate of the eye/camera location
+     * @param eyeY
+     *              the y-coordinate of the eye/camera location
+     * @param eyeZ
+     *              the z-coordinate of the eye/camera location
+     * @param centerX
+     *              the x-coordinate of the point to look at
+     * @param centerY
+     *              the y-coordinate of the point to look at
+     * @param centerZ
+     *              the z-coordinate of the point to look at
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix4d lookAt(double eyeX, double eyeY, double eyeZ,
+                           double centerX, double centerY, double centerZ,
+                           double upX, double upY, double upZ) {
+        return lookAt(eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ, this);
+    }
+
+    /**
+     * Apply a symmetric perspective projection frustum transformation to this matrix and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>P</code> the perspective projection matrix,
+     * then the new matrix will be <code>M * P</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * P * v</code>,
+     * the perspective projection will be applied first!
+     * <p>
+     * This method first computes the frustum corners using the specified parameters and then makes use of
+     * {@link #frustum(double, double, double, double, double, double) frustum()} to finally apply the frustum
+     * transformation.
+     * <p>
+     * In order to set the matrix to a perspective frustum transformation without post-multiplying,
+     * use {@link #setPerspective(double, double, double, double) setPerspective}.
+     * 
+     * @see #frustum(double, double, double, double, double, double)
+     * @see #setPerspective(double, double, double, double)
+     * 
+     * @param fovy
+     *            the vertical field of view in radians
+     * @param aspect
+     *            the aspect ratio (i.e. width / height)
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d perspective(double fovy, double aspect, double zNear, double zFar, Matrix4d dest) {
+        double h = Math.tan(fovy * 0.5) * zNear;
+        double w = h * aspect;
+
+        // calculate right matrix elements
+        double rm00 = zNear / w;
+        double rm11 = zNear / h;
+        double rm22 = -(zFar + zNear) / (zFar - zNear);
+        double rm32 = -2.0 * zFar * zNear / (zFar - zNear);
+
+        // perform optimized matrix multiplication
+        double nm20 = m20 * rm22 - m30;
+        double nm21 = m21 * rm22 - m31;
+        double nm22 = m22 * rm22 - m32;
+        double nm23 = m23 * rm22 - m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m30 = m20 * rm32;
+        dest.m31 = m21 * rm32;
+        dest.m32 = m22 * rm32;
+        dest.m33 = m23 * rm32;
+        dest.m20 = nm20;
+        dest.m21 = nm21;
+        dest.m22 = nm22;
+        dest.m23 = nm23;
+
+        return dest;
+    }
+
+    /**
+     * Apply a symmetric perspective projection frustum transformation to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>P</code> the perspective projection matrix,
+     * then the new matrix will be <code>M * P</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * P * v</code>,
+     * the perspective projection will be applied first!
+     * <p>
+     * This method first computes the frustum corners using the specified parameters and then makes use of
+     * {@link #frustum(double, double, double, double, double, double) frustum()} to finally apply the frustum
+     * transformation.
+     * <p>
+     * In order to set the matrix to a perspective frustum transformation without post-multiplying,
+     * use {@link #setPerspective(double, double, double, double) setPerspective}.
+     * 
+     * @see #frustum(double, double, double, double, double, double)
+     * @see #setPerspective(double, double, double, double)
+     * 
+     * @param fovy
+     *            the vertical field of view in radians
+     * @param aspect
+     *            the aspect ratio (i.e. width / height)
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4d perspective(double fovy, double aspect, double zNear, double zFar) {
+        return perspective(fovy, aspect, zNear, zFar, this);
+    }
+
+    /**
+     * Set this matrix to be a symmetric perspective projection frustum transformation.
+     * <p>
+     * This method first computes the frustum corners using the specified parameters and then makes use of
+     * {@link #setFrustum(double, double, double, double, double, double) setFrustum()} to finally apply the frustum
+     * transformation.
+     * <p>
+     * In order to apply the perspective projection transformation to an existing transformation,
+     * use {@link #perspective(double, double, double, double) perspective()}.
+     * 
+     * @see #setFrustum(double, double, double, double, double, double)
+     * @see #perspective(double, double, double, double)
+     * 
+     * @param fovy
+     *            the vertical field of view in radians
+     * @param aspect
+     *            the aspect ratio (i.e. width / height)
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4d setPerspective(double fovy, double aspect, double zNear, double zFar) {
+        double h = Math.tan(fovy * 0.5) * zNear;
+        double w = h * aspect;
+        m00 = zNear / w;
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = zNear / h;
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = 0.0;
+        m21 = 0.0;
+        m22 = -(zFar + zNear) / (zFar - zNear);
+        m23 = -1.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = -2.0 * zFar * zNear / (zFar - zNear);
+        m33 = 0.0;
+        return this;
+    }
+
+    /**
+     * Apply an arbitrary perspective projection frustum transformation to this matrix 
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>F</code> the frustum matrix,
+     * then the new matrix will be <code>M * F</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * F * v</code>,
+     * the frustum transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a perspective frustum transformation without post-multiplying,
+     * use {@link #setFrustum(double, double, double, double, double, double) setFrustum()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#perspective">http://www.songho.ca</a>
+     * 
+     * @see #setFrustum(double, double, double, double, double, double)
+     * 
+     * @param left
+     *            the distance along the x-axis to the left frustum edge
+     * @param right
+     *            the distance along the x-axis to the right frustum edge
+     * @param bottom
+     *            the distance along the y-axis to the bottom frustum edge
+     * @param top
+     *            the distance along the y-axis to the top frustum edge
+     * @param zNear
+     *            the distance along the z-axis to the near clipping plane
+     * @param zFar
+     *            the distance along the z-axis to the far clipping plane
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4d frustum(double left, double right, double bottom, double top, double zNear, double zFar, Matrix4d dest) {
+        // calculate right matrix elements
+        double rm00 = 2.0 * zNear / (right - left);
+        double rm11 = 2.0 * zNear / (top - bottom);
+        double rm20 = (right + left) / (right - left);
+        double rm21 = (top + bottom) / (top - bottom);
+        double rm22 = -(zFar + zNear) / (zFar - zNear);
+        double rm32 = -2.0 * zFar * zNear / (zFar - zNear);
+
+        // perform optimized matrix multiplication
+        double nm20 = m00 * rm20 + m10 * rm21 + m20 * rm22 - m30;
+        double nm21 = m01 * rm20 + m11 * rm21 + m21 * rm22 - m31;
+        double nm22 = m02 * rm20 + m12 * rm21 + m22 * rm22 - m32;
+        double nm23 = m03 * rm20 + m13 * rm21 + m23 * rm22 - m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m30 = m20 * rm32;
+        dest.m31 = m21 * rm32;
+        dest.m32 = m22 * rm32;
+        dest.m33 = m23 * rm32;
+        dest.m20 = nm20;
+        dest.m21 = nm21;
+        dest.m22 = nm22;
+        dest.m23 = nm23;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply an arbitrary perspective projection frustum transformation to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>F</code> the frustum matrix,
+     * then the new matrix will be <code>M * F</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * F * v</code>,
+     * the frustum transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a perspective frustum transformation without post-multiplying,
+     * use {@link #setFrustum(double, double, double, double, double, double) setFrustum()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#perspective">http://www.songho.ca</a>
+     * 
+     * @see #setFrustum(double, double, double, double, double, double)
+     * 
+     * @param left
+     *            the distance along the x-axis to the left frustum edge
+     * @param right
+     *            the distance along the x-axis to the right frustum edge
+     * @param bottom
+     *            the distance along the y-axis to the bottom frustum edge
+     * @param top
+     *            the distance along the y-axis to the top frustum edge
+     * @param zNear
+     *            the distance along the z-axis to the near clipping plane
+     * @param zFar
+     *            the distance along the z-axis to the far clipping plane
+     * @return this
+     */
+    public Matrix4d frustum(double left, double right, double bottom, double top, double zNear, double zFar) {
+        return frustum(left, right, bottom, top, zNear, zFar, this);
+    }
+
+    /**
+     * Set this matrix to be an arbitrary perspective projection frustum transformation.
+     * <p>
+     * In order to apply the perspective frustum transformation to an existing transformation,
+     * use {@link #frustum(double, double, double, double, double, double) frustum()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#perspective">http://www.songho.ca</a>
+     * 
+     * @see #frustum(double, double, double, double, double, double)
+     * 
+     * @param left
+     *            the distance along the x-axis to the left frustum edge
+     * @param right
+     *            the distance along the x-axis to the right frustum edge
+     * @param bottom
+     *            the distance along the y-axis to the bottom frustum edge
+     * @param top
+     *            the distance along the y-axis to the top frustum edge
+     * @param zNear
+     *            the distance along the z-axis to the near clipping plane
+     * @param zFar
+     *            the distance along the z-axis to the far clipping plane
+     * @return this
+     */
+    public Matrix4d setFrustum(double left, double right, double bottom, double top, double zNear, double zFar) {
+        m00 = 2.0 * zNear / (right - left);
+        m01 = 0.0;
+        m02 = 0.0;
+        m03 = 0.0;
+        m10 = 0.0;
+        m11 = 2.0 * zNear / (top - bottom);
+        m12 = 0.0;
+        m13 = 0.0;
+        m20 = (right + left) / (right - left);
+        m21 = (top + bottom) / (top - bottom);
+        m22 = -(zFar + zNear) / (zFar - zNear);
+        m23 = -1.0;
+        m30 = 0.0;
+        m31 = 0.0;
+        m32 = -2.0 * zFar * zNear / (zFar - zNear);
+        m33 = 0.0;
+        return this;
+    }
+
+    /**
+     * Calculate a frustum plane of the this matrix, which
+     * can be a projection matrix or a combined modelview-projection matrix, and store the result
+     * in the given <code>planeEquation</code>.
+     * <p>
+     * Generally, this method computes the frustum plane in the local frame of
+     * any coordinate system that existed before <code>this</code>
+     * transformation was applied to it in order to yield homogeneous clipping space.
+     * <p>
+     * The frustum plane will be given in the form of a general plane equation:
+     * <tt>a*x + b*y + c*z + d = 0</tt>, where the given {@link Vector4d} components will
+     * hold the <tt>(a, b, c, d)</tt> values of the equation.
+     * <p>
+     * The plane normal, which is <tt>(a, b, c)</tt>, is directed "inwards" of the frustum.
+     * Any plane/point test using <tt>a*x + b*y + c*z + d</tt> therefore will yield a result greater than zero
+     * if the point is within the frustum (i.e. at the <i>positive</i> side of the frustum plane).
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     *
+     * @param plane
+     *          one of the six possible planes, given as numeric constants
+     *          {@link #PLANE_NX}, {@link #PLANE_PX},
+     *          {@link #PLANE_NY}, {@link #PLANE_PY}, 
+     *          {@link #PLANE_NZ} and {@link #PLANE_PZ}
+     * @param planeEquation
+     *          will hold the computed plane equation.
+     *          The plane equation will be normalized, meaning that <tt>(a, b, c)</tt> will be a unit vector
+     * @return planeEquation
+     */
+    public Vector4d frustumPlane(int plane, Vector4d planeEquation) {
+        switch (plane) {
+        case PLANE_NX:
+            planeEquation.set(m03 + m00, m13 + m10, m23 + m20, m33 + m30).normalize3();
+            break;
+        case PLANE_PX:
+            planeEquation.set(m03 - m00, m13 - m10, m23 - m20, m33 - m30).normalize3();
+            break;
+        case PLANE_NY:
+            planeEquation.set(m03 + m01, m13 + m11, m23 + m21, m33 + m31).normalize3();
+            break;
+        case PLANE_PY:
+            planeEquation.set(m03 - m01, m13 - m11, m23 - m21, m33 - m31).normalize3();
+            break;
+        case PLANE_NZ:
+            planeEquation.set(m03 + m02, m13 + m12, m23 + m22, m33 + m32).normalize3();
+            break;
+        case PLANE_PZ:
+            planeEquation.set(m03 - m02, m13 - m12, m23 - m22, m33 - m32).normalize3();
+            break;
+        default:
+            throw new IllegalArgumentException("plane"); //$NON-NLS-1$
+        }
+        return planeEquation;
+    }
+
+    /**
+     * Compute the corner coordinates of the frustum defined by <code>this</code> matrix, which
+     * can be a projection matrix or a combined modelview-projection matrix, and store the result
+     * in the given <code>point</code>.
+     * <p>
+     * Generally, this method computes the frustum corners in the local frame of
+     * any coordinate system that existed before <code>this</code>
+     * transformation was applied to it in order to yield homogeneous clipping space.
+     * <p>
+     * Reference: <a href="http://geomalgorithms.com/a05-_intersect-1.html">http://geomalgorithms.com</a>
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * 
+     * @param corner
+     *          one of the eight possible corners, given as numeric constants
+     *          {@link #CORNER_NXNYNZ}, {@link #CORNER_PXNYNZ}, {@link #CORNER_PXPYNZ}, {@link #CORNER_NXPYNZ},
+     *          {@link #CORNER_PXNYPZ}, {@link #CORNER_NXNYPZ}, {@link #CORNER_NXPYPZ}, {@link #CORNER_PXPYPZ}
+     * @param point
+     *          will hold the resulting corner point coordinates
+     * @return point
+     */
+    public Vector3d frustumCorner(int corner, Vector3d point) {
+        double d1, d2, d3;
+        double n1x, n1y, n1z, n2x, n2y, n2z, n3x, n3y, n3z;
+        switch (corner) {
+        case CORNER_NXNYNZ: // left, bottom, near
+            n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+            n2x = m03 + m01; n2y = m13 + m11; n2z = m23 + m21; d2 = m33 + m31; // bottom
+            n3x = m03 + m02; n3y = m13 + m12; n3z = m23 + m22; d3 = m33 + m32; // near
+            break;
+        case CORNER_PXNYNZ: // right, bottom, near
+            n1x = m03 - m00; n1y = m13 - m10; n1z = m23 - m20; d1 = m33 - m30; // right
+            n2x = m03 + m01; n2y = m13 + m11; n2z = m23 + m21; d2 = m33 + m31; // bottom
+            n3x = m03 + m02; n3y = m13 + m12; n3z = m23 + m22; d3 = m33 + m32; // near
+            break;
+        case CORNER_PXPYNZ: // right, top, near
+            n1x = m03 - m00; n1y = m13 - m10; n1z = m23 - m20; d1 = m33 - m30; // right
+            n2x = m03 - m01; n2y = m13 - m11; n2z = m23 - m21; d2 = m33 - m31; // top
+            n3x = m03 + m02; n3y = m13 + m12; n3z = m23 + m22; d3 = m33 + m32; // near
+            break;
+        case CORNER_NXPYNZ: // left, top, near
+            n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+            n2x = m03 - m01; n2y = m13 - m11; n2z = m23 - m21; d2 = m33 - m31; // top
+            n3x = m03 + m02; n3y = m13 + m12; n3z = m23 + m22; d3 = m33 + m32; // near
+            break;
+        case CORNER_PXNYPZ: // right, bottom, far
+            n1x = m03 - m00; n1y = m13 - m10; n1z = m23 - m20; d1 = m33 - m30; // right
+            n2x = m03 + m01; n2y = m13 + m11; n2z = m23 + m21; d2 = m33 + m31; // bottom
+            n3x = m03 - m02; n3y = m13 - m12; n3z = m23 - m22; d3 = m33 - m32; // far
+            break;
+        case CORNER_NXNYPZ: // left, bottom, far
+            n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+            n2x = m03 + m01; n2y = m13 + m11; n2z = m23 + m21; d2 = m33 + m31; // bottom
+            n3x = m03 - m02; n3y = m13 - m12; n3z = m23 - m22; d3 = m33 - m32; // far
+            break;
+        case CORNER_NXPYPZ: // left, top, far
+            n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+            n2x = m03 - m01; n2y = m13 - m11; n2z = m23 - m21; d2 = m33 - m31; // top
+            n3x = m03 - m02; n3y = m13 - m12; n3z = m23 - m22; d3 = m33 - m32; // far
+            break;
+        case CORNER_PXPYPZ: // right, top, far
+            n1x = m03 - m00; n1y = m13 - m10; n1z = m23 - m20; d1 = m33 - m30; // right
+            n2x = m03 - m01; n2y = m13 - m11; n2z = m23 - m21; d2 = m33 - m31; // top
+            n3x = m03 - m02; n3y = m13 - m12; n3z = m23 - m22; d3 = m33 - m32; // far
+            break;
+        default:
+            throw new IllegalArgumentException("corner"); //$NON-NLS-1$
+        }
+        double c23x, c23y, c23z;
+        c23x = n2y * n3z - n2z * n3y;
+        c23y = n2z * n3x - n2x * n3z;
+        c23z = n2x * n3y - n2y * n3x;
+        double c31x, c31y, c31z;
+        c31x = n3y * n1z - n3z * n1y;
+        c31y = n3z * n1x - n3x * n1z;
+        c31z = n3x * n1y - n3y * n1x;
+        double c12x, c12y, c12z;
+        c12x = n1y * n2z - n1z * n2y;
+        c12y = n1z * n2x - n1x * n2z;
+        c12z = n1x * n2y - n1y * n2x;
+        double invDot = 1.0 / (n1x * c23x + n1y * c23y + n1z * c23z);
+        point.x = (-c23x * d1 - c31x * d2 - c12x * d3) * invDot;
+        point.y = (-c23y * d1 - c31y * d2 - c12y * d3) * invDot;
+        point.z = (-c23z * d1 - c31z * d2 - c12z * d3) * invDot;
+        return point;
+    }
+
+    /**
+     * Compute the eye/origin of the perspective frustum transformation defined by <code>this</code> matrix, 
+     * which can be a projection matrix or a combined modelview-projection matrix, and store the result
+     * in the given <code>origin</code>.
+     * <p>
+     * Note that this method will only work using perspective projections obtained via one of the
+     * perspective methods, such as {@link #perspective(double, double, double, double) perspective()}
+     * or {@link #frustum(double, double, double, double, double, double) frustum()}.
+     * <p>
+     * Generally, this method computes the origin in the local frame of
+     * any coordinate system that existed before <code>this</code>
+     * transformation was applied to it in order to yield homogeneous clipping space.
+     * <p>
+     * Reference: <a href="http://geomalgorithms.com/a05-_intersect-1.html">http://geomalgorithms.com</a>
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * 
+     * @param origin
+     *          will hold the origin of the coordinate system before applying <code>this</code>
+     *          perspective projection transformation
+     * @return origin
+     */
+    public Vector3d perspectiveOrigin(Vector3d origin) {
+        /*
+         * Simply compute the intersection point of the left, right and top frustum plane.
+         */
+    	double d1, d2, d3;
+        double n1x, n1y, n1z, n2x, n2y, n2z, n3x, n3y, n3z;
+        n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+        n2x = m03 - m00; n2y = m13 - m10; n2z = m23 - m20; d2 = m33 - m30; // right
+        n3x = m03 - m01; n3y = m13 - m11; n3z = m23 - m21; d3 = m33 - m31; // top
+        double c23x, c23y, c23z;
+        c23x = n2y * n3z - n2z * n3y;
+        c23y = n2z * n3x - n2x * n3z;
+        c23z = n2x * n3y - n2y * n3x;
+        double c31x, c31y, c31z;
+        c31x = n3y * n1z - n3z * n1y;
+        c31y = n3z * n1x - n3x * n1z;
+        c31z = n3x * n1y - n3y * n1x;
+        double c12x, c12y, c12z;
+        c12x = n1y * n2z - n1z * n2y;
+        c12y = n1z * n2x - n1x * n2z;
+        c12z = n1x * n2y - n1y * n2x;
+        double invDot = 1.0 / (n1x * c23x + n1y * c23y + n1z * c23z);
+        origin.x = (-c23x * d1 - c31x * d2 - c12x * d3) * invDot;
+        origin.y = (-c23y * d1 - c31y * d2 - c12y * d3) * invDot;
+        origin.z = (-c23z * d1 - c31z * d2 - c12z * d3) * invDot;
+        return origin;
+    }
+
+    /**
+     * Return the vertical field-of-view angle in radians of this perspective transformation matrix.
+     * <p>
+     * Note that this method will only work using perspective projections obtained via one of the
+     * perspective methods, such as {@link #perspective(double, double, double, double) perspective()}
+     * or {@link #frustum(double, double, double, double, double, double) frustum()}.
+     * <p>
+     * For orthogonal transformations this method will return <tt>0.0</tt>.
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * 
+     * @return the vertical field-of-view angle in radians
+     */
+    public double perspectiveFov() {
+        /*
+         * Compute the angle between the bottom and top frustum plane normals.
+         */
+        double n1x, n1y, n1z, n2x, n2y, n2z;
+        n1x = m03 + m01; n1y = m13 + m11; n1z = m23 + m21; // bottom
+        n2x = m01 - m03; n2y = m11 - m13; n2z = m21 - m23; // top
+        double n1len = Math.sqrt(n1x * n1x + n1y * n1y + n1z * n1z);
+        double n2len = Math.sqrt(n2x * n2x + n2y * n2y + n2z * n2z);
+        return Math.acos((n1x * n2x + n1y * n2y + n1z * n2z) / (n1len * n2len));
+    }
+
+    /**
+     * Obtain the direction of a ray starting at the center of the coordinate system and going
+     * through the near frustum plane.
+     * <p>
+     * This method computes the <code>dir</code> vector in the local frame of
+     * any coordinate system that existed before <code>this</code>
+     * transformation was applied to it in order to yield homogeneous clipping space.
+     * <p>
+     * The parameters <code>x</code> and <code>y</code> are used to interpolate the generated ray direction
+     * from the bottom-left to the top-right frustum corners.
+     * <p>
+     * For optimal efficiency when building many ray directions over the whole frustum,
+     * it is recommended to use this method only in order to compute the four corner rays at
+     * <tt>(0, 0)</tt>, <tt>(1, 0)</tt>, <tt>(0, 1)</tt> and <tt>(1, 1)</tt>
+     * and then bilinearly interpolating between them; or to use the {@link FrustumRayBuilder}.
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * 
+     * @param x
+     *          the interpolation factor along the left-to-right frustum planes, within <tt>[0..1]</tt>
+     * @param y
+     *          the interpolation factor along the bottom-to-top frustum planes, within <tt>[0..1]</tt>
+     * @param dir
+     *          will hold the normalized ray direction in the local frame of the coordinate system before 
+     *          transforming to homogeneous clipping space using <code>this</code> matrix
+     * @return dir
+     */
+    public Vector3d frustumRayDir(double x, double y, Vector3d dir) {
+        /*
+         * This method works by first obtaining the frustum plane normals,
+         * then building the cross product to obtain the corner rays,
+         * and finally bilinearly interpolating to obtain the desired direction.
+         * The code below uses a condense form of doing all this making use 
+         * of some mathematical identities to simplify the overall expression.
+         */
+        double a = m10 * m23, b = m13 * m21, c = m10 * m21, d = m11 * m23, e = m13 * m20, f = m11 * m20;
+        double g = m03 * m20, h = m01 * m23, i = m01 * m20, j = m03 * m21, k = m00 * m23, l = m00 * m21;
+        double m = m00 * m13, n = m03 * m11, o = m00 * m11, p = m01 * m13, q = m03 * m10, r = m01 * m10;
+        double m1x, m1y, m1z;
+        m1x = (d + e + f - a - b - c) * (1.0 - y) + (a - b - c + d - e + f) * y;
+        m1y = (j + k + l - g - h - i) * (1.0 - y) + (g - h - i + j - k + l) * y;
+        m1z = (p + q + r - m - n - o) * (1.0 - y) + (m - n - o + p - q + r) * y;
+        double m2x, m2y, m2z;
+        m2x = (b - c - d + e + f - a) * (1.0 - y) + (a + b - c - d - e + f) * y;
+        m2y = (h - i - j + k + l - g) * (1.0 - y) + (g + h - i - j - k + l) * y;
+        m2z = (n - o - p + q + r - m) * (1.0 - y) + (m + n - o - p - q + r) * y;
+        dir.x = m1x * (1.0 - x) + m2x * x;
+        dir.y = m1y * (1.0 - x) + m2y * x;
+        dir.z = m1z * (1.0 - x) + m2z * x;
+        dir.normalize();
+        return dir;
+    }
+
+    /**
+     * Obtain the direction of <tt>+Z</tt> before the orthogonal transformation represented by
+     * <code>this</code> matrix is applied.
+     * <p>
+     * This method uses the rotation component of the upper left 3x3 submatrix to obtain the direction 
+     * that is transformed to <tt>+Z</tt> by <code>this</code> matrix.
+     * <p>
+     * Reference: <a href="http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/threeD/">http://www.euclideanspace.com</a>
+     * 
+     * @param dir
+     *          will hold the direction of <tt>+Z</tt>
+     * @return dir
+     */
+    public Vector3d positiveZ(Vector3d dir) {
+        dir.x = m10 * m21 - m11 * m20;
+        dir.y = m20 * m01 - m21 * m00;
+        dir.z = m00 * m11 - m01 * m10;
+        dir.normalize();
+        return dir;
+    }
+
+    /**
+     * Obtain the direction of <tt>+X</tt> before the orthogonal transformation represented by
+     * <code>this</code> matrix is applied.
+     * <p>
+     * This method uses the rotation component of the upper left 3x3 submatrix to obtain the direction 
+     * that is transformed to <tt>+X</tt> by <code>this</code> matrix.
+     * <p>
+     * Reference: <a href="http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/threeD/">http://www.euclideanspace.com</a>
+     * 
+     * @param dir
+     *          will hold the direction of <tt>+X</tt>
+     * @return dir
+     */
+    public Vector3d positiveX(Vector3d dir) {
+        dir.x = m11 * m22 - m12 * m21;
+        dir.y = m02 * m21 - m01 * m22;
+        dir.z = m01 * m12 - m02 * m11;
+        dir.normalize();
+        return dir;
+    }
+
+    /**
+     * Obtain the direction of <tt>+Y</tt> before the orthogonal transformation represented by
+     * <code>this</code> matrix is applied.
+     * <p>
+     * This method uses the rotation component of the upper left 3x3 submatrix to obtain the direction 
+     * that is transformed to <tt>+Y</tt> by <code>this</code> matrix.
+     * <p>
+     * Reference: <a href="http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/threeD/">http://www.euclideanspace.com</a>
+     * 
+     * @param dir
+     *          will hold the direction of <tt>+Y</tt>
+     * @return dir
+     */
+    public Vector3d positiveY(Vector3d dir) {
+        dir.x = m12 * m20 - m10 * m22;
+        dir.y = m00 * m22 - m02 * m20;
+        dir.z = m02 * m10 - m00 * m12;
+        dir.normalize();
+        return dir;
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane specified via the general plane equation
+     * <tt>x*a + y*b + z*c + d = 0</tt> as if casting a shadow from a given light position/direction <code>light</code>.
+     * <p>
+     * If <tt>light.w</tt> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="ftp://ftp.sgi.com/opengl/contrib/blythe/advanced99/notes/node192.html">ftp.sgi.com</a>
+     * 
+     * @param light
+     *          the light's vector
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return this
+     */
+    public Matrix4d shadow(Vector4d light, double a, double b, double c, double d) {
+        return shadow(light.x, light.y, light.z, light.w, a, b, c, d, this);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane specified via the general plane equation
+     * <tt>x*a + y*b + z*c + d = 0</tt> as if casting a shadow from a given light position/direction <code>light</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <tt>light.w</tt> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="ftp://ftp.sgi.com/opengl/contrib/blythe/advanced99/notes/node192.html">ftp.sgi.com</a>
+     * 
+     * @param light
+     *          the light's vector
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d shadow(Vector4d light, double a, double b, double c, double d, Matrix4d dest) {
+        return shadow(light.x, light.y, light.z, light.w, a, b, c, d, dest);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane specified via the general plane equation
+     * <tt>x*a + y*b + z*c + d = 0</tt> as if casting a shadow from a given light position/direction <tt>(lightX, lightY, lightZ, lightW)</tt>.
+     * <p>
+     * If <code>lightW</code> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="ftp://ftp.sgi.com/opengl/contrib/blythe/advanced99/notes/node192.html">ftp.sgi.com</a>
+     * 
+     * @param lightX
+     *          the x-component of the light's vector
+     * @param lightY
+     *          the y-component of the light's vector
+     * @param lightZ
+     *          the z-component of the light's vector
+     * @param lightW
+     *          the w-component of the light's vector
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return this
+     */
+    public Matrix4d shadow(double lightX, double lightY, double lightZ, double lightW, double a, double b, double c, double d) {
+        return shadow(lightX, lightY, lightZ, lightW, a, b, c, d, this);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane specified via the general plane equation
+     * <tt>x*a + y*b + z*c + d = 0</tt> as if casting a shadow from a given light position/direction <tt>(lightX, lightY, lightZ, lightW)</tt>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>lightW</code> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="ftp://ftp.sgi.com/opengl/contrib/blythe/advanced99/notes/node192.html">ftp.sgi.com</a>
+     * 
+     * @param lightX
+     *          the x-component of the light's vector
+     * @param lightY
+     *          the y-component of the light's vector
+     * @param lightZ
+     *          the z-component of the light's vector
+     * @param lightW
+     *          the w-component of the light's vector
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d shadow(double lightX, double lightY, double lightZ, double lightW, double a, double b, double c, double d, Matrix4d dest) {
+        // normalize plane
+        double invPlaneLen = 1.0 / Math.sqrt(a*a + b*b + c*c);
+        double an = a * invPlaneLen;
+        double bn = b * invPlaneLen;
+        double cn = c * invPlaneLen;
+        double dn = d * invPlaneLen;
+
+        double dot = an * lightX + bn * lightY + cn * lightZ + dn * lightW;
+
+        // compute right matrix elements
+        double rm00 = dot - an * lightX;
+        double rm01 = -an * lightY;
+        double rm02 = -an * lightZ;
+        double rm03 = -an * lightW;
+        double rm10 = -bn * lightX;
+        double rm11 = dot - bn * lightY;
+        double rm12 = -bn * lightZ;
+        double rm13 = -bn * lightW;
+        double rm20 = -cn * lightX;
+        double rm21 = -cn * lightY;
+        double rm22 = dot - cn * lightZ;
+        double rm23 = -cn * lightW;
+        double rm30 = -dn * lightX;
+        double rm31 = -dn * lightY;
+        double rm32 = -dn * lightZ;
+        double rm33 = dot - dn * lightW;
+
+        // matrix multiplication
+        double nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02 + m30 * rm03;
+        double nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02 + m31 * rm03;
+        double nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02 + m32 * rm03;
+        double nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02 + m33 * rm03;
+        double nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12 + m30 * rm13;
+        double nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12 + m31 * rm13;
+        double nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12 + m32 * rm13;
+        double nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12 + m33 * rm13;
+        double nm20 = m00 * rm20 + m10 * rm21 + m20 * rm22 + m30 * rm23;
+        double nm21 = m01 * rm20 + m11 * rm21 + m21 * rm22 + m31 * rm23;
+        double nm22 = m02 * rm20 + m12 * rm21 + m22 * rm22 + m32 * rm23;
+        double nm23 = m03 * rm20 + m13 * rm21 + m23 * rm22 + m33 * rm23;
+        dest.m30 = m00 * rm30 + m10 * rm31 + m20 * rm32 + m30 * rm33;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m21 * rm32 + m31 * rm33;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m22 * rm32 + m32 * rm33;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m23 * rm32 + m33 * rm33;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m20 = nm20;
+        dest.m21 = nm21;
+        dest.m22 = nm22;
+        dest.m23 = nm23;
+
+        return dest;
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane with the general plane equation
+     * <tt>y = 0</tt> as if casting a shadow from a given light position/direction <code>light</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * Before the shadow projection is applied, the plane is transformed via the specified <code>planeTransformation</code>.
+     * <p>
+     * If <tt>light.w</tt> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param light
+     *          the light's vector
+     * @param planeTransform
+     *          the transformation to transform the implied plane <tt>y = 0</tt> before applying the projection
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d shadow(Vector4d light, Matrix4d planeTransform, Matrix4d dest) {
+        // compute plane equation by transforming (y = 0)
+        double a = planeTransform.m10;
+        double b = planeTransform.m11;
+        double c = planeTransform.m12;
+        double d = -a * planeTransform.m30 - b * planeTransform.m31 - c * planeTransform.m32;
+        return shadow(light.x, light.y, light.z, light.w, a, b, c, d, dest);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane with the general plane equation
+     * <tt>y = 0</tt> as if casting a shadow from a given light position/direction <code>light</code>.
+     * <p>
+     * Before the shadow projection is applied, the plane is transformed via the specified <code>planeTransformation</code>.
+     * <p>
+     * If <tt>light.w</tt> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param light
+     *          the light's vector
+     * @param planeTransform
+     *          the transformation to transform the implied plane <tt>y = 0</tt> before applying the projection
+     * @return this
+     */
+    public Matrix4d shadow(Vector4d light, Matrix4d planeTransform) {
+        return shadow(light, planeTransform, this);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane with the general plane equation
+     * <tt>y = 0</tt> as if casting a shadow from a given light position/direction <tt>(lightX, lightY, lightZ, lightW)</tt>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * Before the shadow projection is applied, the plane is transformed via the specified <code>planeTransformation</code>.
+     * <p>
+     * If <code>lightW</code> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param lightX
+     *          the x-component of the light vector
+     * @param lightY
+     *          the y-component of the light vector
+     * @param lightZ
+     *          the z-component of the light vector
+     * @param lightW
+     *          the w-component of the light vector
+     * @param planeTransform
+     *          the transformation to transform the implied plane <tt>y = 0</tt> before applying the projection
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4d shadow(double lightX, double lightY, double lightZ, double lightW, Matrix4d planeTransform, Matrix4d dest) {
+        // compute plane equation by transforming (y = 0)
+        double a = planeTransform.m10;
+        double b = planeTransform.m11;
+        double c = planeTransform.m12;
+        double d = -a * planeTransform.m30 - b * planeTransform.m31 - c * planeTransform.m32;
+        return shadow(lightX, lightY, lightZ, lightW, a, b, c, d, dest);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane with the general plane equation
+     * <tt>y = 0</tt> as if casting a shadow from a given light position/direction <tt>(lightX, lightY, lightZ, lightW)</tt>.
+     * <p>
+     * Before the shadow projection is applied, the plane is transformed via the specified <code>planeTransformation</code>.
+     * <p>
+     * If <code>lightW</code> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param lightX
+     *          the x-component of the light vector
+     * @param lightY
+     *          the y-component of the light vector
+     * @param lightZ
+     *          the z-component of the light vector
+     * @param lightW
+     *          the w-component of the light vector
+     * @param planeTransform
+     *          the transformation to transform the implied plane <tt>y = 0</tt> before applying the projection
+     * @return this
+     */
+    public Matrix4d shadow(double lightX, double lightY, double lightZ, double lightW, Matrix4d planeTransform) {
+        return shadow(lightX, lightY, lightZ, lightW, planeTransform, this);
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Matrix4f.java
+++ b/GVRf/Framework/src/org/joml/Matrix4f.java
@@ -1,0 +1,7561 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Contains the definition of a 4x4 Matrix of floats, and associated functions to transform
+ * it. The matrix is column-major to match OpenGL's interpretation, and it looks like this:
+ * <p>
+ *      m00  m10  m20  m30<br>
+ *      m01  m11  m21  m31<br>
+ *      m02  m12  m22  m32<br>
+ *      m03  m13  m23  m33<br>
+ * 
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Matrix4f implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4f)}
+     * identifying the plane with equation <tt>x=-1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_NX = 0;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4f)}
+     * identifying the plane with equation <tt>x=1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_PX = 1;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4f)}
+     * identifying the plane with equation <tt>y=-1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_NY= 2;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4f)}
+     * identifying the plane with equation <tt>y=1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_PY = 3;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4f)}
+     * identifying the plane with equation <tt>z=-1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_NZ = 4;
+    /**
+     * Argument to the first parameter of {@link #frustumPlane(int, Vector4f)}
+     * identifying the plane with equation <tt>z=1</tt> when using the identity matrix.  
+     */
+    public static final int PLANE_PZ = 5;
+
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3f)}
+     * identifying the corner <tt>(-1, -1, -1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_NXNYNZ = 0;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3f)}
+     * identifying the corner <tt>(1, -1, -1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_PXNYNZ = 1;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3f)}
+     * identifying the corner <tt>(1, 1, -1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_PXPYNZ = 2;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3f)}
+     * identifying the corner <tt>(-1, 1, -1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_NXPYNZ = 3;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3f)}
+     * identifying the corner <tt>(1, -1, 1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_PXNYPZ = 4;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3f)}
+     * identifying the corner <tt>(-1, -1, 1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_NXNYPZ = 5;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3f)}
+     * identifying the corner <tt>(-1, 1, 1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_NXPYPZ = 6;
+    /**
+     * Argument to the first parameter of {@link #frustumCorner(int, Vector3f)}
+     * identifying the corner <tt>(1, 1, 1)</tt> when using the identity matrix.
+     */
+    public static final int CORNER_PXPYPZ = 7;
+
+    public float m00, m10, m20, m30;
+    public float m01, m11, m21, m31;
+    public float m02, m12, m22, m32;
+    public float m03, m13, m23, m33;
+
+    /**
+     * Create a new {@link Matrix4f} and set it to {@link #identity() identity}.
+     */
+    public Matrix4f() {
+        m00 = 1.0f;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = 1.0f;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = 1.0f;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+    }
+
+    /**
+     * Create a new {@link Matrix4f} by setting its uppper left 3x3 submatrix to the values of the given {@link Matrix3f}
+     * and the rest to identity.
+     * 
+     * @param mat
+     *          the {@link Matrix3f}
+     */
+    public Matrix4f(Matrix3f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m33 = 1.0f;
+    }
+
+    /**
+     * Create a new {@link Matrix4f} and make it a copy of the given matrix.
+     * 
+     * @param mat
+     *          the {@link Matrix4f} to copy the values from
+     */
+    public Matrix4f(Matrix4f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m03 = mat.m03;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m13 = mat.m13;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m23 = mat.m23;
+        m30 = mat.m30;
+        m31 = mat.m31;
+        m32 = mat.m32;
+        m33 = mat.m33;
+    }
+
+    /**
+     * Create a new {@link Matrix4f} and make it a copy of the given matrix.
+     * <p>
+     * Note that due to the given {@link Matrix4d} storing values in double-precision and the constructed {@link Matrix4f} storing them
+     * in single-precision, there is the possibility of losing precision.
+     * 
+     * @param mat
+     *          the {@link Matrix4d} to copy the values from
+     */
+    public Matrix4f(Matrix4d mat) {
+        m00 = (float) mat.m00;
+        m01 = (float) mat.m01;
+        m02 = (float) mat.m02;
+        m03 = (float) mat.m03;
+        m10 = (float) mat.m10;
+        m11 = (float) mat.m11;
+        m12 = (float) mat.m12;
+        m13 = (float) mat.m13;
+        m20 = (float) mat.m20;
+        m21 = (float) mat.m21;
+        m22 = (float) mat.m22;
+        m23 = (float) mat.m23;
+        m30 = (float) mat.m30;
+        m31 = (float) mat.m31;
+        m32 = (float) mat.m32;
+        m33 = (float) mat.m33;
+    }
+
+    /**
+     * Create a new 4x4 matrix using the supplied float values.
+     * 
+     * @param m00
+     *          the value of m00
+     * @param m01
+     *          the value of m01
+     * @param m02
+     *          the value of m02
+     * @param m03
+     *          the value of m03
+     * @param m10
+     *          the value of m10
+     * @param m11
+     *          the value of m11
+     * @param m12
+     *          the value of m12
+     * @param m13
+     *          the value of m13
+     * @param m20
+     *          the value of m20
+     * @param m21
+     *          the value of m21
+     * @param m22
+     *          the value of m22
+     * @param m23
+     *          the value of m23
+     * @param m30
+     *          the value of m30
+     * @param m31
+     *          the value of m31
+     * @param m32
+     *          the value of m32
+     * @param m33
+     *          the value of m33
+     */
+    public Matrix4f(float m00, float m01, float m02, float m03, 
+                    float m10, float m11, float m12, float m13, 
+                    float m20, float m21, float m22, float m23,
+                    float m30, float m31, float m32, float m33) {
+        this.m00 = m00;
+        this.m01 = m01;
+        this.m02 = m02;
+        this.m03 = m03;
+        this.m10 = m10;
+        this.m11 = m11;
+        this.m12 = m12;
+        this.m13 = m13;
+        this.m20 = m20;
+        this.m21 = m21;
+        this.m22 = m22;
+        this.m23 = m23;
+        this.m30 = m30;
+        this.m31 = m31;
+        this.m32 = m32;
+        this.m33 = m33;
+    }
+
+    /**
+     * Create a new {@link Matrix4f} by reading its 16 float components from the given {@link FloatBuffer}
+     * at the buffer's current position.
+     * <p>
+     * That FloatBuffer is expected to hold the values in column-major order.
+     * <p>
+     * The buffer's position will not be changed by this method.
+     * 
+     * @param buffer
+     *          the {@link FloatBuffer} to read the matrix values from
+     */
+    public Matrix4f(FloatBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.get(pos);
+        m01 = buffer.get(pos+1);
+        m02 = buffer.get(pos+2);
+        m03 = buffer.get(pos+3);
+        m10 = buffer.get(pos+4);
+        m11 = buffer.get(pos+5);
+        m12 = buffer.get(pos+6);
+        m13 = buffer.get(pos+7);
+        m20 = buffer.get(pos+8);
+        m21 = buffer.get(pos+9);
+        m22 = buffer.get(pos+10);
+        m23 = buffer.get(pos+11);
+        m30 = buffer.get(pos+12);
+        m31 = buffer.get(pos+13);
+        m32 = buffer.get(pos+14);
+        m33 = buffer.get(pos+15);
+    }
+
+    /**
+     * Reset this matrix to the identity.
+     * <p>
+     * Please note that if a call to {@link #identity()} is immediately followed by a call to:
+     * {@link #translate(float, float, float) translate}, 
+     * {@link #rotate(float, float, float, float) rotate},
+     * {@link #scale(float, float, float) scale},
+     * {@link #perspective(float, float, float, float) perspective},
+     * {@link #frustum(float, float, float, float, float, float) frustum},
+     * {@link #ortho(float, float, float, float, float, float) ortho},
+     * {@link #ortho2D(float, float, float, float) ortho2D},
+     * {@link #lookAt(float, float, float, float, float, float, float, float, float) lookAt},
+     * {@link #lookAlong(float, float, float, float, float, float) lookAlong},
+     * or any of their overloads, then the call to {@link #identity()} can be omitted and the subsequent call replaced with:
+     * {@link #translation(float, float, float) translation},
+     * {@link #rotation(float, float, float, float) rotation},
+     * {@link #scaling(float, float, float) scaling},
+     * {@link #setPerspective(float, float, float, float) setPerspective},
+     * {@link #setFrustum(float, float, float, float, float, float) setFrustum},
+     * {@link #setOrtho(float, float, float, float, float, float) setOrtho},
+     * {@link #setOrtho2D(float, float, float, float) setOrtho2D},
+     * {@link #setLookAt(float, float, float, float, float, float, float, float, float) setLookAt},
+     * {@link #setLookAlong(float, float, float, float, float, float) setLookAlong},
+     * or any of their overloads.
+     * 
+     * @return this
+     */
+    public Matrix4f identity() {
+        m00 = 1.0f;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = 1.0f;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = 1.0f;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Store the values of the given matrix <code>m</code> into <code>this</code> matrix.
+     * 
+     * @see #Matrix4f(Matrix4f)
+     * @see #get(Matrix4f)
+     * 
+     * @param m
+     *          the matrix to copy the values from
+     * @return this
+     */
+    public Matrix4f set(Matrix4f m) {
+        m00 = m.m00;
+        m01 = m.m01;
+        m02 = m.m02;
+        m03 = m.m03;
+        m10 = m.m10;
+        m11 = m.m11;
+        m12 = m.m12;
+        m13 = m.m13;
+        m20 = m.m20;
+        m21 = m.m21;
+        m22 = m.m22;
+        m23 = m.m23;
+        m30 = m.m30;
+        m31 = m.m31;
+        m32 = m.m32;
+        m33 = m.m33;
+        return this;
+    }
+
+    /**
+     * Store the values of the given matrix <code>m</code> into <code>this</code> matrix.
+     * <p>
+     * Note that due to the given matrix <code>m</code> storing values in double-precision and <code>this</code> matrix storing
+     * them in single-precision, there is the possibility to lose precision.
+     * 
+     * @see #Matrix4f(Matrix4d)
+     * @see #get(Matrix4d)
+     * 
+     * @param m
+     *          the matrix to copy the values from
+     * @return this
+     */
+    public Matrix4f set(Matrix4d m) {
+        m00 = (float) m.m00;
+        m01 = (float) m.m01;
+        m02 = (float) m.m02;
+        m03 = (float) m.m03;
+        m10 = (float) m.m10;
+        m11 = (float) m.m11;
+        m12 = (float) m.m12;
+        m13 = (float) m.m13;
+        m20 = (float) m.m20;
+        m21 = (float) m.m21;
+        m22 = (float) m.m22;
+        m23 = (float) m.m23;
+        m30 = (float) m.m30;
+        m31 = (float) m.m31;
+        m32 = (float) m.m32;
+        m33 = (float) m.m33;
+        return this;
+    }
+
+    /**
+     * Set the upper left 3x3 submatrix of this {@link Matrix4f} to the given {@link Matrix3f} 
+     * and the rest to identity.
+     * 
+     * @see #Matrix4f(Matrix3f)
+     * 
+     * @param mat
+     *          the {@link Matrix3f}
+     * @return this
+     */
+    public Matrix4f set(Matrix3f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m03 = 0.0f;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m13 = 0.0f;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link AxisAngle4f}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f}
+     * @return this
+     */
+    public Matrix4f set(AxisAngle4f axisAngle) {
+        float x = axisAngle.x;
+        float y = axisAngle.y;
+        float z = axisAngle.z;
+        double angle = axisAngle.angle;
+        double n = Math.sqrt(x*x + y*y + z*z);
+        n = 1/n;
+        x *= n;
+        y *= n;
+        z *= n;
+        double c = Math.cos(angle);
+        double s = Math.sin(angle);
+        double omc = 1.0 - c;
+        m00 = (float)(c + x*x*omc);
+        m11 = (float)(c + y*y*omc);
+        m22 = (float)(c + z*z*omc);
+        double tmp1 = x*y*omc;
+        double tmp2 = z*s;
+        m10 = (float)(tmp1 - tmp2);
+        m01 = (float)(tmp1 + tmp2);
+        tmp1 = x*z*omc;
+        tmp2 = y*s;
+        m20 = (float)(tmp1 + tmp2);
+        m02 = (float)(tmp1 - tmp2);
+        tmp1 = y*z*omc;
+        tmp2 = x*s;
+        m21 = (float)(tmp1 - tmp2);
+        m12 = (float)(tmp1 + tmp2);
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link AxisAngle4d}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d}
+     * @return this
+     */
+    public Matrix4f set(AxisAngle4d axisAngle) {
+        double x = axisAngle.x;
+        double y = axisAngle.y;
+        double z = axisAngle.z;
+        double angle = axisAngle.angle;
+        double n = Math.sqrt(x*x + y*y + z*z);
+        n = 1/n;
+        x *= n;
+        y *= n;
+        z *= n;
+        double c = Math.cos(angle);
+        double s = Math.sin(angle);
+        double omc = 1.0 - c;
+        m00 = (float)(c + x*x*omc);
+        m11 = (float)(c + y*y*omc);
+        m22 = (float)(c + z*z*omc);
+        double tmp1 = x*y*omc;
+        double tmp2 = z*s;
+        m10 = (float)(tmp1 - tmp2);
+        m01 = (float)(tmp1 + tmp2);
+        tmp1 = x*z*omc;
+        tmp2 = y*s;
+        m20 = (float)(tmp1 + tmp2);
+        m02 = (float)(tmp1 - tmp2);
+        tmp1 = y*z*omc;
+        tmp2 = x*s;
+        m21 = (float)(tmp1 - tmp2);
+        m12 = (float)(tmp1 + tmp2);
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link Quaternionf}.
+     * 
+     * @see Quaternionf#get(Matrix4f)
+     * 
+     * @param q
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix4f set(Quaternionf q) {
+        q.get(this);
+        return this;
+    }
+
+    /**
+     * Set this matrix to be equivalent to the rotation specified by the given {@link Quaterniond}.
+     * 
+     * @see Quaterniond#get(Matrix4f)
+     * 
+     * @param q
+     *          the {@link Quaterniond}
+     * @return this
+     */
+    public Matrix4f set(Quaterniond q) {
+        q.get(this);
+        return this;
+    }
+
+    /**
+     * Set the upper left 3x3 submatrix of this {@link Matrix4f} to that of the given {@link Matrix4f} 
+     * and the rest to identity.
+     * 
+     * @param mat
+     *          the {@link Matrix4f}
+     * @return this
+     */
+    public Matrix4f set3x3(Matrix4f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m03 = 0.0f;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m13 = 0.0f;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Multiply this matrix by the supplied <code>right</code> matrix and store the result in <code>this</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication
+     * @return this
+     */
+    public Matrix4f mul(Matrix4f right) {
+       return mul(right, this);
+    }
+
+    /**
+     * Multiply this matrix by the supplied <code>right</code> matrix and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication
+     * @param dest
+     *          the destination matrix, which will hold the result
+     * @return dest
+     */
+    public Matrix4f mul(Matrix4f right, Matrix4f dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02 + m30 * right.m03,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02 + m31 * right.m03,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02 + m32 * right.m03,
+                 m03 * right.m00 + m13 * right.m01 + m23 * right.m02 + m33 * right.m03,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12 + m30 * right.m13,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12 + m31 * right.m13,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12 + m32 * right.m13,
+                 m03 * right.m10 + m13 * right.m11 + m23 * right.m12 + m33 * right.m13,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22 + m30 * right.m23,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22 + m31 * right.m23,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22 + m32 * right.m23,
+                 m03 * right.m20 + m13 * right.m21 + m23 * right.m22 + m33 * right.m23,
+                 m00 * right.m30 + m10 * right.m31 + m20 * right.m32 + m30 * right.m33,
+                 m01 * right.m30 + m11 * right.m31 + m21 * right.m32 + m31 * right.m33,
+                 m02 * right.m30 + m12 * right.m31 + m22 * right.m32 + m32 * right.m33,
+                 m03 * right.m30 + m13 * right.m31 + m23 * right.m32 + m33 * right.m33);
+        return dest;
+    }
+
+    /**
+     * Multiply this matrix by the top 4x3 submatrix of the supplied <code>right</code> matrix and store the result in <code>this</code>.
+     * This method assumes that the last row of <code>right</code> is equal to <tt>(0, 0, 0, 1)</tt>.
+     * <p>
+     * This method can be used to speed up matrix multiplication if the <code>right</code> matrix only represents affine transformations, such as
+     * translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication (the last row is assumed to be <tt>(0, 0, 0, 1)</tt>)
+     * @return this
+     */
+    public Matrix4f mul4x3r(Matrix4f right) {
+       return mul4x3r(right, this);
+    }
+
+    /**
+     * Multiply this matrix by the top 4x3 submatrix of the supplied <code>right</code> matrix and store the result in <code>dest</code>.
+     * This method assumes that the last row of <code>right</code> is equal to <tt>(0, 0, 0, 1)</tt>.
+     * <p>
+     * This method can be used to speed up matrix multiplication if the <code>right</code> matrix only represents affine transformations, such as
+     * translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication (the last row is assumed to be <tt>(0, 0, 0, 1)</tt>)
+     * @param dest
+     *          the destination matrix, which will hold the result
+     * @return dest
+     */
+    public Matrix4f mul4x3r(Matrix4f right, Matrix4f dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02,
+                 m03 * right.m00 + m13 * right.m01 + m23 * right.m02,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12,
+                 m03 * right.m10 + m13 * right.m11 + m23 * right.m12,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22,
+                 m03 * right.m20 + m13 * right.m21 + m23 * right.m22,
+                 m00 * right.m30 + m10 * right.m31 + m20 * right.m32 + m30,
+                 m01 * right.m30 + m11 * right.m31 + m21 * right.m32 + m31,
+                 m02 * right.m30 + m12 * right.m31 + m22 * right.m32 + m32,
+                 m03 * right.m30 + m13 * right.m31 + m23 * right.m32 + m33);
+        return dest;
+    }
+
+    /**
+     * Multiply the top 4x3 submatrix of this matrix by the top 4x3 submatrix of the supplied <code>right</code> matrix and store the result in <code>this</code>.
+     * This method assumes that the last row of both <code>this</code> and <code>right</code> is equal to <tt>(0, 0, 0, 1)</tt>.
+     * <p>
+     * This method can be used to speed up matrix multiplication if both <code>this</code> and the <code>right</code> matrix only represent affine transformations,
+     * such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * This method will not modify either the last row of <code>this</code> or the last row of <code>right</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication (the last row is assumed to be <tt>(0, 0, 0, 1)</tt>)
+     * @return this
+     */
+    public Matrix4f mul4x3(Matrix4f right) {
+       return mul4x3(right, this);
+    }
+
+    /**
+     * Multiply the top 4x3 submatrix of this matrix by the top 4x3 submatrix of the supplied <code>right</code> matrix and store the result in <code>dest</code>.
+     * This method assumes that the last row of both <code>this</code> and <code>right</code> is equal to <tt>(0, 0, 0, 1)</tt>.
+     * <p>
+     * This method can be used to speed up matrix multiplication if both <code>this</code> and the <code>right</code> matrix only represent affine transformations,
+     * such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * This method will not modify either the last row of <code>this</code> or the last row of <code>right</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the <code>right</code> matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * transformation of the right matrix will be applied first!
+     *
+     * @param right
+     *          the right operand of the matrix multiplication (the last row is assumed to be <tt>(0, 0, 0, 1)</tt>)
+     * @param dest
+     *          the destination matrix, which will hold the result
+     * @return dest
+     */
+    public Matrix4f mul4x3(Matrix4f right, Matrix4f dest) {
+        dest.set(m00 * right.m00 + m10 * right.m01 + m20 * right.m02,
+                 m01 * right.m00 + m11 * right.m01 + m21 * right.m02,
+                 m02 * right.m00 + m12 * right.m01 + m22 * right.m02,
+                 m03,
+                 m00 * right.m10 + m10 * right.m11 + m20 * right.m12,
+                 m01 * right.m10 + m11 * right.m11 + m21 * right.m12,
+                 m02 * right.m10 + m12 * right.m11 + m22 * right.m12,
+                 m13,
+                 m00 * right.m20 + m10 * right.m21 + m20 * right.m22,
+                 m01 * right.m20 + m11 * right.m21 + m21 * right.m22,
+                 m02 * right.m20 + m12 * right.m21 + m22 * right.m22,
+                 m23,
+                 m00 * right.m30 + m10 * right.m31 + m20 * right.m32 + m30,
+                 m01 * right.m30 + m11 * right.m31 + m21 * right.m32 + m31,
+                 m02 * right.m30 + m12 * right.m31 + m22 * right.m32 + m32,
+                 m33);
+        return dest;
+    }
+
+    /**
+     * Component-wise add the upper 4x3 submatrices of <code>this</code> and <code>other</code>
+     * by first multiplying each component of <code>other</code>'s 4x3 submatrix by <code>otherFactor</code> and
+     * adding that result to <code>this</code>.
+     * <p>
+     * The matrix <code>other</code> will not be changed.
+     * 
+     * @param other
+     *          the other matrix 
+     * @param otherFactor
+     *          the factor to multiply each of the other matrix's 4x3 components
+     * @return this
+     */
+    public Matrix4f fma4x3(Matrix4f other, float otherFactor) {
+        return fma4x3(other, otherFactor, this);
+    }
+
+    /**
+     * Component-wise add the upper 4x3 submatrices of <code>this</code> and <code>other</code>
+     * by first multiplying each component of <code>other</code>'s 4x3 submatrix by <code>otherFactor</code>,
+     * adding that to <code>this</code> and storing the final result in <code>dest</code>.
+     * <p>
+     * The other components of <code>dest</code> will be set to the ones of <code>this</code>.
+     * <p>
+     * The matrices <code>this</code> and <code>other</code> will not be changed.
+     * 
+     * @param other
+     *          the other matrix 
+     * @param otherFactor
+     *          the factor to multiply each of the other matrix's 4x3 components
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f fma4x3(Matrix4f other, float otherFactor, Matrix4f dest) {
+        dest.m00 = m00 + other.m00 * otherFactor;
+        dest.m01 = m01 + other.m01 * otherFactor;
+        dest.m02 = m02 + other.m02 * otherFactor;
+        dest.m03 = m03;
+        dest.m10 = m10 + other.m10 * otherFactor;
+        dest.m11 = m11 + other.m11 * otherFactor;
+        dest.m12 = m12 + other.m12 * otherFactor;
+        dest.m13 = m13;
+        dest.m20 = m20 + other.m20 * otherFactor;
+        dest.m21 = m21 + other.m21 * otherFactor;
+        dest.m22 = m22 + other.m22 * otherFactor;
+        dest.m23 = m23;
+        dest.m30 = m30 + other.m30 * otherFactor;
+        dest.m31 = m31 + other.m31 * otherFactor;
+        dest.m32 = m32 + other.m32 * otherFactor;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise add <code>this</code> and <code>other</code>.
+     * 
+     * @param other
+     *          the other addend 
+     * @return this
+     */
+    public Matrix4f add(Matrix4f other) {
+        return add(other, this);
+    }
+
+    /**
+     * Component-wise add <code>this</code> and <code>other</code> and store the result in <code>dest</code>.
+     * 
+     * @param other
+     *          the other addend 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f add(Matrix4f other, Matrix4f dest) {
+        dest.m00 = m00 + other.m00;
+        dest.m01 = m01 + other.m01;
+        dest.m02 = m02 + other.m02;
+        dest.m03 = m03 + other.m03;
+        dest.m10 = m10 + other.m10;
+        dest.m11 = m11 + other.m11;
+        dest.m12 = m12 + other.m12;
+        dest.m13 = m13 + other.m13;
+        dest.m20 = m20 + other.m20;
+        dest.m21 = m21 + other.m21;
+        dest.m22 = m22 + other.m22;
+        dest.m23 = m23 + other.m23;
+        dest.m30 = m30 + other.m30;
+        dest.m31 = m31 + other.m31;
+        dest.m32 = m32 + other.m32;
+        dest.m33 = m33 + other.m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise subtract <code>subtrahend</code> from <code>this</code>.
+     * 
+     * @param subtrahend
+     *          the subtrahend
+     * @return this
+     */
+    public Matrix4f sub(Matrix4f subtrahend) {
+        return sub(subtrahend, this);
+    }
+
+    /**
+     * Component-wise subtract <code>subtrahend</code> from <code>this</code> and store the result in <code>dest</code>.
+     * 
+     * @param subtrahend
+     *          the subtrahend 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f sub(Matrix4f subtrahend, Matrix4f dest) {
+        dest.m00 = m00 - subtrahend.m00;
+        dest.m01 = m01 - subtrahend.m01;
+        dest.m02 = m02 - subtrahend.m02;
+        dest.m03 = m03 - subtrahend.m03;
+        dest.m10 = m10 - subtrahend.m10;
+        dest.m11 = m11 - subtrahend.m11;
+        dest.m12 = m12 - subtrahend.m12;
+        dest.m13 = m13 - subtrahend.m13;
+        dest.m20 = m20 - subtrahend.m20;
+        dest.m21 = m21 - subtrahend.m21;
+        dest.m22 = m22 - subtrahend.m22;
+        dest.m23 = m23 - subtrahend.m23;
+        dest.m30 = m30 - subtrahend.m30;
+        dest.m31 = m31 - subtrahend.m31;
+        dest.m32 = m32 - subtrahend.m32;
+        dest.m33 = m33 - subtrahend.m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise multiply <code>this</code> by <code>other</code>.
+     * 
+     * @param other
+     *          the other matrix
+     * @return this
+     */
+    public Matrix4f mulComponentWise(Matrix4f other) {
+        return mulComponentWise(other, this);
+    }
+
+    /**
+     * Component-wise multiply <code>this</code> by <code>other</code> and store the result in <code>dest</code>.
+     * 
+     * @param other
+     *          the other matrix
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f mulComponentWise(Matrix4f other, Matrix4f dest) {
+        dest.m00 = m00 * other.m00;
+        dest.m01 = m01 * other.m01;
+        dest.m02 = m02 * other.m02;
+        dest.m03 = m03 * other.m03;
+        dest.m10 = m10 * other.m10;
+        dest.m11 = m11 * other.m11;
+        dest.m12 = m12 * other.m12;
+        dest.m13 = m13 * other.m13;
+        dest.m20 = m20 * other.m20;
+        dest.m21 = m21 * other.m21;
+        dest.m22 = m22 * other.m22;
+        dest.m23 = m23 * other.m23;
+        dest.m30 = m30 * other.m30;
+        dest.m31 = m31 * other.m31;
+        dest.m32 = m32 * other.m32;
+        dest.m33 = m33 * other.m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise add the upper 4x3 submatrices of <code>this</code> and <code>other</code>.
+     * 
+     * @param other
+     *          the other addend 
+     * @return this
+     */
+    public Matrix4f add4x3(Matrix4f other) {
+        return add4x3(other, this);
+    }
+
+    /**
+     * Component-wise add the upper 4x3 submatrices of <code>this</code> and <code>other</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * The other components of <code>dest</code> will be set to the ones of <code>this</code>.
+     * 
+     * @param other
+     *          the other addend
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f add4x3(Matrix4f other, Matrix4f dest) {
+        dest.m00 = m00 + other.m00;
+        dest.m01 = m01 + other.m01;
+        dest.m02 = m02 + other.m02;
+        dest.m03 = m03;
+        dest.m10 = m10 + other.m10;
+        dest.m11 = m11 + other.m11;
+        dest.m12 = m12 + other.m12;
+        dest.m13 = m13;
+        dest.m20 = m20 + other.m20;
+        dest.m21 = m21 + other.m21;
+        dest.m22 = m22 + other.m22;
+        dest.m23 = m23;
+        dest.m30 = m30 + other.m30;
+        dest.m31 = m31 + other.m31;
+        dest.m32 = m32 + other.m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise subtract the upper 4x3 submatrices of <code>subtrahend</code> from <code>this</code>.
+     * 
+     * @param subtrahend
+     *          the subtrahend
+     * @return this
+     */
+    public Matrix4f sub4x3(Matrix4f subtrahend) {
+        return sub4x3(subtrahend, this);
+    }
+
+    /**
+     * Component-wise subtract the upper 4x3 submatrices of <code>subtrahend</code> from <code>this</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * The other components of <code>dest</code> will be set to the ones of <code>this</code>.
+     * 
+     * @param subtrahend
+     *          the subtrahend
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f sub4x3(Matrix4f subtrahend, Matrix4f dest) {
+        dest.m00 = m00 - subtrahend.m00;
+        dest.m01 = m01 - subtrahend.m01;
+        dest.m02 = m02 - subtrahend.m02;
+        dest.m03 = m03;
+        dest.m10 = m10 - subtrahend.m10;
+        dest.m11 = m11 - subtrahend.m11;
+        dest.m12 = m12 - subtrahend.m12;
+        dest.m13 = m13;
+        dest.m20 = m20 - subtrahend.m20;
+        dest.m21 = m21 - subtrahend.m21;
+        dest.m22 = m22 - subtrahend.m22;
+        dest.m23 = m23;
+        dest.m30 = m30 - subtrahend.m30;
+        dest.m31 = m31 - subtrahend.m31;
+        dest.m32 = m32 - subtrahend.m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Component-wise multiply the upper 4x3 submatrices of <code>this</code> by <code>other</code>.
+     * 
+     * @param other
+     *          the other matrix
+     * @return this
+     */
+    public Matrix4f mul4x3ComponentWise(Matrix4f other) {
+        return mul4x3ComponentWise(other, this);
+    }
+
+    /**
+     * Component-wise multiply the upper 4x3 submatrices of <code>this</code> by <code>other</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * The other components of <code>dest</code> will be set to the ones of <code>this</code>.
+     * 
+     * @param other
+     *          the other matrix
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f mul4x3ComponentWise(Matrix4f other, Matrix4f dest) {
+        dest.m00 = m00 * other.m00;
+        dest.m01 = m01 * other.m01;
+        dest.m02 = m02 * other.m02;
+        dest.m03 = m03;
+        dest.m10 = m10 * other.m10;
+        dest.m11 = m11 * other.m11;
+        dest.m12 = m12 * other.m12;
+        dest.m13 = m13;
+        dest.m20 = m20 * other.m20;
+        dest.m21 = m21 * other.m21;
+        dest.m22 = m22 * other.m22;
+        dest.m23 = m23;
+        dest.m30 = m30 * other.m30;
+        dest.m31 = m31 * other.m31;
+        dest.m32 = m32 * other.m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Set the values within this matrix to the supplied float values. The matrix will look like this:<br><br>
+     *
+     *  m00, m10, m20, m30<br>
+     *  m01, m11, m21, m31<br>
+     *  m02, m12, m22, m32<br>
+     *  m03, m13, m23, m33
+     * 
+     * @param m00
+     *          the new value of m00
+     * @param m01
+     *          the new value of m01
+     * @param m02
+     *          the new value of m02
+     * @param m03
+     *          the new value of m03
+     * @param m10
+     *          the new value of m10
+     * @param m11
+     *          the new value of m11
+     * @param m12
+     *          the new value of m12
+     * @param m13
+     *          the new value of m13
+     * @param m20
+     *          the new value of m20
+     * @param m21
+     *          the new value of m21
+     * @param m22
+     *          the new value of m22
+     * @param m23
+     *          the new value of m23
+     * @param m30
+     *          the new value of m30
+     * @param m31
+     *          the new value of m31
+     * @param m32
+     *          the new value of m32
+     * @param m33
+     *          the new value of m33
+     * @return this
+     */
+    public Matrix4f set(float m00, float m01, float m02, float m03,
+                        float m10, float m11, float m12, float m13,
+                        float m20, float m21, float m22, float m23, 
+                        float m30, float m31, float m32, float m33) {
+        this.m00 = m00;
+        this.m01 = m01;
+        this.m02 = m02;
+        this.m03 = m03;
+        this.m10 = m10;
+        this.m11 = m11;
+        this.m12 = m12;
+        this.m13 = m13;
+        this.m20 = m20;
+        this.m21 = m21;
+        this.m22 = m22;
+        this.m23 = m23;
+        this.m30 = m30;
+        this.m31 = m31;
+        this.m32 = m32;
+        this.m33 = m33;
+        return this;
+    }
+
+    /**
+     * Set the values in the matrix using a float array that contains the matrix elements in column-major order.
+     * <p>
+     * The results will look like this:<br><br>
+     * 
+     * 0, 4, 8, 12<br>
+     * 1, 5, 9, 13<br>
+     * 2, 6, 10, 14<br>
+     * 3, 7, 11, 15<br>
+     * 
+     * @see #set(float[])
+     * 
+     * @param m
+     *          the array to read the matrix values from
+     * @param off
+     *          the offset into the array
+     * @return this
+     */
+    public Matrix4f set(float m[], int off) {
+        m00 = m[off+0];
+        m01 = m[off+1];
+        m02 = m[off+2];
+        m03 = m[off+3];
+        m10 = m[off+4];
+        m11 = m[off+5];
+        m12 = m[off+6];
+        m13 = m[off+7];
+        m20 = m[off+8];
+        m21 = m[off+9];
+        m22 = m[off+10];
+        m23 = m[off+11];
+        m30 = m[off+12];
+        m31 = m[off+13];
+        m32 = m[off+14];
+        m33 = m[off+15];
+        return this;
+    }
+
+    /**
+     * Set the values in the matrix using a float array that contains the matrix elements in column-major order.
+     * <p>
+     * The results will look like this:<br><br>
+     * 
+     * 0, 4, 8, 12<br>
+     * 1, 5, 9, 13<br>
+     * 2, 6, 10, 14<br>
+     * 3, 7, 11, 15<br>
+     * 
+     * @see #set(float[], int)
+     * 
+     * @param m
+     *          the array to read the matrix values from
+     * @return this
+     */
+    public Matrix4f set(float m[]) {
+        return set(m, 0);
+    }
+
+    /**
+     * Set the values of this matrix by reading 16 float values from the given {@link FloatBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The FloatBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the FloatBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the FloatBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix4f set(FloatBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.get(pos);
+        m01 = buffer.get(pos+1);
+        m02 = buffer.get(pos+2);
+        m03 = buffer.get(pos+3);
+        m10 = buffer.get(pos+4);
+        m11 = buffer.get(pos+5);
+        m12 = buffer.get(pos+6);
+        m13 = buffer.get(pos+7);
+        m20 = buffer.get(pos+8);
+        m21 = buffer.get(pos+9);
+        m22 = buffer.get(pos+10);
+        m23 = buffer.get(pos+11);
+        m30 = buffer.get(pos+12);
+        m31 = buffer.get(pos+13);
+        m32 = buffer.get(pos+14);
+        m33 = buffer.get(pos+15);
+        return this;
+    }
+
+    /**
+     * Set the values of this matrix by reading 16 float values from the given {@link ByteBuffer} in column-major order,
+     * starting at its current position.
+     * <p>
+     * The ByteBuffer is expected to contain the values in column-major order.
+     * <p>
+     * The position of the ByteBuffer will not be changed by this method.
+     * 
+     * @param buffer
+     *              the ByteBuffer to read the matrix values from in column-major order
+     * @return this
+     */
+    public Matrix4f set(ByteBuffer buffer) {
+        int pos = buffer.position();
+        m00 = buffer.getFloat(pos);
+        m01 = buffer.getFloat(pos+4);
+        m02 = buffer.getFloat(pos+8);
+        m03 = buffer.getFloat(pos+12);
+        m10 = buffer.getFloat(pos+16);
+        m11 = buffer.getFloat(pos+20);
+        m12 = buffer.getFloat(pos+24);
+        m13 = buffer.getFloat(pos+28);
+        m20 = buffer.getFloat(pos+32);
+        m21 = buffer.getFloat(pos+36);
+        m22 = buffer.getFloat(pos+40);
+        m23 = buffer.getFloat(pos+44);
+        m30 = buffer.getFloat(pos+48);
+        m31 = buffer.getFloat(pos+52);
+        m32 = buffer.getFloat(pos+56);
+        m33 = buffer.getFloat(pos+60);
+        return this;
+    }
+
+    /**
+     * Return the determinant of this matrix.
+     * <p>
+     * If <code>this</code> matrix is only composed of affine transformations, such as translation, rotation, scaling and shearing,
+     * and thus its last row is equal to <tt>(0, 0, 0, 1)</tt>, then {@link #determinant4x3()} can be used instead of this method.
+     * 
+     * @see #determinant4x3()
+     * 
+     * @return the determinant
+     */
+    public float determinant() {
+        return (m00 * m11 - m01 * m10) * (m22 * m33 - m23 * m32)
+             + (m02 * m10 - m00 * m12) * (m21 * m33 - m23 * m31)
+             + (m00 * m13 - m03 * m10) * (m21 * m32 - m22 * m31)
+             + (m01 * m12 - m02 * m11) * (m20 * m33 - m23 * m30)
+             + (m03 * m11 - m01 * m13) * (m20 * m32 - m22 * m30)
+             + (m02 * m13 - m03 * m12) * (m20 * m31 - m21 * m30);
+    }
+
+    /**
+     * Return the determinant of the upper left 3x3 submatrix of this matrix.
+     * 
+     * @return the determinant
+     */
+    public float determinant3x3() {
+        return (m00 * m11 - m01 * m10) * m22
+             + (m02 * m10 - m00 * m12) * m21
+             + (m01 * m12 - m02 * m11) * m20;
+    }
+
+    /**
+     * Return the determinant of this matrix by assuming that its last row is equal to <tt>(0, 0, 0, 1)</tt>.
+     * 
+     * @return the determinant
+     */
+    public float determinant4x3() {
+        return (m00 * m11 - m01 * m10) * m22
+             + (m02 * m10 - m00 * m12) * m21
+             + (m01 * m12 - m02 * m11) * m20;
+    }
+
+    /**
+     * Invert this matrix and write the result into <code>dest</code>.
+     * <p>
+     * If <code>this</code> matrix is only composed of affine transformations, such as translation, rotation, scaling and shearing,
+     * and thus its last row is equal to <tt>(0, 0, 0, 1)</tt>, then {@link #invert4x3(Matrix4f)} can be used instead of this method.
+     * 
+     * @see #invert4x3(Matrix4f)
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f invert(Matrix4f dest) {
+        float a = m00 * m11 - m01 * m10;
+        float b = m00 * m12 - m02 * m10;
+        float c = m00 * m13 - m03 * m10;
+        float d = m01 * m12 - m02 * m11;
+        float e = m01 * m13 - m03 * m11;
+        float f = m02 * m13 - m03 * m12;
+        float g = m20 * m31 - m21 * m30;
+        float h = m20 * m32 - m22 * m30;
+        float i = m20 * m33 - m23 * m30;
+        float j = m21 * m32 - m22 * m31;
+        float k = m21 * m33 - m23 * m31;
+        float l = m22 * m33 - m23 * m32;
+        float det = a * l - b * k + c * j + d * i - e * h + f * g;
+        det = 1.0f / det;
+        dest.set(( m11 * l - m12 * k + m13 * j) * det,
+                 (-m01 * l + m02 * k - m03 * j) * det,
+                 ( m31 * f - m32 * e + m33 * d) * det,
+                 (-m21 * f + m22 * e - m23 * d) * det,
+                 (-m10 * l + m12 * i - m13 * h) * det,
+                 ( m00 * l - m02 * i + m03 * h) * det,
+                 (-m30 * f + m32 * c - m33 * b) * det,
+                 ( m20 * f - m22 * c + m23 * b) * det,
+                 ( m10 * k - m11 * i + m13 * g) * det,
+                 (-m00 * k + m01 * i - m03 * g) * det,
+                 ( m30 * e - m31 * c + m33 * a) * det,
+                 (-m20 * e + m21 * c - m23 * a) * det,
+                 (-m10 * j + m11 * h - m12 * g) * det,
+                 ( m00 * j - m01 * h + m02 * g) * det,
+                 (-m30 * d + m31 * b - m32 * a) * det,
+                 ( m20 * d - m21 * b + m22 * a) * det);
+        return dest;
+    }
+
+    /**
+     * Invert this matrix.
+     * <p>
+     * If <code>this</code> matrix is only composed of affine transformations, such as translation, rotation, scaling and shearing,
+     * and thus its last row is equal to <tt>(0, 0, 0, 1)</tt>, then {@link #invert4x3()} can be used instead of this method.
+     * 
+     * @see #invert4x3()
+     * 
+     * @return this
+     */
+    public Matrix4f invert() {
+        return invert(this);
+    }
+
+    /**
+     * Invert this matrix by assuming that its last row is equal to <tt>(0, 0, 0, 1)</tt> and write the result into <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f invert4x3(Matrix4f dest) {
+        float s = determinant4x3();
+        s = 1.0f / s;
+        float m10m22 = m10 * m22;
+        float m10m21 = m10 * m21;
+        float m10m02 = m10 * m02;
+        float m10m01 = m10 * m01;
+        float m11m22 = m11 * m22;
+        float m11m20 = m11 * m20;
+        float m11m02 = m11 * m02;
+        float m11m00 = m11 * m00;
+        float m12m21 = m12 * m21;
+        float m12m20 = m12 * m20;
+        float m12m01 = m12 * m01;
+        float m12m00 = m12 * m00;
+        float m20m02 = m20 * m02;
+        float m20m01 = m20 * m01;
+        float m21m02 = m21 * m02;
+        float m21m00 = m21 * m00;
+        float m22m01 = m22 * m01;
+        float m22m00 = m22 * m00;
+        dest.set((m11m22 - m12m21) * s,
+                 (m21m02 - m22m01) * s,
+                 (m12m01 - m11m02) * s,
+                 0.0f,
+                 (m12m20 - m10m22) * s,
+                 (m22m00 - m20m02) * s,
+                 (m10m02 - m12m00) * s,
+                 0.0f,
+                 (m10m21 - m11m20) * s,
+                 (m20m01 - m21m00) * s,
+                 (m11m00 - m10m01) * s,
+                 0.0f,
+                 (m10m22 * m31 - m10m21 * m32 + m11m20 * m32 - m11m22 * m30 + m12m21 * m30 - m12m20 * m31) * s,
+                 (m20m02 * m31 - m20m01 * m32 + m21m00 * m32 - m21m02 * m30 + m22m01 * m30 - m22m00 * m31) * s,
+                 (m11m02 * m30 - m12m01 * m30 + m12m00 * m31 - m10m02 * m31 + m10m01 * m32 - m11m00 * m32) * s,
+                 1.0f);
+        return dest;
+    }
+
+    /**
+     * Invert this matrix by assuming that its last row is equal to <tt>(0, 0, 0, 1)</tt>.
+     * 
+     * @return this
+     */
+    public Matrix4f invert4x3() {
+        return invert4x3(this);
+    }
+
+    /**
+     * Transpose this matrix and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix4f transpose(Matrix4f dest) {
+        dest.set(m00, m10, m20, m30,
+                 m01, m11, m21, m31,
+                 m02, m12, m22, m32,
+                 m03, m13, m23, m33);
+        return dest;
+    }
+
+    /**
+     * Transpose only the upper left 3x3 submatrix of this matrix and set the rest of the matrix elements to identity.
+     * 
+     * @return this
+     */
+    public Matrix4f transpose3x3() {
+        return transpose3x3(this);
+    }
+
+    /**
+     * Transpose only the upper left 3x3 submatrix of this matrix and store the result in <code>dest</code>.
+     * <p>
+     * All other matrix elements of <code>dest</code> will be set to identity.
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix4f transpose3x3(Matrix4f dest) {
+        dest.set(m00,  m10,  m20,  0.0f,
+                 m01,  m11,  m21,  0.0f,
+                 m02,  m12,  m22,  0.0f,
+                 0.0f, 0.0f, 0.0f, 1.0f);
+        return dest;
+    }
+
+    /**
+     * Transpose only the upper left 3x3 submatrix of this matrix and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3f transpose3x3(Matrix3f dest) {
+        dest.m00 = m00;
+        dest.m01 = m10;
+        dest.m02 = m20;
+        dest.m10 = m01;
+        dest.m11 = m11;
+        dest.m12 = m21;
+        dest.m20 = m02;
+        dest.m21 = m12;
+        dest.m22 = m22;
+        return dest;
+    }
+
+    /**
+     * Transpose this matrix.
+     * 
+     * @return this
+     */
+    public Matrix4f transpose() {
+        return transpose(this);
+    }
+
+    /**
+     * Set this matrix to be a simple translation matrix.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional translation.
+     * <p>
+     * In order to post-multiply a translation transformation directly to a
+     * matrix, use {@link #translate(float, float, float) translate()} instead.
+     * 
+     * @see #translate(float, float, float)
+     * 
+     * @param x
+     *          the offset to translate in x
+     * @param y
+     *          the offset to translate in y
+     * @param z
+     *          the offset to translate in z
+     * @return this
+     */
+    public Matrix4f translation(float x, float y, float z) {
+        m00 = 1.0f;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = 1.0f;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = 1.0f;
+        m23 = 0.0f;
+        m30 = x;
+        m31 = y;
+        m32 = z;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple translation matrix.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional translation.
+     * <p>
+     * In order to post-multiply a translation transformation directly to a
+     * matrix, use {@link #translate(Vector3f) translate()} instead.
+     * 
+     * @see #translate(float, float, float)
+     * 
+     * @param offset
+     *              the offsets in x, y and z to translate
+     * @return this
+     */
+    public Matrix4f translation(Vector3f offset) {
+        return translation(offset.x, offset.y, offset.z);
+    }
+
+    /**
+     * Set only the translation components of this matrix <tt>(m30, m31, m32)</tt> to the given values <tt>(x, y, z)</tt>.
+     * <p>
+     * Note that this will only work properly for orthogonal matrices (without any perspective).
+     * <p>
+     * To build a translation matrix instead, use {@link #translation(float, float, float)}.
+     * To apply a translation to another matrix, use {@link #translate(float, float, float)}.
+     * 
+     * @see #translation(float, float, float)
+     * @see #translate(float, float, float)
+     * 
+     * @param x
+     *          the offset to translate in x
+     * @param y
+     *          the offset to translate in y
+     * @param z
+     *          the offset to translate in z
+     * @return this
+     */
+    public Matrix4f setTranslation(float x, float y, float z) {
+        m30 = x;
+        m31 = y;
+        m32 = z;
+        return this;
+    }
+
+    /**
+     * Set only the translation components of this matrix <tt>(m30, m31, m32)</tt> to the values <tt>(xyz.x, xyz.y, xyz.z)</tt>.
+     * <p>
+     * Note that this will only work properly for orthogonal matrices (without any perspective).
+     * <p>
+     * To build a translation matrix instead, use {@link #translation(Vector3f)}.
+     * To apply a translation to another matrix, use {@link #translate(Vector3f)}.
+     * 
+     * @see #translation(Vector3f)
+     * @see #translate(Vector3f)
+     * 
+     * @param xyz
+     *          the units to translate in <tt>(x, y, z)</tt>
+     * @return this
+     */
+    public Matrix4f setTranslation(Vector3f xyz) {
+        m30 = xyz.x;
+        m31 = xyz.y;
+        m32 = xyz.z;
+        return this;
+    }
+
+    /**
+     * Get only the translation components of this matrix <tt>(m30, m31, m32)</tt> and store them in the given vector <code>xyz</code>.
+     * 
+     * @param dest
+     *          will hold the translation components of this matrix
+     * @return dest
+     */
+    public Vector3f getTranslation(Vector3f dest) {
+        dest.x = m30;
+        dest.y = m31;
+        dest.z = m32;
+        return dest;
+    }
+
+    /**
+     * Get the scaling factors of <code>this</code> matrix for the three base axes.
+     * 
+     * @param dest
+     *          will hold the scaling factors for <tt>x</tt>, <tt>y</tt> and <tt>z</tt>
+     * @return dest
+     */
+    public Vector3f getScale(Vector3f dest) {
+        dest.x = (float) Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02);
+        dest.y = (float) Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12);
+        dest.z = (float) Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22);
+        return dest;
+    }
+
+    /**
+     * Return a string representation of this matrix.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt>  0.000E0; -</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat("  0.000E0; -"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this matrix by formatting the matrix elements with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the matrix values with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return formatter.format(m00) + formatter.format(m10) + formatter.format(m20) + formatter.format(m30) + "\n" //$NON-NLS-1$
+             + formatter.format(m01) + formatter.format(m11) + formatter.format(m21) + formatter.format(m31) + "\n" //$NON-NLS-1$
+             + formatter.format(m02) + formatter.format(m12) + formatter.format(m22) + formatter.format(m32) + "\n" //$NON-NLS-1$
+             + formatter.format(m03) + formatter.format(m13) + formatter.format(m23) + formatter.format(m33) + "\n"; //$NON-NLS-1$
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store them into
+     * <code>dest</code>.
+     * <p>
+     * This is the reverse method of {@link #set(Matrix4f)} and allows to obtain
+     * intermediate calculation results when chaining multiple transformations.
+     * 
+     * @see #set(Matrix4f)
+     * 
+     * @param dest
+     *            the destination matrix
+     * @return the passed in destination
+     */
+    public Matrix4f get(Matrix4f dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store them into
+     * <code>dest</code>.
+     * <p>
+     * This is the reverse method of {@link #set(Matrix4d)} and allows to obtain
+     * intermediate calculation results when chaining multiple transformations.
+     * 
+     * @see #set(Matrix4d)
+     * 
+     * @param dest
+     *            the destination matrix
+     * @return the passed in destination
+     */
+    public Matrix4d get(Matrix4d dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of the upper left 3x3 submatrix of <code>this</code> matrix and store them into
+     * <code>dest</code>.
+     * 
+     * @param dest
+     *            the destination matrix
+     * @return the passed in destination
+     */
+    public Matrix3f get3x3(Matrix3f dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of the upper left 3x3 submatrix of <code>this</code> matrix and store them into
+     * <code>dest</code>.
+     * 
+     * @param dest
+     *            the destination matrix
+     * @return the passed in destination
+     */
+    public Matrix3d get3x3(Matrix3d dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the rotational component of <code>this</code> matrix and store the represented rotation
+     * into the given {@link AxisAngle4f}.
+     * 
+     * @see AxisAngle4f#set(Matrix4f)
+     * 
+     * @param dest
+     *          the destination {@link AxisAngle4f}
+     * @return the passed in destination
+     */
+    public AxisAngle4f getRotation(AxisAngle4f dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the rotational component of <code>this</code> matrix and store the represented rotation
+     * into the given {@link AxisAngle4d}.
+     * 
+     * @see AxisAngle4f#set(Matrix4d)
+     * 
+     * @param dest
+     *          the destination {@link AxisAngle4d}
+     * @return the passed in destination
+     */
+    public AxisAngle4d getRotation(AxisAngle4d dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaternionf}.
+     * <p>
+     * This method assumes that the first three column vectors of the upper left 3x3 submatrix are not normalized and
+     * thus allows to ignore any additional scaling factor that is applied to the matrix.
+     * 
+     * @see Quaternionf#setFromUnnormalized(Matrix4f)
+     * 
+     * @param dest
+     *          the destination {@link Quaternionf}
+     * @return the passed in destination
+     */
+    public Quaternionf getUnnormalizedRotation(Quaternionf dest) {
+        return dest.setFromUnnormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaternionf}.
+     * <p>
+     * This method assumes that the first three column vectors of the upper left 3x3 submatrix are normalized.
+     * 
+     * @see Quaternionf#setFromNormalized(Matrix4f)
+     * 
+     * @param dest
+     *          the destination {@link Quaternionf}
+     * @return the passed in destination
+     */
+    public Quaternionf getNormalizedRotation(Quaternionf dest) {
+        return dest.setFromNormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaterniond}.
+     * <p>
+     * This method assumes that the first three column vectors of the upper left 3x3 submatrix are not normalized and
+     * thus allows to ignore any additional scaling factor that is applied to the matrix.
+     * 
+     * @see Quaterniond#setFromUnnormalized(Matrix4f)
+     * 
+     * @param dest
+     *          the destination {@link Quaterniond}
+     * @return the passed in destination
+     */
+    public Quaterniond getUnnormalizedRotation(Quaterniond dest) {
+        return dest.setFromUnnormalized(this);
+    }
+
+    /**
+     * Get the current values of <code>this</code> matrix and store the represented rotation
+     * into the given {@link Quaterniond}.
+     * <p>
+     * This method assumes that the first three column vectors of the upper left 3x3 submatrix are normalized.
+     * 
+     * @see Quaterniond#setFromNormalized(Matrix4f)
+     * 
+     * @param dest
+     *          the destination {@link Quaterniond}
+     * @return the passed in destination
+     */
+    public Quaterniond getNormalizedRotation(Quaterniond dest) {
+        return dest.setFromNormalized(this);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the matrix is stored, use {@link #get(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, FloatBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(FloatBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * 
+     * @param index
+     *            the absolute position into the FloatBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(int index, FloatBuffer buffer) {
+        buffer.put(index,    m00);
+        buffer.put(index+1,  m01);
+        buffer.put(index+2,  m02);
+        buffer.put(index+3,  m03);
+        buffer.put(index+4,  m10);
+        buffer.put(index+5,  m11);
+        buffer.put(index+6,  m12);
+        buffer.put(index+7,  m13);
+        buffer.put(index+8,  m20);
+        buffer.put(index+9,  m21);
+        buffer.put(index+10, m22);
+        buffer.put(index+11, m23);
+        buffer.put(index+12, m30);
+        buffer.put(index+13, m31);
+        buffer.put(index+14, m32);
+        buffer.put(index+15, m33);
+        return buffer;
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the matrix is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, ByteBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this matrix in column-major order into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * 
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putFloat(index,    m00);
+        buffer.putFloat(index+4,  m01);
+        buffer.putFloat(index+8,  m02);
+        buffer.putFloat(index+12, m03);
+        buffer.putFloat(index+16, m10);
+        buffer.putFloat(index+20, m11);
+        buffer.putFloat(index+24, m12);
+        buffer.putFloat(index+28, m13);
+        buffer.putFloat(index+32, m20);
+        buffer.putFloat(index+36, m21);
+        buffer.putFloat(index+40, m22);
+        buffer.putFloat(index+44, m23);
+        buffer.putFloat(index+48, m30);
+        buffer.putFloat(index+52, m31);
+        buffer.putFloat(index+56, m32);
+        buffer.putFloat(index+60, m33);
+        return buffer;
+    }
+
+    /**
+     * Store the transpose of this matrix in column-major order into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the matrix is stored, use {@link #getTransposed(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #getTransposed(int, FloatBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public FloatBuffer getTransposed(FloatBuffer buffer) {
+        return getTransposed(buffer.position(), buffer);
+    }
+
+    /**
+     * Store the transpose of this matrix in column-major order into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * 
+     * @param index
+     *            the absolute position into the FloatBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public FloatBuffer getTransposed(int index, FloatBuffer buffer) {
+        buffer.put(index,    m00);
+        buffer.put(index+1,  m10);
+        buffer.put(index+2,  m20);
+        buffer.put(index+3,  m30);
+        buffer.put(index+4,  m01);
+        buffer.put(index+5,  m11);
+        buffer.put(index+6,  m21);
+        buffer.put(index+7,  m31);
+        buffer.put(index+8,  m02);
+        buffer.put(index+9,  m12);
+        buffer.put(index+10, m22);
+        buffer.put(index+11, m32);
+        buffer.put(index+12, m03);
+        buffer.put(index+13, m13);
+        buffer.put(index+14, m23);
+        buffer.put(index+15, m33);
+        return buffer;
+    }
+
+    /**
+     * Store the transpose of this matrix in column-major order into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the matrix is stored, use {@link #getTransposed(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #getTransposed(int, ByteBuffer)
+     * 
+     * @param buffer
+     *            will receive the values of this matrix in column-major order at its current position
+     * @return the passed in buffer
+     */
+    public ByteBuffer getTransposed(ByteBuffer buffer) {
+        return getTransposed(buffer.position(), buffer);
+    }
+
+    /**
+     * Store the transpose of this matrix in column-major order into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * 
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            will receive the values of this matrix in column-major order
+     * @return the passed in buffer
+     */
+    public ByteBuffer getTransposed(int index, ByteBuffer buffer) {
+        buffer.putFloat(index,    m00);
+        buffer.putFloat(index+4,  m10);
+        buffer.putFloat(index+8,  m20);
+        buffer.putFloat(index+12, m30);
+        buffer.putFloat(index+16, m01);
+        buffer.putFloat(index+20, m11);
+        buffer.putFloat(index+24, m21);
+        buffer.putFloat(index+28, m31);
+        buffer.putFloat(index+32, m02);
+        buffer.putFloat(index+36, m12);
+        buffer.putFloat(index+40, m22);
+        buffer.putFloat(index+44, m32);
+        buffer.putFloat(index+48, m03);
+        buffer.putFloat(index+52, m13);
+        buffer.putFloat(index+56, m23);
+        buffer.putFloat(index+60, m33);
+        return buffer;
+    }
+
+    /**
+     * Store this matrix into the supplied float array in column-major order at the given offset.
+     * 
+     * @param arr
+     *          the array to write the matrix values into
+     * @param offset
+     *          the offset into the array
+     * @return the passed in array
+     */
+    public float[] get(float[] arr, int offset) {
+        arr[offset+0] =  m00;
+        arr[offset+1] =  m01;
+        arr[offset+2] =  m02;
+        arr[offset+3] =  m03;
+        arr[offset+4] =  m10;
+        arr[offset+5] =  m11;
+        arr[offset+6] =  m12;
+        arr[offset+7] =  m13;
+        arr[offset+8] =  m20;
+        arr[offset+9] =  m21;
+        arr[offset+10] = m22;
+        arr[offset+11] = m23;
+        arr[offset+12] = m30;
+        arr[offset+13] = m31;
+        arr[offset+14] = m32;
+        arr[offset+15] = m33;
+        return arr;
+    }
+
+    /**
+     * Store this matrix into the supplied float array in column-major order.
+     * <p>
+     * In order to specify an explicit offset into the array, use the method {@link #get(float[], int)}.
+     * 
+     * @see #get(float[], int)
+     * 
+     * @param arr
+     *          the array to write the matrix values into
+     * @return the passed in array
+     */
+    public float[] get(float[] arr) {
+        arr[0] =  m00;
+        arr[1] =  m01;
+        arr[2] =  m02;
+        arr[3] =  m03;
+        arr[4] =  m10;
+        arr[5] =  m11;
+        arr[6] =  m12;
+        arr[7] =  m13;
+        arr[8] =  m20;
+        arr[9] =  m21;
+        arr[10] = m22;
+        arr[11] = m23;
+        arr[12] = m30;
+        arr[13] = m31;
+        arr[14] = m32;
+        arr[15] = m33;
+        return arr;
+    }
+
+    /**
+     * Update the given {@link FrustumCuller} with <code>this</code> matrix.
+     * <p>
+     * This will result in the frustum culler recalculating <code>this</code> matrix's frustum planes.
+     * 
+     * @see FrustumCuller#set(Matrix4f)
+     * 
+     * @param culler
+     *          the {@link FrustumCuller} to update
+     * @return the passed in culler
+     */
+    public FrustumCuller getFrustum(FrustumCuller culler) {
+        return culler.set(this);
+    }
+
+    /**
+     * Update the given {@link FrustumRayBuilder} with <code>this</code> matrix.
+     * <p>
+     * This will result in the recalculation of <code>this</code> matrix's frustum.
+     * 
+     * @see FrustumRayBuilder#set(Matrix4f)
+     * 
+     * @param frustumRayBuilder
+     *          the {@link FrustumRayBuilder} to update
+     * @return the passed in frustum ray builder
+     */
+    public FrustumRayBuilder getFrustum(FrustumRayBuilder frustumRayBuilder) {
+        return frustumRayBuilder.set(this);
+    }
+
+    /**
+     * Set all the values within this matrix to <code>0</code>.
+     * 
+     * @return this
+     */
+    public Matrix4f zero() {
+        m00 = 0.0f;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = 0.0f;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = 0.0f;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 0.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix, which scales all axes uniformly by the given factor.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional scaling.
+     * <p>
+     * In order to post-multiply a scaling transformation directly to a
+     * matrix, use {@link #scale(float) scale()} instead.
+     * 
+     * @see #scale(float)
+     * 
+     * @param factor
+     *             the scale factor in x, y and z
+     * @return this
+     */
+    public Matrix4f scaling(float factor) {
+        m00 = factor;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = factor;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = factor;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a simple scale matrix.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional scaling.
+     * <p>
+     * In order to post-multiply a scaling transformation directly to a
+     * matrix, use {@link #scale(float, float, float) scale()} instead.
+     * 
+     * @see #scale(float, float, float)
+     * 
+     * @param x
+     *             the scale in x
+     * @param y
+     *             the scale in y
+     * @param z
+     *             the scale in z
+     * @return this
+     */
+    public Matrix4f scaling(float x, float y, float z) {
+        m00 = x;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = y;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = z;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+    
+    /**
+     * Set this matrix to be a simple scale matrix which scales the base axes by <tt>xyz.x</tt>, <tt>xyz.y</tt> and <tt>xyz.z</tt> respectively.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional scaling.
+     * <p>
+     * In order to post-multiply a scaling transformation directly to a
+     * matrix use {@link #scale(Vector3f) scale()} instead.
+     * 
+     * @see #scale(Vector3f)
+     * 
+     * @param xyz
+     *             the scale in x, y and z respectively
+     * @return this
+     */
+    public Matrix4f scaling(Vector3f xyz) {
+        return scaling(xyz.x, xyz.y, xyz.z);
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to post-multiply a rotation transformation directly to a
+     * matrix, use {@link #rotate(float, Vector3f) rotate()} instead.
+     * 
+     * @see #rotate(float, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the axis to rotate about (needs to be {@link Vector3f#normalize() normalized})
+     * @return this
+     */
+    public Matrix4f rotation(float angle, Vector3f axis) {
+        return rotation(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation using the given {@link AxisAngle4f}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(AxisAngle4f) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     *
+     * @see #rotate(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @return this
+     */
+    public Matrix4f rotation(AxisAngle4f axisAngle) {
+        return rotation(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this matrix to a rotation matrix which rotates the given radians about a given axis.
+     * <p>
+     * The axis described by the three components needs to be a unit vector.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(float, float, float, float) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param x
+     *          the x-component of the rotation axis
+     * @param y
+     *          the y-component of the rotation axis
+     * @param z
+     *          the z-component of the rotation axis
+     * @return this
+     */
+    public Matrix4f rotation(float angle, float x, float y, float z) {
+        float cos = (float) Math.cos(angle);
+        float sin = (float) Math.sin(angle);
+        float C = 1.0f - cos;
+        float xy = x * y, xz = x * z, yz = y * z;
+        m00 = cos + x * x * C;
+        m10 = xy * C - z * sin;
+        m20 = xz * C + y * sin;
+        m30 = 0.0f;
+        m01 = xy * C + z * sin;
+        m11 = cos + y * y * C;
+        m21 = yz * C - x * sin;
+        m31 = 0.0f;
+        m02 = xz * C - y * sin;
+        m12 = yz * C + x * sin;
+        m22 = cos + z * z * C;
+        m32 = 0.0f;
+        m03 = 0.0f;
+        m13 = 0.0f;
+        m23 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the X axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4f rotationX(float ang) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        m00 = 1.0f;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = cos;
+        m12 = sin;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = -sin;
+        m22 = cos;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the Y axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4f rotationY(float ang) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        m00 = cos;
+        m01 = 0.0f;
+        m02 = -sin;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = 1.0f;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = sin;
+        m21 = 0.0f;
+        m22 = cos;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation transformation about the Z axis.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4f rotationZ(float ang) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        m00 = cos;
+        m01 = sin;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = -sin;
+        m11 = cos;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = 1.0f;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleX</code> radians about the X axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4f rotationXYZ(float angleX, float angleY, float angleZ) {
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinX = -sinX;
+        float m_sinY = -sinY;
+        float m_sinZ = -sinZ;
+
+        // rotateX
+        float nm11 = cosX;
+        float nm12 = sinX;
+        float nm21 = m_sinX;
+        float nm22 = cosX;
+        // rotateY
+        float nm00 = cosY;
+        float nm01 = nm21 * m_sinY;
+        float nm02 = nm22 * m_sinY;
+        m20 = sinY;
+        m21 = nm21 * cosY;
+        m22 = nm22 * cosY;
+        m23 = 0.0f;
+        // rotateZ
+        m00 = nm00 * cosZ;
+        m01 = nm01 * cosZ + nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m03 = 0.0f;
+        m10 = nm00 * m_sinZ;
+        m11 = nm01 * m_sinZ + nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        m13 = 0.0f;
+        // set last column to identity
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix4f rotationZYX(float angleZ, float angleY, float angleX) {
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float m_sinZ = -sinZ;
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+
+        // rotateZ
+        float nm00 = cosZ;
+        float nm01 = sinZ;
+        float nm10 = m_sinZ;
+        float nm11 = cosZ;
+        // rotateY
+        float nm20 = nm00 * sinY;
+        float nm21 = nm01 * sinY;
+        float nm22 = cosY;
+        m00 = nm00 * cosY;
+        m01 = nm01 * cosY;
+        m02 = m_sinY;
+        m03 = 0.0f;
+        // rotateX
+        m10 = nm10 * cosX + nm20 * sinX;
+        m11 = nm11 * cosX + nm21 * sinX;
+        m12 = nm22 * sinX;
+        m13 = 0.0f;
+        m20 = nm10 * m_sinX + nm20 * cosX;
+        m21 = nm11 * m_sinX + nm21 * cosX;
+        m22 = nm22 * cosX;
+        m23 = 0.0f;
+        // set last column to identity
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a rotation of <code>angleY</code> radians about the Y axis, followed by a rotation
+     * of <code>angleX</code> radians about the X axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4f rotationYXZ(float angleY, float angleX, float angleZ) {
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+        float m_sinZ = -sinZ;
+
+        // rotateY
+        float nm00 = cosY;
+        float nm02 = m_sinY;
+        float nm20 = sinY;
+        float nm22 = cosY;
+        // rotateX
+        float nm10 = nm20 * sinX;
+        float nm11 = cosX;
+        float nm12 = nm22 * sinX;
+        m20 = nm20 * cosX;
+        m21 = m_sinX;
+        m22 = nm22 * cosX;
+        m23 = 0.0f;
+        // rotateZ
+        m00 = nm00 * cosZ + nm10 * sinZ;
+        m01 = nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m03 = 0.0f;
+        m10 = nm00 * m_sinZ + nm10 * cosZ;
+        m11 = nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        m13 = 0.0f;
+        // set last column to identity
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set only the upper left 3x3 submatrix of this matrix to a rotation of <code>angleX</code> radians about the X axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4f setRotationXYZ(float angleX, float angleY, float angleZ) {
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinX = -sinX;
+        float m_sinY = -sinY;
+        float m_sinZ = -sinZ;
+
+        // rotateX
+        float nm11 = cosX;
+        float nm12 = sinX;
+        float nm21 = m_sinX;
+        float nm22 = cosX;
+        // rotateY
+        float nm00 = cosY;
+        float nm01 = nm21 * m_sinY;
+        float nm02 = nm22 * m_sinY;
+        m20 = sinY;
+        m21 = nm21 * cosY;
+        m22 = nm22 * cosY;
+        // rotateZ
+        m00 = nm00 * cosZ;
+        m01 = nm01 * cosZ + nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m10 = nm00 * m_sinZ;
+        m11 = nm01 * m_sinZ + nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return this;
+    }
+
+    /**
+     * Set only the upper left 3x3 submatrix of this matrix to a rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation
+     * of <code>angleY</code> radians about the Y axis and followed by a rotation of <code>angleX</code> radians about the X axis.
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix4f setRotationZYX(float angleZ, float angleY, float angleX) {
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float m_sinZ = -sinZ;
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+
+        // rotateZ
+        float nm00 = cosZ;
+        float nm01 = sinZ;
+        float nm10 = m_sinZ;
+        float nm11 = cosZ;
+        // rotateY
+        float nm20 = nm00 * sinY;
+        float nm21 = nm01 * sinY;
+        float nm22 = cosY;
+        m00 = nm00 * cosY;
+        m01 = nm01 * cosY;
+        m02 = m_sinY;
+        // rotateX
+        m10 = nm10 * cosX + nm20 * sinX;
+        m11 = nm11 * cosX + nm21 * sinX;
+        m12 = nm22 * sinX;
+        m20 = nm10 * m_sinX + nm20 * cosX;
+        m21 = nm11 * m_sinX + nm21 * cosX;
+        m22 = nm22 * cosX;
+        return this;
+    }
+
+    /**
+     * Set only the upper left 3x3 submatrix of this matrix to a rotation of <code>angleY</code> radians about the Y axis, followed by a rotation
+     * of <code>angleX</code> radians about the X axis and followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4f setRotationYXZ(float angleY, float angleX, float angleZ) {
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+        float m_sinZ = -sinZ;
+
+        // rotateY
+        float nm00 = cosY;
+        float nm02 = m_sinY;
+        float nm20 = sinY;
+        float nm22 = cosY;
+        // rotateX
+        float nm10 = nm20 * sinX;
+        float nm11 = cosX;
+        float nm12 = nm22 * sinX;
+        m20 = nm20 * cosX;
+        m21 = m_sinX;
+        m22 = nm22 * cosX;
+        // rotateZ
+        m00 = nm00 * cosZ + nm10 * sinZ;
+        m01 = nm11 * sinZ;
+        m02 = nm02 * cosZ + nm12 * sinZ;
+        m10 = nm00 * m_sinZ + nm10 * cosZ;
+        m11 = nm11 * cosZ;
+        m12 = nm02 * m_sinZ + nm12 * cosZ;
+        return this;
+    }
+
+    /**
+     * Set this matrix to the rotation transformation of the given {@link Quaternionf}.
+     * <p>
+     * The resulting matrix can be multiplied against another transformation
+     * matrix to obtain an additional rotation.
+     * <p>
+     * In order to apply the rotation transformation to an existing transformation,
+     * use {@link #rotate(Quaternionf) rotate()} instead.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix4f rotation(Quaternionf quat) {
+        float dqx = 2.0f * quat.x;
+        float dqy = 2.0f * quat.y;
+        float dqz = 2.0f * quat.z;
+        float q00 = dqx * quat.x;
+        float q11 = dqy * quat.y;
+        float q22 = dqz * quat.z;
+        float q01 = dqx * quat.y;
+        float q02 = dqx * quat.z;
+        float q03 = dqx * quat.w;
+        float q12 = dqy * quat.z;
+        float q13 = dqy * quat.w;
+        float q23 = dqz * quat.w;
+
+        m00 = 1.0f - q11 - q22;
+        m01 = q01 + q23;
+        m02 = q02 - q13;
+        m03 = 0.0f;
+        m10 = q01 - q23;
+        m11 = 1.0f - q22 - q00;
+        m12 = q12 + q03;
+        m13 = 0.0f;
+        m20 = q02 + q13;
+        m21 = q12 - q03;
+        m22 = 1.0f - q11 - q00;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+
+        return this;
+    }
+
+    /**
+     * Set <code>this</code> matrix to <tt>T * R * S</tt>, where <tt>T</tt> is a translation by the given <tt>(tx, ty, tz)</tt>,
+     * <tt>R</tt> is a rotation transformation specified by the quaternion <tt>(qx, qy, qz, qw)</tt>, and <tt>S</tt> is a scaling transformation
+     * which scales the three axes x, y and z by <tt>(sx, sy, sz)</tt>.
+     * <p>
+     * When transforming a vector by the resulting matrix the scaling transformation will be applied first, then the rotation and
+     * at last the translation.
+     * <p>
+     * This method is equivalent to calling: <tt>translation(tx, ty, tz).rotate(quat).scale(sx, sy, sz)</tt>
+     * 
+     * @see #translation(float, float, float)
+     * @see #rotate(Quaternionf)
+     * @see #scale(float, float, float)
+     * 
+     * @param tx
+     *          the number of units by which to translate the x-component
+     * @param ty
+     *          the number of units by which to translate the y-component
+     * @param tz
+     *          the number of units by which to translate the z-component
+     * @param qx
+     *          the x-coordinate of the vector part of the quaternion
+     * @param qy
+     *          the y-coordinate of the vector part of the quaternion
+     * @param qz
+     *          the z-coordinate of the vector part of the quaternion
+     * @param qw
+     *          the scalar part of the quaternion
+     * @param sx
+     *          the scaling factor for the x-axis
+     * @param sy
+     *          the scaling factor for the y-axis
+     * @param sz
+     *          the scaling factor for the z-axis
+     * @return this
+     */
+    public Matrix4f translationRotateScale(float tx, float ty, float tz, 
+                                           float qx, float qy, float qz, float qw, 
+                                           float sx, float sy, float sz) {
+        float dqx = 2.0f * qx, dqy = 2.0f * qy, dqz = 2.0f * qz;
+        float q00 = dqx * qx;
+        float q11 = dqy * qy;
+        float q22 = dqz * qz;
+        float q01 = dqx * qy;
+        float q02 = dqx * qz;
+        float q03 = dqx * qw;
+        float q12 = dqy * qz;
+        float q13 = dqy * qw;
+        float q23 = dqz * qw;
+        m00 = sx - (q11 + q22) * sx;
+        m01 = (q01 + q23) * sx;
+        m02 = (q02 - q13) * sx;
+        m03 = 0.0f;
+        m10 = (q01 - q23) * sy;
+        m11 = sy - (q22 + q00) * sy;
+        m12 = (q12 + q03) * sy;
+        m13 = 0.0f;
+        m20 = (q02 + q13) * sz;
+        m21 = (q12 - q03) * sz;
+        m22 = sz - (q11 + q00) * sz;
+        m23 = 0.0f;
+        m30 = tx;
+        m31 = ty;
+        m32 = tz;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set <code>this</code> matrix to <tt>T * R * S</tt>, where <tt>T</tt> is the given <code>translation</code>,
+     * <tt>R</tt> is a rotation transformation specified by the given quaternion, and <tt>S</tt> is a scaling transformation
+     * which scales the axes by <code>scale</code>.
+     * <p>
+     * When transforming a vector by the resulting matrix the scaling transformation will be applied first, then the rotation and
+     * at last the translation.
+     * <p>
+     * This method is equivalent to calling: <tt>translation(translation).rotate(quat).scale(scale)</tt>
+     * 
+     * @see #translation(Vector3f)
+     * @see #rotate(Quaternionf)
+     * 
+     * @param translation
+     *          the translation
+     * @param quat
+     *          the quaternion representing a rotation
+     * @param scale
+     *          the scaling factors
+     * @return this
+     */
+    public Matrix4f translationRotateScale(Vector3f translation, 
+                                           Quaternionf quat, 
+                                           Vector3f scale) {
+        return translationRotateScale(translation.x, translation.y, translation.z, quat.x, quat.y, quat.z, quat.w, scale.x, scale.y, scale.z);
+    }
+
+    /**
+     * Set <code>this</code> matrix to <tt>T * R</tt>, where <tt>T</tt> is a translation by the given <tt>(tx, ty, tz)</tt> and
+     * <tt>R</tt> is a rotation transformation specified by the given quaternion.
+     * <p>
+     * When transforming a vector by the resulting matrix the rotation transformation will be applied first and then the translation.
+     * <p>
+     * This method is equivalent to calling: <tt>translation(tx, ty, tz).rotate(quat)</tt>
+     * 
+     * @see #translation(float, float, float)
+     * @see #rotate(Quaternionf)
+     * 
+     * @param tx
+     *          the number of units by which to translate the x-component
+     * @param ty
+     *          the number of units by which to translate the y-component
+     * @param tz
+     *          the number of units by which to translate the z-component
+     * @param quat
+     *          the quaternion representing a rotation
+     * @return this
+     */
+    public Matrix4f translationRotate(float tx, float ty, float tz, Quaternionf quat) {
+        float dqx = 2.0f * quat.x, dqy = 2.0f * quat.y, dqz = 2.0f * quat.z;
+        float q00 = dqx * quat.x;
+        float q11 = dqy * quat.y;
+        float q22 = dqz * quat.z;
+        float q01 = dqx * quat.y;
+        float q02 = dqx * quat.z;
+        float q03 = dqx * quat.w;
+        float q12 = dqy * quat.z;
+        float q13 = dqy * quat.w;
+        float q23 = dqz * quat.w;
+        m00 = 1.0f - (q11 + q22);
+        m01 = q01 + q23;
+        m02 = q02 - q13;
+        m03 = 0.0f;
+        m10 = q01 - q23;
+        m11 = 1.0f - (q22 + q00);
+        m12 = q12 + q03;
+        m13 = 0.0f;
+        m20 = q02 + q13;
+        m21 = q12 - q03;
+        m22 = 1.0f - (q11 + q00);
+        m23 = 0.0f;
+        m30 = tx;
+        m31 = ty;
+        m32 = tz;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set the upper 3x3 matrix of this {@link Matrix4f} to the given {@link Matrix3f} and the rest to the identity.
+     * 
+     * @param mat
+     *          the 3x3 matrix
+     * @return this
+     */
+    public Matrix4f set3x3(Matrix3f mat) {
+        m00 = mat.m00;
+        m01 = mat.m01;
+        m02 = mat.m02;
+        m03 = 0.0f;
+        m10 = mat.m10;
+        m11 = mat.m11;
+        m12 = mat.m12;
+        m13 = 0.0f;
+        m20 = mat.m20;
+        m21 = mat.m21;
+        m22 = mat.m22;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix and store the result in that vector.
+     * 
+     * @see Vector4f#mul(Matrix4f)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector4f transform(Vector4f v) {
+        return v.mul(this);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix and store the result in <code>dest</code>.
+     * 
+     * @see Vector4f#mul(Matrix4f, Vector4f)
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will contain the result
+     * @return dest
+     */
+    public Vector4f transform(Vector4f v, Vector4f dest) {
+        return v.mul(this, dest);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix, perform perspective divide and store the result in that vector.
+     * 
+     * @see Vector4f#mulProject(Matrix4f)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector4f transformProject(Vector4f v) {
+        return v.mulProject(this);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix, perform perspective divide and store the result in <code>dest</code>.
+     * 
+     * @see Vector4f#mulProject(Matrix4f, Vector4f)
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will contain the result
+     * @return dest
+     */
+    public Vector4f transformProject(Vector4f v, Vector4f dest) {
+        return v.mulProject(this, dest);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix, perform perspective divide and store the result in that vector.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @see Vector3f#mulProject(Matrix4f)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector3f transformProject(Vector3f v) {
+        return v.mulProject(this);
+    }
+
+    /**
+     * Transform/multiply the given vector by this matrix, perform perspective divide and store the result in <code>dest</code>.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @see Vector3f#mulProject(Matrix4f, Vector3f)
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will contain the result
+     * @return dest
+     */
+    public Vector3f transformProject(Vector3f v, Vector3f dest) {
+        return v.mulProject(this, dest);
+    }
+
+    /**
+     * Transform/multiply the given 3D-vector, as if it was a 4D-vector with w=1, by
+     * this matrix and store the result in that vector.
+     * <p>
+     * The given 3D-vector is treated as a 4D-vector with its w-component being 1.0, so it
+     * will represent a point/location in 3D-space rather than a direction. This method is therefore
+     * not suited for perspective projection transformations as it will not save the
+     * <tt>w</tt> component of the transformed vector.
+     * For perspective projection use {@link #transform(Vector4f)}.
+     * <p>
+     * In order to store the result in another vector, use {@link #transformPoint(Vector3f, Vector3f)}.
+     * 
+     * @see #transformPoint(Vector3f, Vector3f)
+     * @see #transform(Vector4f)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector3f transformPoint(Vector3f v) {
+        v.set(m00 * v.x + m10 * v.y + m20 * v.z + m30,
+              m01 * v.x + m11 * v.y + m21 * v.z + m31,
+              m02 * v.x + m12 * v.y + m22 * v.z + m32);
+        return v;
+    }
+
+    /**
+     * Transform/multiply the given 3D-vector, as if it was a 4D-vector with w=1, by
+     * this matrix and store the result in <code>dest</code>.
+     * <p>
+     * The given 3D-vector is treated as a 4D-vector with its w-component being 1.0, so it
+     * will represent a point/location in 3D-space rather than a direction. This method is therefore
+     * not suited for perspective projection transformations as it will not save the
+     * <tt>w</tt> component of the transformed vector.
+     * For perspective projection use {@link #transform(Vector4f, Vector4f)}.
+     * <p>
+     * In order to store the result in the same vector, use {@link #transformPoint(Vector3f)}.
+     * 
+     * @see #transformPoint(Vector3f)
+     * @see #transform(Vector4f, Vector4f)
+     * 
+     * @param v
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f transformPoint(Vector3f v, Vector3f dest) {
+        dest.set(m00 * v.x + m10 * v.y + m20 * v.z + m30,
+                 m01 * v.x + m11 * v.y + m21 * v.z + m31,
+                 m02 * v.x + m12 * v.y + m22 * v.z + m32);
+        return dest;
+    }
+
+    /**
+     * Transform/multiply the given 3D-vector, as if it was a 4D-vector with w=0, by
+     * this matrix and store the result in that vector.
+     * <p>
+     * The given 3D-vector is treated as a 4D-vector with its w-component being <tt>0.0</tt>, so it
+     * will represent a direction in 3D-space rather than a point. This method will therefore
+     * not take the translation part of the matrix into account.
+     * <p>
+     * In order to store the result in another vector, use {@link #transformDirection(Vector3f, Vector3f)}.
+     * 
+     * @see #transformDirection(Vector3f, Vector3f)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @return v
+     */
+    public Vector3f transformDirection(Vector3f v) {
+        v.set(m00 * v.x + m10 * v.y + m20 * v.z,
+              m01 * v.x + m11 * v.y + m21 * v.z,
+              m02 * v.x + m12 * v.y + m22 * v.z);
+        return v;
+    }
+
+    /**
+     * Transform/multiply the given 3D-vector, as if it was a 4D-vector with w=0, by
+     * this matrix and store the result in <code>dest</code>.
+     * <p>
+     * The given 3D-vector is treated as a 4D-vector with its w-component being <tt>0.0</tt>, so it
+     * will represent a direction in 3D-space rather than a point. This method will therefore
+     * not take the translation part of the matrix into account.
+     * <p>
+     * In order to store the result in the same vector, use {@link #transformDirection(Vector3f)}.
+     * 
+     * @see #transformDirection(Vector3f)
+     * 
+     * @param v
+     *          the vector to transform and to hold the final result
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f transformDirection(Vector3f v, Vector3f dest) {
+        dest.set(m00 * v.x + m10 * v.y + m20 * v.z,
+                 m01 * v.x + m11 * v.y + m21 * v.z,
+                 m02 * v.x + m12 * v.y + m22 * v.z);
+        return dest;
+    }
+
+    /**
+     * Apply scaling to the this matrix by scaling the base axes by the given <tt>xyz.x</tt>,
+     * <tt>xyz.y</tt> and <tt>xyz.z</tt> factors, respectively and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param xyz
+     *            the factors of the x, y and z component, respectively
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f scale(Vector3f xyz, Matrix4f dest) {
+        return scale(xyz.x, xyz.y, xyz.z, dest);
+    }
+
+    /**
+     * Apply scaling to this matrix by scaling the base axes by the given <tt>xyz.x</tt>,
+     * <tt>xyz.y</tt> and <tt>xyz.z</tt> factors, respectively.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * scaling will be applied first!
+     * 
+     * @param xyz
+     *            the factors of the x, y and z component, respectively
+     * @return this
+     */
+    public Matrix4f scale(Vector3f xyz) {
+        return scale(xyz.x, xyz.y, xyz.z, this);
+    }
+
+    /**
+     * Apply scaling to this matrix by uniformly scaling all base axes by the given <code>xyz</code> factor
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * scaling will be applied first!
+     * <p>
+     * Individual scaling of all three axes can be applied using {@link #scale(float, float, float, Matrix4f)}. 
+     * 
+     * @see #scale(float, float, float, Matrix4f)
+     * 
+     * @param xyz
+     *            the factor for all components
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f scale(float xyz, Matrix4f dest) {
+        return scale(xyz, xyz, xyz, dest);
+    }
+
+    /**
+     * Apply scaling to this matrix by uniformly scaling all base axes by the given <code>xyz</code> factor.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * scaling will be applied first!
+     * <p>
+     * Individual scaling of all three axes can be applied using {@link #scale(float, float, float)}. 
+     * 
+     * @see #scale(float, float, float)
+     * 
+     * @param xyz
+     *            the factor for all components
+     * @return this
+     */
+    public Matrix4f scale(float xyz) {
+        return scale(xyz, xyz, xyz);
+    }
+
+    /**
+     * Apply scaling to the this matrix by scaling the base axes by the given x,
+     * y and z factors and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>
+     * , the scaling will be applied first!
+     * 
+     * @param x
+     *            the factor of the x component
+     * @param y
+     *            the factor of the y component
+     * @param z
+     *            the factor of the z component
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f scale(float x, float y, float z, Matrix4f dest) {
+        // scale matrix elements:
+        // m00 = x, m11 = y, m22 = z
+        // m33 = 1
+        // all others = 0
+        dest.m00 = m00 * x;
+        dest.m01 = m01 * x;
+        dest.m02 = m02 * x;
+        dest.m03 = m03 * x;
+        dest.m10 = m10 * y;
+        dest.m11 = m11 * y;
+        dest.m12 = m12 * y;
+        dest.m13 = m13 * y;
+        dest.m20 = m20 * z;
+        dest.m21 = m21 * z;
+        dest.m22 = m22 * z;
+        dest.m23 = m23 * z;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply scaling to this matrix by scaling the base axes by the given x,
+     * y and z factors.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the scaling matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * scaling will be applied first!
+     * 
+     * @param x
+     *            the factor of the x component
+     * @param y
+     *            the factor of the y component
+     * @param z
+     *            the factor of the z component
+     * @return this
+     */
+    public Matrix4f scale(float x, float y, float z) {
+        return scale(x, y, z, this);
+    }
+
+    /**
+     * Apply rotation about the X axis to this matrix by rotating the given amount of radians 
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotateX(float ang, Matrix4f dest) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        float rm11 = cos;
+        float rm12 = sin;
+        float rm21 = -sin;
+        float rm22 = cos;
+
+        // add temporaries for dependent values
+        float nm10 = m10 * rm11 + m20 * rm12;
+        float nm11 = m11 * rm11 + m21 * rm12;
+        float nm12 = m12 * rm11 + m22 * rm12;
+        float nm13 = m13 * rm11 + m23 * rm12;
+        // set non-dependent values directly
+        dest.m20 = m10 * rm21 + m20 * rm22;
+        dest.m21 = m11 * rm21 + m21 * rm22;
+        dest.m22 = m12 * rm21 + m22 * rm22;
+        dest.m23 = m13 * rm21 + m23 * rm22;
+        // set other values
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m00 = m00;
+        dest.m01 = m01;
+        dest.m02 = m02;
+        dest.m03 = m03;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the X axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4f rotateX(float ang) {
+        return rotateX(ang, this);
+    }
+
+    /**
+     * Apply rotation about the Y axis to this matrix by rotating the given amount of radians 
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotateY(float ang, Matrix4f dest) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        float rm00 = cos;
+        float rm02 = -sin;
+        float rm20 = sin;
+        float rm22 = cos;
+
+        // add temporaries for dependent values
+        float nm00 = m00 * rm00 + m20 * rm02;
+        float nm01 = m01 * rm00 + m21 * rm02;
+        float nm02 = m02 * rm00 + m22 * rm02;
+        float nm03 = m03 * rm00 + m23 * rm02;
+        // set non-dependent values directly
+        dest.m20 = m00 * rm20 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m23 * rm22;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = m10;
+        dest.m11 = m11;
+        dest.m12 = m12;
+        dest.m13 = m13;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the Y axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4f rotateY(float ang) {
+        return rotateY(ang, this);
+    }
+
+    /**
+     * Apply rotation about the Z axis to this matrix by rotating the given amount of radians 
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotateZ(float ang, Matrix4f dest) {
+        float cos = (float) Math.cos(ang);
+        float sin = (float) Math.sin(ang);
+        float rm00 = cos;
+        float rm01 = sin;
+        float rm10 = -sin;
+        float rm11 = cos;
+
+        // add temporaries for dependent values
+        float nm00 = m00 * rm00 + m10 * rm01;
+        float nm01 = m01 * rm00 + m11 * rm01;
+        float nm02 = m02 * rm00 + m12 * rm01;
+        float nm03 = m03 * rm00 + m13 * rm01;
+        // set non-dependent values directly
+        dest.m10 = m00 * rm10 + m10 * rm11;
+        dest.m11 = m01 * rm10 + m11 * rm11;
+        dest.m12 = m02 * rm10 + m12 * rm11;
+        dest.m13 = m03 * rm10 + m13 * rm11;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m20 = m20;
+        dest.m21 = m21;
+        dest.m22 = m22;
+        dest.m23 = m23;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation about the Z axis to this matrix by rotating the given amount of radians.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">http://en.wikipedia.org</a>
+     * 
+     * @param ang
+     *            the angle in radians
+     * @return this
+     */
+    public Matrix4f rotateZ(float ang) {
+        return rotateZ(ang, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4f rotateXYZ(float angleX, float angleY, float angleZ) {
+        return rotateXYZ(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX, dest).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotateXYZ(float angleX, float angleY, float angleZ, Matrix4f dest) {
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinX = -sinX;
+        float m_sinY = -sinY;
+        float m_sinZ = -sinZ;
+
+        // rotateX
+        float nm10 = m10 * cosX + m20 * sinX;
+        float nm11 = m11 * cosX + m21 * sinX;
+        float nm12 = m12 * cosX + m22 * sinX;
+        float nm13 = m13 * cosX + m23 * sinX;
+        float nm20 = m10 * m_sinX + m20 * cosX;
+        float nm21 = m11 * m_sinX + m21 * cosX;
+        float nm22 = m12 * m_sinX + m22 * cosX;
+        float nm23 = m13 * m_sinX + m23 * cosX;
+        // rotateY
+        float nm00 = m00 * cosY + nm20 * m_sinY;
+        float nm01 = m01 * cosY + nm21 * m_sinY;
+        float nm02 = m02 * cosY + nm22 * m_sinY;
+        float nm03 = m03 * cosY + nm23 * m_sinY;
+        dest.m20 = m00 * sinY + nm20 * cosY;
+        dest.m21 = m01 * sinY + nm21 * cosY;
+        dest.m22 = m02 * sinY + nm22 * cosY;
+        dest.m23 = m03 * sinY + nm23 * cosY;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m03 = nm03 * cosZ + nm13 * sinZ;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        dest.m13 = nm03 * m_sinZ + nm13 * cosZ;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4f rotateXYZ4x3(float angleX, float angleY, float angleZ) {
+        return rotateXYZ4x3(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleX</code> radians about the X axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotateXYZ4x3(float angleX, float angleY, float angleZ, Matrix4f dest) {
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinX = -sinX;
+        float m_sinY = -sinY;
+        float m_sinZ = -sinZ;
+
+        // rotateX
+        float nm10 = m10 * cosX + m20 * sinX;
+        float nm11 = m11 * cosX + m21 * sinX;
+        float nm12 = m12 * cosX + m22 * sinX;
+        float nm20 = m10 * m_sinX + m20 * cosX;
+        float nm21 = m11 * m_sinX + m21 * cosX;
+        float nm22 = m12 * m_sinX + m22 * cosX;
+        // rotateY
+        float nm00 = m00 * cosY + nm20 * m_sinY;
+        float nm01 = m01 * cosY + nm21 * m_sinY;
+        float nm02 = m02 * cosY + nm22 * m_sinY;
+        dest.m20 = m00 * sinY + nm20 * cosY;
+        dest.m21 = m01 * sinY + nm21 * cosY;
+        dest.m22 = m02 * sinY + nm22 * cosY;
+        dest.m23 = 0.0f;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m03 = 0.0f;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        dest.m13 = 0.0f;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix4f rotateZYX(float angleZ, float angleY, float angleX) {
+        return rotateZYX(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ, dest).rotateY(angleY).rotateX(angleX)</tt>
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotateZYX(float angleZ, float angleY, float angleX, Matrix4f dest) {
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float m_sinZ = -sinZ;
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+
+        // rotateZ
+        float nm00 = m00 * cosZ + m10 * sinZ;
+        float nm01 = m01 * cosZ + m11 * sinZ;
+        float nm02 = m02 * cosZ + m12 * sinZ;
+        float nm03 = m03 * cosZ + m13 * sinZ;
+        float nm10 = m00 * m_sinZ + m10 * cosZ;
+        float nm11 = m01 * m_sinZ + m11 * cosZ;
+        float nm12 = m02 * m_sinZ + m12 * cosZ;
+        float nm13 = m03 * m_sinZ + m13 * cosZ;
+        // rotateY
+        float nm20 = nm00 * sinY + m20 * cosY;
+        float nm21 = nm01 * sinY + m21 * cosY;
+        float nm22 = nm02 * sinY + m22 * cosY;
+        float nm23 = nm03 * sinY + m23 * cosY;
+        dest.m00 = nm00 * cosY + m20 * m_sinY;
+        dest.m01 = nm01 * cosY + m21 * m_sinY;
+        dest.m02 = nm02 * cosY + m22 * m_sinY;
+        dest.m03 = nm03 * cosY + m23 * m_sinY;
+        // rotateX
+        dest.m10 = nm10 * cosX + nm20 * sinX;
+        dest.m11 = nm11 * cosX + nm21 * sinX;
+        dest.m12 = nm12 * cosX + nm22 * sinX;
+        dest.m13 = nm13 * cosX + nm23 * sinX;
+        dest.m20 = nm10 * m_sinX + nm20 * cosX;
+        dest.m21 = nm11 * m_sinX + nm21 * cosX;
+        dest.m22 = nm12 * m_sinX + nm22 * cosX;
+        dest.m23 = nm13 * m_sinX + nm23 * cosX;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @return this
+     */
+    public Matrix4f rotateZYX4x3(float angleZ, float angleY, float angleX) {
+        return rotateZYX4x3(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleZ</code> radians about the Z axis, followed by a rotation of <code>angleY</code> radians about the Y axis and
+     * followed by a rotation of <code>angleX</code> radians about the X axis and store the result in <code>dest</code>.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotateZYX4x3(float angleZ, float angleY, float angleX, Matrix4f dest) {
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float m_sinZ = -sinZ;
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+
+        // rotateZ
+        float nm00 = m00 * cosZ + m10 * sinZ;
+        float nm01 = m01 * cosZ + m11 * sinZ;
+        float nm02 = m02 * cosZ + m12 * sinZ;
+        float nm10 = m00 * m_sinZ + m10 * cosZ;
+        float nm11 = m01 * m_sinZ + m11 * cosZ;
+        float nm12 = m02 * m_sinZ + m12 * cosZ;
+        // rotateY
+        float nm20 = nm00 * sinY + m20 * cosY;
+        float nm21 = nm01 * sinY + m21 * cosY;
+        float nm22 = nm02 * sinY + m22 * cosY;
+        dest.m00 = nm00 * cosY + m20 * m_sinY;
+        dest.m01 = nm01 * cosY + m21 * m_sinY;
+        dest.m02 = nm02 * cosY + m22 * m_sinY;
+        dest.m03 = 0.0f;
+        // rotateX
+        dest.m10 = nm10 * cosX + nm20 * sinX;
+        dest.m11 = nm11 * cosX + nm21 * sinX;
+        dest.m12 = nm12 * cosX + nm22 * sinX;
+        dest.m13 = 0.0f;
+        dest.m20 = nm10 * m_sinX + nm20 * cosX;
+        dest.m21 = nm11 * m_sinX + nm21 * cosX;
+        dest.m22 = nm12 * m_sinX + nm22 * cosX;
+        dest.m23 = 0.0f;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleY</code> radians about the Y axis, followed by a rotation of <code>angleX</code> radians about the X axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4f rotateYXZ(float angleY, float angleX, float angleZ) {
+        return rotateYXZ(angleY, angleX, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleY</code> radians about the Y axis, followed by a rotation of <code>angleX</code> radians about the X axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * This method is equivalent to calling: <tt>rotateY(angleY, dest).rotateX(angleX).rotateZ(angleZ)</tt>
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotateYXZ(float angleY, float angleX, float angleZ, Matrix4f dest) {
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+        float m_sinZ = -sinZ;
+
+        // rotateY
+        float nm20 = m00 * sinY + m20 * cosY;
+        float nm21 = m01 * sinY + m21 * cosY;
+        float nm22 = m02 * sinY + m22 * cosY;
+        float nm23 = m03 * sinY + m23 * cosY;
+        float nm00 = m00 * cosY + m20 * m_sinY;
+        float nm01 = m01 * cosY + m21 * m_sinY;
+        float nm02 = m02 * cosY + m22 * m_sinY;
+        float nm03 = m03 * cosY + m23 * m_sinY;
+        // rotateX
+        float nm10 = m10 * cosX + nm20 * sinX;
+        float nm11 = m11 * cosX + nm21 * sinX;
+        float nm12 = m12 * cosX + nm22 * sinX;
+        float nm13 = m13 * cosX + nm23 * sinX;
+        dest.m20 = m10 * m_sinX + nm20 * cosX;
+        dest.m21 = m11 * m_sinX + nm21 * cosX;
+        dest.m22 = m12 * m_sinX + nm22 * cosX;
+        dest.m23 = m13 * m_sinX + nm23 * cosX;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m03 = nm03 * cosZ + nm13 * sinZ;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        dest.m13 = nm03 * m_sinZ + nm13 * cosZ;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation of <code>angleY</code> radians about the Y axis, followed by a rotation of <code>angleX</code> radians about the X axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @return this
+     */
+    public Matrix4f rotateYXZ4x3(float angleY, float angleX, float angleZ) {
+        return rotateYXZ4x3(angleY, angleX, angleZ, this);
+    }
+
+    /**
+     * Apply rotation of <code>angleY</code> radians about the Y axis, followed by a rotation of <code>angleX</code> radians about the X axis and
+     * followed by a rotation of <code>angleZ</code> radians about the Z axis and store the result in <code>dest</code>.
+     * <p>
+     * This method assumes that the last row of <code>this</code> is <tt>(0, 0, 0, 1)</tt> and can be used to speed up matrix multiplication if
+     * the matrix only represents affine transformations, such as translation, rotation, scaling and shearing (in any combination).
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * 
+     * @param angleY
+     *            the angle to rotate about Y
+     * @param angleX
+     *            the angle to rotate about X
+     * @param angleZ
+     *            the angle to rotate about Z
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotateYXZ4x3(float angleY, float angleX, float angleZ, Matrix4f dest) {
+        float cosY = (float) Math.cos(angleY);
+        float sinY = (float) Math.sin(angleY);
+        float cosX = (float) Math.cos(angleX);
+        float sinX = (float) Math.sin(angleX);
+        float cosZ = (float) Math.cos(angleZ);
+        float sinZ = (float) Math.sin(angleZ);
+        float m_sinY = -sinY;
+        float m_sinX = -sinX;
+        float m_sinZ = -sinZ;
+
+        // rotateY
+        float nm20 = m00 * sinY + m20 * cosY;
+        float nm21 = m01 * sinY + m21 * cosY;
+        float nm22 = m02 * sinY + m22 * cosY;
+        float nm00 = m00 * cosY + m20 * m_sinY;
+        float nm01 = m01 * cosY + m21 * m_sinY;
+        float nm02 = m02 * cosY + m22 * m_sinY;
+        // rotateX
+        float nm10 = m10 * cosX + nm20 * sinX;
+        float nm11 = m11 * cosX + nm21 * sinX;
+        float nm12 = m12 * cosX + nm22 * sinX;
+        dest.m20 = m10 * m_sinX + nm20 * cosX;
+        dest.m21 = m11 * m_sinX + nm21 * cosX;
+        dest.m22 = m12 * m_sinX + nm22 * cosX;
+        dest.m23 = 0.0f;
+        // rotateZ
+        dest.m00 = nm00 * cosZ + nm10 * sinZ;
+        dest.m01 = nm01 * cosZ + nm11 * sinZ;
+        dest.m02 = nm02 * cosZ + nm12 * sinZ;
+        dest.m03 = 0.0f;
+        dest.m10 = nm00 * m_sinZ + nm10 * cosZ;
+        dest.m11 = nm01 * m_sinZ + nm11 * cosZ;
+        dest.m12 = nm02 * m_sinZ + nm12 * cosZ;
+        dest.m13 = 0.0f;
+        // copy last column from 'this'
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+        return dest;
+    }
+
+    /**
+     * Apply rotation to this matrix by rotating the given amount of radians
+     * about the specified <tt>(x, y, z)</tt> axis and store the result in <code>dest</code>.
+     * <p>
+     * The axis described by the three components needs to be a unit vector.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation matrix without post-multiplying the rotation
+     * transformation, use {@link #rotation(float, float, float, float) rotation()}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(float, float, float, float)
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param x
+     *            the x component of the axis
+     * @param y
+     *            the y component of the axis
+     * @param z
+     *            the z component of the axis
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f rotate(float ang, float x, float y, float z, Matrix4f dest) {
+        float s = (float) Math.sin(ang);
+        float c = (float) Math.cos(ang);
+        float C = 1.0f - c;
+
+        // rotation matrix elements:
+        // m30, m31, m32, m03, m13, m23 = 0
+        // m33 = 1
+        float xx = x * x, xy = x * y, xz = x * z;
+        float yy = y * y, yz = y * z;
+        float zz = z * z;
+        float rm00 = xx * C + c;
+        float rm01 = xy * C + z * s;
+        float rm02 = xz * C - y * s;
+        float rm10 = xy * C - z * s;
+        float rm11 = yy * C + c;
+        float rm12 = yz * C + x * s;
+        float rm20 = xz * C + y * s;
+        float rm21 = yz * C - x * s;
+        float rm22 = zz * C + c;
+
+        // add temporaries for dependent values
+        float nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        float nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        float nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        float nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        float nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        float nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        float nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        float nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        // set non-dependent values directly
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        // set other values
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply rotation to this matrix by rotating the given amount of radians
+     * about the specified <tt>(x, y, z)</tt> axis.
+     * <p>
+     * The axis described by the three components needs to be a unit vector.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the rotation matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation matrix without post-multiplying the rotation
+     * transformation, use {@link #rotation(float, float, float, float) rotation()}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(float, float, float, float)
+     * 
+     * @param ang
+     *            the angle in radians
+     * @param x
+     *            the x component of the axis
+     * @param y
+     *            the y component of the axis
+     * @param z
+     *            the z component of the axis
+     * @return this
+     */
+    public Matrix4f rotate(float ang, float x, float y, float z) {
+        return rotate(ang, x, y, z, this);
+    }
+
+    /**
+     * Apply a translation to this matrix by translating by the given number of
+     * units in x, y and z.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>T</code> the translation
+     * matrix, then the new matrix will be <code>M * T</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>M * T * v</code>, the translation will be applied first!
+     * <p>
+     * In order to set the matrix to a translation transformation without post-multiplying
+     * it, use {@link #translation(Vector3f)}.
+     * 
+     * @see #translation(Vector3f)
+     * 
+     * @param offset
+     *          the number of units in x, y and z by which to translate
+     * @return this
+     */
+    public Matrix4f translate(Vector3f offset) {
+        return translate(offset.x, offset.y, offset.z);
+    }
+
+    /**
+     * Apply a translation to this matrix by translating by the given number of
+     * units in x, y and z and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>T</code> the translation
+     * matrix, then the new matrix will be <code>M * T</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>M * T * v</code>, the translation will be applied first!
+     * <p>
+     * In order to set the matrix to a translation transformation without post-multiplying
+     * it, use {@link #translation(Vector3f)}.
+     * 
+     * @see #translation(Vector3f)
+     * 
+     * @param offset
+     *          the number of units in x, y and z by which to translate
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f translate(Vector3f offset, Matrix4f dest) {
+        return translate(offset.x, offset.y, offset.z, dest);
+    }
+
+    /**
+     * Apply a translation to this matrix by translating by the given number of
+     * units in x, y and z and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>T</code> the translation
+     * matrix, then the new matrix will be <code>M * T</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>M * T * v</code>, the translation will be applied first!
+     * <p>
+     * In order to set the matrix to a translation transformation without post-multiplying
+     * it, use {@link #translation(float, float, float)}.
+     * 
+     * @see #translation(float, float, float)
+     * 
+     * @param x
+     *          the offset to translate in x
+     * @param y
+     *          the offset to translate in y
+     * @param z
+     *          the offset to translate in z
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f translate(float x, float y, float z, Matrix4f dest) {
+        // translation matrix elements:
+        // m00, m11, m22, m33 = 1
+        // m30 = x, m31 = y, m32 = z
+        // all others = 0
+        dest.m00 = m00;
+        dest.m01 = m01;
+        dest.m02 = m02;
+        dest.m03 = m03;
+        dest.m10 = m10;
+        dest.m11 = m11;
+        dest.m12 = m12;
+        dest.m13 = m13;
+        dest.m20 = m20;
+        dest.m21 = m21;
+        dest.m22 = m22;
+        dest.m23 = m23;
+        dest.m30 = m00 * x + m10 * y + m20 * z + m30;
+        dest.m31 = m01 * x + m11 * y + m21 * z + m31;
+        dest.m32 = m02 * x + m12 * y + m22 * z + m32;
+        dest.m33 = m03 * x + m13 * y + m23 * z + m33;
+        return dest;
+    }
+
+    /**
+     * Apply a translation to this matrix by translating by the given number of
+     * units in x, y and z.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>T</code> the translation
+     * matrix, then the new matrix will be <code>M * T</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>M * T * v</code>, the translation will be applied first!
+     * <p>
+     * In order to set the matrix to a translation transformation without post-multiplying
+     * it, use {@link #translation(float, float, float)}.
+     * 
+     * @see #translation(float, float, float)
+     * 
+     * @param x
+     *          the offset to translate in x
+     * @param y
+     *          the offset to translate in y
+     * @param z
+     *          the offset to translate in z
+     * @return this
+     */
+    public Matrix4f translate(float x, float y, float z) {
+        Matrix4f c = this;
+        // translation matrix elements:
+        // m00, m11, m22, m33 = 1
+        // m30 = x, m31 = y, m32 = z
+        // all others = 0
+        c.m30 = c.m00 * x + c.m10 * y + c.m20 * z + c.m30;
+        c.m31 = c.m01 * x + c.m11 * y + c.m21 * z + c.m31;
+        c.m32 = c.m02 * x + c.m12 * y + c.m22 * z + c.m32;
+        c.m33 = c.m03 * x + c.m13 * y + c.m23 * z + c.m33;
+        return this;
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeFloat(m00);
+        out.writeFloat(m01);
+        out.writeFloat(m02);
+        out.writeFloat(m03);
+        out.writeFloat(m10);
+        out.writeFloat(m11);
+        out.writeFloat(m12);
+        out.writeFloat(m13);
+        out.writeFloat(m20);
+        out.writeFloat(m21);
+        out.writeFloat(m22);
+        out.writeFloat(m23);
+        out.writeFloat(m30);
+        out.writeFloat(m31);
+        out.writeFloat(m32);
+        out.writeFloat(m33);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        m00 = in.readFloat();
+        m01 = in.readFloat();
+        m02 = in.readFloat();
+        m03 = in.readFloat();
+        m10 = in.readFloat();
+        m11 = in.readFloat();
+        m12 = in.readFloat();
+        m13 = in.readFloat();
+        m20 = in.readFloat();
+        m21 = in.readFloat();
+        m22 = in.readFloat();
+        m23 = in.readFloat();
+        m30 = in.readFloat();
+        m31 = in.readFloat();
+        m32 = in.readFloat();
+        m33 = in.readFloat();
+    }
+
+    /**
+     * Apply an orthographic projection transformation to this matrix and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to an orthographic projection without post-multiplying it,
+     * use {@link #setOrtho(float, float, float, float, float, float) setOrtho()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrtho(float, float, float, float, float, float)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f ortho(float left, float right, float bottom, float top, float zNear, float zFar, Matrix4f dest) {
+        // calculate right matrix elements
+        float rm00 = 2.0f / (right - left);
+        float rm11 = 2.0f / (top - bottom);
+        float rm22 = -2.0f / (zFar - zNear);
+        float rm30 = -(right + left) / (right - left);
+        float rm31 = -(top + bottom) / (top - bottom);
+        float rm32 = -(zFar + zNear) / (zFar - zNear);
+
+        // perform optimized multiplication
+        // compute the last column first, because other columns do not depend on it
+        dest.m30 = m00 * rm30 + m10 * rm31 + m20 * rm32 + m30;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m21 * rm32 + m31;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m22 * rm32 + m32;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m23 * rm32 + m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m20 = m20 * rm22;
+        dest.m21 = m21 * rm22;
+        dest.m22 = m22 * rm22;
+        dest.m23 = m23 * rm22;
+
+        return dest;
+    }
+
+    /**
+     * Apply an orthographic projection transformation to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to an orthographic projection without post-multiplying it,
+     * use {@link #setOrtho(float, float, float, float, float, float) setOrtho()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrtho(float, float, float, float, float, float)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4f ortho(float left, float right, float bottom, float top, float zNear, float zFar) {
+        return ortho(left, right, bottom, top, zNear, zFar, this);
+    }
+
+    /**
+     * Set this matrix to be an orthographic projection transformation.
+     * <p>
+     * In order to apply the orthographic projection to an already existing transformation,
+     * use {@link #ortho(float, float, float, float, float, float) ortho()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #ortho(float, float, float, float, float, float)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4f setOrtho(float left, float right, float bottom, float top, float zNear, float zFar) {
+        m00 = 2.0f / (right - left);
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = 2.0f / (top - bottom);
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = -2.0f / (zFar - zNear);
+        m23 = 0.0f;
+        m30 = -(right + left) / (right - left);
+        m31 = -(top + bottom) / (top - bottom);
+        m32 = -(zFar + zNear) / (zFar - zNear);
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Apply a symmetric orthographic projection transformation to this matrix and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling {@link #ortho(float, float, float, float, float, float, Matrix4f) ortho()} with
+     * <code>left=-width/2</code>, <code>right=+width/2</code>, <code>bottom=-height/2</code> and <code>top=+height/2</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a symmetric orthographic projection without post-multiplying it,
+     * use {@link #setOrthoSymmetric(float, float, float, float) setOrthoSymmetric()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrthoSymmetric(float, float, float, float)
+     * 
+     * @param width
+     *            the distance between the right and left frustum edges
+     * @param height
+     *            the distance between the top and bottom frustum edges
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f orthoSymmetric(float width, float height, float zNear, float zFar, Matrix4f dest) {
+        // calculate right matrix elements
+        float rm00 = 2.0f / width;
+        float rm11 = 2.0f / height;
+        float rm22 = -2.0f / (zFar - zNear);
+        float rm32 = -(zFar + zNear) / (zFar - zNear);
+
+        // perform optimized multiplication
+        // compute the last column first, because other columns do not depend on it
+        dest.m30 = m20 * rm32 + m30;
+        dest.m31 = m21 * rm32 + m31;
+        dest.m32 = m22 * rm32 + m32;
+        dest.m33 = m23 * rm32 + m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m20 = m20 * rm22;
+        dest.m21 = m21 * rm22;
+        dest.m22 = m22 * rm22;
+        dest.m23 = m23 * rm22;
+
+        return dest;
+    }
+
+    /**
+     * Apply a symmetric orthographic projection transformation to this matrix.
+     * <p>
+     * This method is equivalent to calling {@link #ortho(float, float, float, float, float, float) ortho()} with
+     * <code>left=-width/2</code>, <code>right=+width/2</code>, <code>bottom=-height/2</code> and <code>top=+height/2</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a symmetric orthographic projection without post-multiplying it,
+     * use {@link #setOrthoSymmetric(float, float, float, float) setOrthoSymmetric()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrthoSymmetric(float, float, float, float)
+     * 
+     * @param width
+     *            the distance between the right and left frustum edges
+     * @param height
+     *            the distance between the top and bottom frustum edges
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4f orthoSymmetric(float width, float height, float zNear, float zFar) {
+        return orthoSymmetric(width, height, zNear, zFar, this);
+    }
+
+    /**
+     * Set this matrix to be a symmetric orthographic projection transformation.
+     * <p>
+     * This method is equivalent to calling {@link #setOrtho(float, float, float, float, float, float) setOrtho()} with
+     * <code>left=-width/2</code>, <code>right=+width/2</code>, <code>bottom=-height/2</code> and <code>top=+height/2</code>.
+     * <p>
+     * In order to apply the symmetric orthographic projection to an already existing transformation,
+     * use {@link #orthoSymmetric(float, float, float, float) orthoSymmetric()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #orthoSymmetric(float, float, float, float)
+     * 
+     * @param width
+     *            the distance between the right and left frustum edges
+     * @param height
+     *            the distance between the top and bottom frustum edges
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4f setOrthoSymmetric(float width, float height, float zNear, float zFar) {
+        m00 = 2.0f / width;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = 2.0f / height;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = -2.0f / (zFar - zNear);
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = -(zFar + zNear) / (zFar - zNear);
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Apply an orthographic projection transformation to this matrix and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling {@link #ortho(float, float, float, float, float, float, Matrix4f) ortho()} with
+     * <code>zNear=-1</code> and <code>zFar=+1</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to an orthographic projection without post-multiplying it,
+     * use {@link #setOrtho2D(float, float, float, float) setOrtho()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #ortho(float, float, float, float, float, float, Matrix4f)
+     * @see #setOrtho2D(float, float, float, float)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f ortho2D(float left, float right, float bottom, float top, Matrix4f dest) {
+        // calculate right matrix elements
+        float rm00 = 2.0f / (right - left);
+        float rm11 = 2.0f / (top - bottom);
+        float rm30 = -(right + left) / (right - left);
+        float rm31 = -(top + bottom) / (top - bottom);
+
+        // perform optimized multiplication
+        // compute the last column first, because other columns do not depend on it
+        dest.m30 = m00 * rm30 + m10 * rm31 + m30;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m31;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m32;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m20 = -m20;
+        dest.m21 = -m21;
+        dest.m22 = -m22;
+        dest.m23 = -m23;
+
+        return dest;
+    }
+
+    /**
+     * Apply an orthographic projection transformation to this matrix.
+     * <p>
+     * This method is equivalent to calling {@link #ortho(float, float, float, float, float, float) ortho()} with
+     * <code>zNear=-1</code> and <code>zFar=+1</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>O</code> the orthographic projection matrix,
+     * then the new matrix will be <code>M * O</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * O * v</code>, the
+     * orthographic projection transformation will be applied first!
+     * <p>
+     * In order to set the matrix to an orthographic projection without post-multiplying it,
+     * use {@link #setOrtho2D(float, float, float, float) setOrtho2D()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #ortho(float, float, float, float, float, float)
+     * @see #setOrtho2D(float, float, float, float)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @return this
+     */
+    public Matrix4f ortho2D(float left, float right, float bottom, float top) {
+        return ortho2D(left, right, bottom, top, this);
+    }
+
+    /**
+     * Set this matrix to be an orthographic projection transformation.
+     * <p>
+     * This method is equivalent to calling {@link #setOrtho(float, float, float, float, float, float) setOrtho()} with
+     * <code>zNear=-1</code> and <code>zFar=+1</code>.
+     * <p>
+     * In order to apply the orthographic projection to an already existing transformation,
+     * use {@link #ortho2D(float, float, float, float) ortho2D()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#ortho">http://www.songho.ca</a>
+     * 
+     * @see #setOrtho(float, float, float, float, float, float)
+     * @see #ortho2D(float, float, float, float)
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @return this
+     */
+    public Matrix4f setOrtho2D(float left, float right, float bottom, float top) {
+        m00 = 2.0f / (right - left);
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = 2.0f / (top - bottom);
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = -1.0f;
+        m23 = 0.0f;
+        m30 = -(right + left) / (right - left);
+        m31 = -(top + bottom) / (top - bottom);
+        m32 = 0.0f;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(Vector3f, Vector3f, Vector3f) lookAt}
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(Vector3f, Vector3f) setLookAlong()}.
+     * 
+     * @see #lookAlong(float, float, float, float, float, float)
+     * @see #lookAt(Vector3f, Vector3f, Vector3f)
+     * @see #setLookAlong(Vector3f, Vector3f)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix4f lookAlong(Vector3f dir, Vector3f up) {
+        return lookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z, this);
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>
+     * and store the result in <code>dest</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(Vector3f, Vector3f, Vector3f) lookAt}
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(Vector3f, Vector3f) setLookAlong()}.
+     * 
+     * @see #lookAlong(float, float, float, float, float, float)
+     * @see #lookAt(Vector3f, Vector3f, Vector3f)
+     * @see #setLookAlong(Vector3f, Vector3f)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f lookAlong(Vector3f dir, Vector3f up, Matrix4f dest) {
+        return lookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>
+     * and store the result in <code>dest</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(float, float, float, float, float, float, float, float, float) lookAt()}
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(float, float, float, float, float, float) setLookAlong()}
+     * 
+     * @see #lookAt(float, float, float, float, float, float, float, float, float)
+     * @see #setLookAlong(float, float, float, float, float, float)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Matrix4f lookAlong(float dirX, float dirY, float dirZ,
+                              float upX, float upY, float upZ, Matrix4f dest) {
+        // Normalize direction
+        float invDirLength = 1.0f / (float) Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
+        float dirnX = dirX * invDirLength;
+        float dirnY = dirY * invDirLength;
+        float dirnZ = dirZ * invDirLength;
+        // right = direction x up
+        float rightX, rightY, rightZ;
+        rightX = dirnY * upZ - dirnZ * upY;
+        rightY = dirnZ * upX - dirnX * upZ;
+        rightZ = dirnX * upY - dirnY * upX;
+        // normalize right
+        float invRightLength = 1.0f / (float) Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        float upnX = rightY * dirnZ - rightZ * dirnY;
+        float upnY = rightZ * dirnX - rightX * dirnZ;
+        float upnZ = rightX * dirnY - rightY * dirnX;
+
+        // calculate right matrix elements
+        float rm00 = rightX;
+        float rm01 = upnX;
+        float rm02 = -dirnX;
+        float rm10 = rightY;
+        float rm11 = upnY;
+        float rm12 = -dirnY;
+        float rm20 = rightZ;
+        float rm21 = upnZ;
+        float rm22 = -dirnZ;
+
+        // perform optimized matrix multiplication
+        // introduce temporaries for dependent results
+        float nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        float nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        float nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        float nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        float nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        float nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        float nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        float nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        // set the rest of the matrix elements
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply a rotation transformation to this matrix to make <code>-z</code> point along <code>dir</code>. 
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookalong rotation matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>, the
+     * lookalong rotation transformation will be applied first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(float, float, float, float, float, float, float, float, float) lookAt()}
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to set the matrix to a lookalong transformation without post-multiplying it,
+     * use {@link #setLookAlong(float, float, float, float, float, float) setLookAlong()}
+     * 
+     * @see #lookAt(float, float, float, float, float, float, float, float, float)
+     * @see #setLookAlong(float, float, float, float, float, float)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix4f lookAlong(float dirX, float dirY, float dirZ,
+                              float upX, float upY, float upZ) {
+        return lookAlong(dirX, dirY, dirZ, upX, upY, upZ, this);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation to make <code>-z</code>
+     * point along <code>dir</code>.
+     * <p>
+     * This is equivalent to calling
+     * {@link #setLookAt(Vector3f, Vector3f, Vector3f) setLookAt()} 
+     * with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to apply the lookalong transformation to any previous existing transformation,
+     * use {@link #lookAlong(Vector3f, Vector3f)}.
+     * 
+     * @see #setLookAlong(Vector3f, Vector3f)
+     * @see #lookAlong(Vector3f, Vector3f)
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix4f setLookAlong(Vector3f dir, Vector3f up) {
+        return setLookAlong(dir.x, dir.y, dir.z, up.x, up.y, up.z);
+    }
+
+    /**
+     * Set this matrix to a rotation transformation to make <code>-z</code>
+     * point along <code>dir</code>.
+     * <p>
+     * This is equivalent to calling
+     * {@link #setLookAt(float, float, float, float, float, float, float, float, float)
+     * setLookAt()} with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * <p>
+     * In order to apply the lookalong transformation to any previous existing transformation,
+     * use {@link #lookAlong(float, float, float, float, float, float) lookAlong()}
+     * 
+     * @see #setLookAlong(float, float, float, float, float, float)
+     * @see #lookAlong(float, float, float, float, float, float)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix4f setLookAlong(float dirX, float dirY, float dirZ,
+                                 float upX, float upY, float upZ) {
+        // Normalize direction
+        float invDirLength = 1.0f / (float) Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
+        float dirnX = dirX * invDirLength;
+        float dirnY = dirY * invDirLength;
+        float dirnZ = dirZ * invDirLength;
+        // right = direction x up
+        float rightX, rightY, rightZ;
+        rightX = dirnY * upZ - dirnZ * upY;
+        rightY = dirnZ * upX - dirnX * upZ;
+        rightZ = dirnX * upY - dirnY * upX;
+        // normalize right
+        float invRightLength = 1.0f / (float) Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        float upnX = rightY * dirnZ - rightZ * dirnY;
+        float upnY = rightZ * dirnX - rightX * dirnZ;
+        float upnZ = rightX * dirnY - rightY * dirnX;
+
+        m00 = rightX;
+        m01 = upnX;
+        m02 = -dirnX;
+        m03 = 0.0f;
+        m10 = rightY;
+        m11 = upnY;
+        m12 = -dirnY;
+        m13 = 0.0f;
+        m20 = rightZ;
+        m21 = upnZ;
+        m22 = -dirnZ;
+        m23 = 0.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = 0.0f;
+        m33 = 1.0f;
+
+        return this;
+    }
+
+    /**
+     * Set this matrix to be a "lookat" transformation for a right-handed coordinate system, that aligns
+     * <code>-z</code> with <code>center - eye</code>.
+     * <p>
+     * In order to not make use of vectors to specify <code>eye</code>, <code>center</code> and <code>up</code> but use primitives,
+     * like in the GLU function, use {@link #setLookAt(float, float, float, float, float, float, float, float, float) setLookAt()}
+     * instead.
+     * <p>
+     * In order to apply the lookat transformation to a previous existing transformation,
+     * use {@link #lookAt(Vector3f, Vector3f, Vector3f) lookAt()}.
+     * 
+     * @see #setLookAt(float, float, float, float, float, float, float, float, float)
+     * @see #lookAt(Vector3f, Vector3f, Vector3f)
+     * 
+     * @param eye
+     *            the position of the camera
+     * @param center
+     *            the point in space to look at
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix4f setLookAt(Vector3f eye, Vector3f center, Vector3f up) {
+        return setLookAt(eye.x, eye.y, eye.z, center.x, center.y, center.z, up.x, up.y, up.z);
+    }
+
+    /**
+     * Set this matrix to be a "lookat" transformation for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code>.
+     * <p>
+     * In order to apply the lookat transformation to a previous existing transformation,
+     * use {@link #lookAt(float, float, float, float, float, float, float, float, float) lookAt}.
+     * 
+     * @see #setLookAt(Vector3f, Vector3f, Vector3f)
+     * @see #lookAt(float, float, float, float, float, float, float, float, float)
+     * 
+     * @param eyeX
+     *              the x-coordinate of the eye/camera location
+     * @param eyeY
+     *              the y-coordinate of the eye/camera location
+     * @param eyeZ
+     *              the z-coordinate of the eye/camera location
+     * @param centerX
+     *              the x-coordinate of the point to look at
+     * @param centerY
+     *              the y-coordinate of the point to look at
+     * @param centerZ
+     *              the z-coordinate of the point to look at
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix4f setLookAt(float eyeX, float eyeY, float eyeZ,
+                              float centerX, float centerY, float centerZ,
+                              float upX, float upY, float upZ) {
+        // Compute direction from position to lookAt
+        float dirX, dirY, dirZ;
+        dirX = centerX - eyeX;
+        dirY = centerY - eyeY;
+        dirZ = centerZ - eyeZ;
+        // Normalize direction
+        float invDirLength = 1.0f / (float) Math.sqrt(
+                  (centerX - eyeX) * (centerX - eyeX)
+                + (centerY - eyeY) * (centerY - eyeY)
+                + (centerZ - eyeZ) * (centerZ - eyeZ));
+        dirX *= invDirLength;
+        dirY *= invDirLength;
+        dirZ *= invDirLength;
+        // right = direction x up
+        float rightX, rightY, rightZ;
+        rightX = dirY * upZ - dirZ * upY;
+        rightY = dirZ * upX - dirX * upZ;
+        rightZ = dirX * upY - dirY * upX;
+        // normalize right
+        float invRightLength = 1.0f / (float) Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        float upnX = rightY * dirZ - rightZ * dirY;
+        float upnY = rightZ * dirX - rightX * dirZ;
+        float upnZ = rightX * dirY - rightY * dirX;
+
+        m00 = rightX;
+        m01 = upnX;
+        m02 = -dirX;
+        m03 = 0.0f;
+        m10 = rightY;
+        m11 = upnY;
+        m12 = -dirY;
+        m13 = 0.0f;
+        m20 = rightZ;
+        m21 = upnZ;
+        m22 = -dirZ;
+        m23 = 0.0f;
+        m30 = -rightX * eyeX - rightY * eyeY - rightZ * eyeZ;
+        m31 = -upnX * eyeX - upnY * eyeY - upnZ * eyeZ;
+        m32 = dirX * eyeX + dirY * eyeY + dirZ * eyeZ;
+        m33 = 1.0f;
+
+        return this;
+    }
+
+    /**
+     * Apply a "lookat" transformation to this matrix for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code> and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookat matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>,
+     * the lookat transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookat transformation without post-multiplying it,
+     * use {@link #setLookAt(Vector3f, Vector3f, Vector3f)}.
+     * 
+     * @see #lookAt(float, float, float, float, float, float, float, float, float)
+     * @see #setLookAlong(Vector3f, Vector3f)
+     * 
+     * @param eye
+     *            the position of the camera
+     * @param center
+     *            the point in space to look at
+     * @param up
+     *            the direction of 'up'
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f lookAt(Vector3f eye, Vector3f center, Vector3f up, Matrix4f dest) {
+        return lookAt(eye.x, eye.y, eye.z, center.x, center.y, center.z, up.x, up.y, up.z, dest);
+    }
+
+    /**
+     * Apply a "lookat" transformation to this matrix for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookat matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>,
+     * the lookat transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookat transformation without post-multiplying it,
+     * use {@link #setLookAt(Vector3f, Vector3f, Vector3f)}.
+     * 
+     * @see #lookAt(float, float, float, float, float, float, float, float, float)
+     * @see #setLookAlong(Vector3f, Vector3f)
+     * 
+     * @param eye
+     *            the position of the camera
+     * @param center
+     *            the point in space to look at
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public Matrix4f lookAt(Vector3f eye, Vector3f center, Vector3f up) {
+        return lookAt(eye.x, eye.y, eye.z, center.x, center.y, center.z, up.x, up.y, up.z, this);
+    }
+
+    /**
+     * Apply a "lookat" transformation to this matrix for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code> and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookat matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>,
+     * the lookat transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookat transformation without post-multiplying it,
+     * use {@link #setLookAt(float, float, float, float, float, float, float, float, float) setLookAt()}.
+     * 
+     * @see #lookAt(Vector3f, Vector3f, Vector3f)
+     * @see #setLookAt(float, float, float, float, float, float, float, float, float)
+     * 
+     * @param eyeX
+     *              the x-coordinate of the eye/camera location
+     * @param eyeY
+     *              the y-coordinate of the eye/camera location
+     * @param eyeZ
+     *              the z-coordinate of the eye/camera location
+     * @param centerX
+     *              the x-coordinate of the point to look at
+     * @param centerY
+     *              the y-coordinate of the point to look at
+     * @param centerZ
+     *              the z-coordinate of the point to look at
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f lookAt(float eyeX, float eyeY, float eyeZ,
+                           float centerX, float centerY, float centerZ,
+                           float upX, float upY, float upZ, Matrix4f dest) {
+        // Compute direction from position to lookAt
+        float dirX, dirY, dirZ;
+        dirX = centerX - eyeX;
+        dirY = centerY - eyeY;
+        dirZ = centerZ - eyeZ;
+        // Normalize direction
+        float invDirLength = 1.0f / (float) Math.sqrt(
+                  (eyeX - centerX) * (eyeX - centerX)
+                + (eyeY - centerY) * (eyeY - centerY)
+                + (eyeZ - centerZ) * (eyeZ - centerZ));
+        dirX *= invDirLength;
+        dirY *= invDirLength;
+        dirZ *= invDirLength;
+        // right = direction x up
+        float rightX, rightY, rightZ;
+        rightX = dirY * upZ - dirZ * upY;
+        rightY = dirZ * upX - dirX * upZ;
+        rightZ = dirX * upY - dirY * upX;
+        // normalize right
+        float invRightLength = 1.0f / (float) Math.sqrt(rightX * rightX + rightY * rightY + rightZ * rightZ);
+        rightX *= invRightLength;
+        rightY *= invRightLength;
+        rightZ *= invRightLength;
+        // up = right x direction
+        float upnX = rightY * dirZ - rightZ * dirY;
+        float upnY = rightZ * dirX - rightX * dirZ;
+        float upnZ = rightX * dirY - rightY * dirX;
+
+        // calculate right matrix elements
+        float rm00 = rightX;
+        float rm01 = upnX;
+        float rm02 = -dirX;
+        float rm10 = rightY;
+        float rm11 = upnY;
+        float rm12 = -dirY;
+        float rm20 = rightZ;
+        float rm21 = upnZ;
+        float rm22 = -dirZ;
+        float rm30 = -rightX * eyeX - rightY * eyeY - rightZ * eyeZ;
+        float rm31 = -upnX * eyeX - upnY * eyeY - upnZ * eyeZ;
+        float rm32 = dirX * eyeX + dirY * eyeY + dirZ * eyeZ;
+
+        // perform optimized matrix multiplication
+        // compute last column first, because others do not depend on it
+        dest.m30 = m00 * rm30 + m10 * rm31 + m20 * rm32 + m30;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m21 * rm32 + m31;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m22 * rm32 + m32;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m23 * rm32 + m33;
+        // introduce temporaries for dependent results
+        float nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        float nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        float nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        float nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        float nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        float nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        float nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        float nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        // set the rest of the matrix elements
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+
+        return dest;
+    }
+
+    /**
+     * Apply a "lookat" transformation to this matrix for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>L</code> the lookat matrix,
+     * then the new matrix will be <code>M * L</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * L * v</code>,
+     * the lookat transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a lookat transformation without post-multiplying it,
+     * use {@link #setLookAt(float, float, float, float, float, float, float, float, float) setLookAt()}.
+     * 
+     * @see #lookAt(Vector3f, Vector3f, Vector3f)
+     * @see #setLookAt(float, float, float, float, float, float, float, float, float)
+     * 
+     * @param eyeX
+     *              the x-coordinate of the eye/camera location
+     * @param eyeY
+     *              the y-coordinate of the eye/camera location
+     * @param eyeZ
+     *              the z-coordinate of the eye/camera location
+     * @param centerX
+     *              the x-coordinate of the point to look at
+     * @param centerY
+     *              the y-coordinate of the point to look at
+     * @param centerZ
+     *              the z-coordinate of the point to look at
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Matrix4f lookAt(float eyeX, float eyeY, float eyeZ,
+                           float centerX, float centerY, float centerZ,
+                           float upX, float upY, float upZ) {
+        return lookAt(eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ, this);
+    }
+
+    /**
+     * Apply a symmetric perspective projection frustum transformation to this matrix and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>P</code> the perspective projection matrix,
+     * then the new matrix will be <code>M * P</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * P * v</code>,
+     * the perspective projection will be applied first!
+     * <p>
+     * This method first computes the frustum corners using the specified parameters and then makes use of
+     * {@link #frustum(float, float, float, float, float, float) frustum()} to finally apply the frustum
+     * transformation.
+     * <p>
+     * In order to set the matrix to a perspective frustum transformation without post-multiplying,
+     * use {@link #setPerspective(float, float, float, float) setPerspective}.
+     * 
+     * @see #frustum(float, float, float, float, float, float)
+     * @see #setPerspective(float, float, float, float)
+     * 
+     * @param fovy
+     *            the vertical field of view in radians
+     * @param aspect
+     *            the aspect ratio (i.e. width / height)
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f perspective(float fovy, float aspect, float zNear, float zFar, Matrix4f dest) {
+        float h = (float) Math.tan(fovy * 0.5f) * zNear;
+        float w = h * aspect;
+
+        // calculate right matrix elements
+        float rm00 = zNear / w;
+        float rm11 = zNear / h;
+        float rm22 = -(zFar + zNear) / (zFar - zNear);
+        float rm32 = -2.0f * zFar * zNear / (zFar - zNear);
+
+        // perform optimized matrix multiplication
+        float nm20 = m20 * rm22 - m30;
+        float nm21 = m21 * rm22 - m31;
+        float nm22 = m22 * rm22 - m32;
+        float nm23 = m23 * rm22 - m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m30 = m20 * rm32;
+        dest.m31 = m21 * rm32;
+        dest.m32 = m22 * rm32;
+        dest.m33 = m23 * rm32;
+        dest.m20 = nm20;
+        dest.m21 = nm21;
+        dest.m22 = nm22;
+        dest.m23 = nm23;
+
+        return dest;
+    }
+
+    /**
+     * Apply a symmetric perspective projection frustum transformation to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>P</code> the perspective projection matrix,
+     * then the new matrix will be <code>M * P</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * P * v</code>,
+     * the perspective projection will be applied first!
+     * <p>
+     * This method first computes the frustum corners using the specified parameters and then makes use of
+     * {@link #frustum(float, float, float, float, float, float) frustum()} to finally apply the frustum
+     * transformation.
+     * <p>
+     * In order to set the matrix to a perspective frustum transformation without post-multiplying,
+     * use {@link #setPerspective(float, float, float, float) setPerspective}.
+     * 
+     * @see #frustum(float, float, float, float, float, float)
+     * @see #setPerspective(float, float, float, float)
+     * 
+     * @param fovy
+     *            the vertical field of view in radians
+     * @param aspect
+     *            the aspect ratio (i.e. width / height)
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4f perspective(float fovy, float aspect, float zNear, float zFar) {
+        return perspective(fovy, aspect, zNear, zFar, this);
+    }
+
+    /**
+     * Set this matrix to be a symmetric perspective projection frustum transformation.
+     * <p>
+     * This method first computes the frustum corners using the specified parameters and then makes use of
+     * {@link #setFrustum(float, float, float, float, float, float) setFrustum()} to finally apply the frustum
+     * transformation.
+     * <p>
+     * In order to apply the perspective projection transformation to an existing transformation,
+     * use {@link #perspective(float, float, float, float) perspective()}.
+     * 
+     * @see #setFrustum(float, float, float, float, float, float)
+     * @see #perspective(float, float, float, float)
+     * 
+     * @param fovy
+     *            the vertical field of view in radians
+     * @param aspect
+     *            the aspect ratio (i.e. width / height)
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public Matrix4f setPerspective(float fovy, float aspect, float zNear, float zFar) {
+        float h = (float) Math.tan(fovy * 0.5f) * zNear;
+        float w = h * aspect;
+        m00 = zNear / w;
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = zNear / h;
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = 0.0f;
+        m21 = 0.0f;
+        m22 = -(zFar + zNear) / (zFar - zNear);
+        m23 = -1.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = -2.0f * zFar * zNear / (zFar - zNear);
+        m33 = 0.0f;
+        return this;
+    }
+
+    /**
+     * Apply an arbitrary perspective projection frustum transformation to this matrix 
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>F</code> the frustum matrix,
+     * then the new matrix will be <code>M * F</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * F * v</code>,
+     * the frustum transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a perspective frustum transformation without post-multiplying,
+     * use {@link #setFrustum(float, float, float, float, float, float) setFrustum()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#perspective">http://www.songho.ca</a>
+     * 
+     * @see #setFrustum(float, float, float, float, float, float)
+     * 
+     * @param left
+     *            the distance along the x-axis to the left frustum edge
+     * @param right
+     *            the distance along the x-axis to the right frustum edge
+     * @param bottom
+     *            the distance along the y-axis to the bottom frustum edge
+     * @param top
+     *            the distance along the y-axis to the top frustum edge
+     * @param zNear
+     *            the distance along the z-axis to the near clipping plane
+     * @param zFar
+     *            the distance along the z-axis to the far clipping plane
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Matrix4f frustum(float left, float right, float bottom, float top, float zNear, float zFar, Matrix4f dest) {
+        // calculate right matrix elements
+        float rm00 = 2.0f * zNear / (right - left);
+        float rm11 = 2.0f * zNear / (top - bottom);
+        float rm20 = (right + left) / (right - left);
+        float rm21 = (top + bottom) / (top - bottom);
+        float rm22 = -(zFar + zNear) / (zFar - zNear);
+        float rm32 = -2.0f * zFar * zNear / (zFar - zNear);
+
+        // perform optimized matrix multiplication
+        float nm20 = m00 * rm20 + m10 * rm21 + m20 * rm22 - m30;
+        float nm21 = m01 * rm20 + m11 * rm21 + m21 * rm22 - m31;
+        float nm22 = m02 * rm20 + m12 * rm21 + m22 * rm22 - m32;
+        float nm23 = m03 * rm20 + m13 * rm21 + m23 * rm22 - m33;
+        dest.m00 = m00 * rm00;
+        dest.m01 = m01 * rm00;
+        dest.m02 = m02 * rm00;
+        dest.m03 = m03 * rm00;
+        dest.m10 = m10 * rm11;
+        dest.m11 = m11 * rm11;
+        dest.m12 = m12 * rm11;
+        dest.m13 = m13 * rm11;
+        dest.m30 = m20 * rm32;
+        dest.m31 = m21 * rm32;
+        dest.m32 = m22 * rm32;
+        dest.m33 = m23 * rm32;
+        dest.m20 = nm20;
+        dest.m21 = nm21;
+        dest.m22 = nm22;
+        dest.m23 = nm23;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply an arbitrary perspective projection frustum transformation to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>F</code> the frustum matrix,
+     * then the new matrix will be <code>M * F</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * F * v</code>,
+     * the frustum transformation will be applied first!
+     * <p>
+     * In order to set the matrix to a perspective frustum transformation without post-multiplying,
+     * use {@link #setFrustum(float, float, float, float, float, float) setFrustum()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#perspective">http://www.songho.ca</a>
+     * 
+     * @see #setFrustum(float, float, float, float, float, float)
+     * 
+     * @param left
+     *            the distance along the x-axis to the left frustum edge
+     * @param right
+     *            the distance along the x-axis to the right frustum edge
+     * @param bottom
+     *            the distance along the y-axis to the bottom frustum edge
+     * @param top
+     *            the distance along the y-axis to the top frustum edge
+     * @param zNear
+     *            the distance along the z-axis to the near clipping plane
+     * @param zFar
+     *            the distance along the z-axis to the far clipping plane
+     * @return this
+     */
+    public Matrix4f frustum(float left, float right, float bottom, float top, float zNear, float zFar) {
+        return frustum(left, right, bottom, top, zNear, zFar, this);
+    }
+
+    /**
+     * Set this matrix to be an arbitrary perspective projection frustum transformation.
+     * <p>
+     * In order to apply the perspective frustum transformation to an existing transformation,
+     * use {@link #frustum(float, float, float, float, float, float) frustum()}.
+     * <p>
+     * Reference: <a href="http://www.songho.ca/opengl/gl_projectionmatrix.html#perspective">http://www.songho.ca</a>
+     * 
+     * @see #frustum(float, float, float, float, float, float)
+     * 
+     * @param left
+     *            the distance along the x-axis to the left frustum edge
+     * @param right
+     *            the distance along the x-axis to the right frustum edge
+     * @param bottom
+     *            the distance along the y-axis to the bottom frustum edge
+     * @param top
+     *            the distance along the y-axis to the top frustum edge
+     * @param zNear
+     *            the distance along the z-axis to the near clipping plane
+     * @param zFar
+     *            the distance along the z-axis to the far clipping plane
+     * @return this
+     */
+    public Matrix4f setFrustum(float left, float right, float bottom, float top, float zNear, float zFar) {
+        m00 = 2.0f * zNear / (right - left);
+        m01 = 0.0f;
+        m02 = 0.0f;
+        m03 = 0.0f;
+        m10 = 0.0f;
+        m11 = 2.0f * zNear / (top - bottom);
+        m12 = 0.0f;
+        m13 = 0.0f;
+        m20 = (right + left) / (right - left);
+        m21 = (top + bottom) / (top - bottom);
+        m22 = -(zFar + zNear) / (zFar - zNear);
+        m23 = -1.0f;
+        m30 = 0.0f;
+        m31 = 0.0f;
+        m32 = -2.0f * zFar * zNear / (zFar - zNear);
+        m33 = 0.0f;
+        return this;
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaternionf} to this matrix and store
+     * the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaternionf)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f rotate(Quaternionf quat, Matrix4f dest) {
+        float dqx = 2.0f * quat.x;
+        float dqy = 2.0f * quat.y;
+        float dqz = 2.0f * quat.z;
+        float q00 = dqx * quat.x;
+        float q11 = dqy * quat.y;
+        float q22 = dqz * quat.z;
+        float q01 = dqx * quat.y;
+        float q02 = dqx * quat.z;
+        float q03 = dqx * quat.w;
+        float q12 = dqy * quat.z;
+        float q13 = dqy * quat.w;
+        float q23 = dqz * quat.w;
+
+        float rm00 = 1.0f - q11 - q22;
+        float rm01 = q01 + q23;
+        float rm02 = q02 - q13;
+        float rm10 = q01 - q23;
+        float rm11 = 1.0f - q22 - q00;
+        float rm12 = q12 + q03;
+        float rm20 = q02 + q13;
+        float rm21 = q12 - q03;
+        float rm22 = 1.0f - q11 - q00;
+
+        float nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        float nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        float nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        float nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        float nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        float nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        float nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        float nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m30 = m30;
+        dest.m31 = m31;
+        dest.m32 = m32;
+        dest.m33 = m33;
+
+        return dest;
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaternionf} to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>Q</code> the rotation matrix obtained from the given quaternion,
+     * then the new matrix will be <code>M * Q</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * Q * v</code>,
+     * the quaternion rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(Quaternionf)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion">http://en.wikipedia.org</a>
+     * 
+     * @see #rotation(Quaternionf)
+     * 
+     * @param quat
+     *          the {@link Quaternionf}
+     * @return this
+     */
+    public Matrix4f rotate(Quaternionf quat) {
+        return rotate(quat, this);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4f}, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4f},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4f} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * @see #rotation(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @return this
+     */
+    public Matrix4f rotate(AxisAngle4f axisAngle) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given {@link AxisAngle4f} and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given {@link AxisAngle4f},
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the {@link AxisAngle4f} rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(AxisAngle4f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * @see #rotation(AxisAngle4f)
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f} (needs to be {@link AxisAngle4f#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f rotate(AxisAngle4f axisAngle, Matrix4f dest) {
+        return rotate(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z, dest);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis, to this matrix.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given axis-angle,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(float, Vector3f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * @see #rotation(float, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3f#normalize() normalized})
+     * @return this
+     */
+    public Matrix4f rotate(float angle, Vector3f axis) {
+        return rotate(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Apply a rotation transformation, rotating the given radians about the specified axis and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>A</code> the rotation matrix obtained from the given axis-angle,
+     * then the new matrix will be <code>M * A</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * A * v</code>,
+     * the axis-angle rotation will be applied first!
+     * <p>
+     * In order to set the matrix to a rotation transformation without post-multiplying,
+     * use {@link #rotation(float, Vector3f)}.
+     * <p>
+     * Reference: <a href="http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle">http://en.wikipedia.org</a>
+     * 
+     * @see #rotate(float, float, float, float)
+     * @see #rotation(float, Vector3f)
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis (needs to be {@link Vector3f#normalize() normalized})
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f rotate(float angle, Vector3f axis, Matrix4f dest) {
+        return rotate(angle, axis.x, axis.y, axis.z, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>this</code> matrix.
+     * In order to avoid computing the matrix inverse with every invocation, the inverse of <code>this</code> matrix can be built
+     * once outside using {@link #invert(Matrix4f)} and then the method {@link #unprojectInv(float, float, float, int[], Vector4f) unprojectInv()} can be invoked on it.
+     * 
+     * @see #unprojectInv(float, float, float, int[], Vector4f)
+     * @see #invert(Matrix4f)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector4f unproject(float winX, float winY, float winZ, int[] viewport, Vector4f dest) {
+        float a = m00 * m11 - m01 * m10;
+        float b = m00 * m12 - m02 * m10;
+        float c = m00 * m13 - m03 * m10;
+        float d = m01 * m12 - m02 * m11;
+        float e = m01 * m13 - m03 * m11;
+        float f = m02 * m13 - m03 * m12;
+        float g = m20 * m31 - m21 * m30;
+        float h = m20 * m32 - m22 * m30;
+        float i = m20 * m33 - m23 * m30;
+        float j = m21 * m32 - m22 * m31;
+        float k = m21 * m33 - m23 * m31;
+        float l = m22 * m33 - m23 * m32;
+        float det = a * l - b * k + c * j + d * i - e * h + f * g;
+        det = 1.0f / det;
+        float im00 = ( m11 * l - m12 * k + m13 * j) * det;
+        float im01 = (-m01 * l + m02 * k - m03 * j) * det;
+        float im02 = ( m31 * f - m32 * e + m33 * d) * det;
+        float im03 = (-m21 * f + m22 * e - m23 * d) * det;
+        float im10 = (-m10 * l + m12 * i - m13 * h) * det;
+        float im11 = ( m00 * l - m02 * i + m03 * h) * det;
+        float im12 = (-m30 * f + m32 * c - m33 * b) * det;
+        float im13 = ( m20 * f - m22 * c + m23 * b) * det;
+        float im20 = ( m10 * k - m11 * i + m13 * g) * det;
+        float im21 = (-m00 * k + m01 * i - m03 * g) * det;
+        float im22 = ( m30 * e - m31 * c + m33 * a) * det;
+        float im23 = (-m20 * e + m21 * c - m23 * a) * det;
+        float im30 = (-m10 * j + m11 * h - m12 * g) * det;
+        float im31 = ( m00 * j - m01 * h + m02 * g) * det;
+        float im32 = (-m30 * d + m31 * b - m32 * a) * det;
+        float im33 = ( m20 * d - m21 * b + m22 * a) * det;
+        float ndcX = (winX-viewport[0])/viewport[2]*2.0f-1.0f;
+        float ndcY = (winY-viewport[1])/viewport[3]*2.0f-1.0f;
+        float ndcZ = 2.0f*winZ-1.0f;
+        dest.x = im00 * ndcX + im10 * ndcY + im20 * ndcZ + im30;
+        dest.y = im01 * ndcX + im11 * ndcY + im21 * ndcZ + im31;
+        dest.z = im02 * ndcX + im12 * ndcY + im22 * ndcZ + im32;
+        dest.w = im03 * ndcX + im13 * ndcY + im23 * ndcZ + im33;
+        dest.div(dest.w);
+        return dest;
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>this</code> matrix.
+     * In order to avoid computing the matrix inverse with every invocation, the inverse of <code>this</code> matrix can be built
+     * once outside using {@link #invert(Matrix4f)} and then the method {@link #unprojectInv(float, float, float, int[], Vector4f) unprojectInv()} can be invoked on it.
+     * 
+     * @see #unprojectInv(float, float, float, int[], Vector3f)
+     * @see #invert(Matrix4f)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector3f unproject(float winX, float winY, float winZ, int[] viewport, Vector3f dest) {
+        float a = m00 * m11 - m01 * m10;
+        float b = m00 * m12 - m02 * m10;
+        float c = m00 * m13 - m03 * m10;
+        float d = m01 * m12 - m02 * m11;
+        float e = m01 * m13 - m03 * m11;
+        float f = m02 * m13 - m03 * m12;
+        float g = m20 * m31 - m21 * m30;
+        float h = m20 * m32 - m22 * m30;
+        float i = m20 * m33 - m23 * m30;
+        float j = m21 * m32 - m22 * m31;
+        float k = m21 * m33 - m23 * m31;
+        float l = m22 * m33 - m23 * m32;
+        float det = a * l - b * k + c * j + d * i - e * h + f * g;
+        det = 1.0f / det;
+        float im00 = ( m11 * l - m12 * k + m13 * j) * det;
+        float im01 = (-m01 * l + m02 * k - m03 * j) * det;
+        float im02 = ( m31 * f - m32 * e + m33 * d) * det;
+        float im03 = (-m21 * f + m22 * e - m23 * d) * det;
+        float im10 = (-m10 * l + m12 * i - m13 * h) * det;
+        float im11 = ( m00 * l - m02 * i + m03 * h) * det;
+        float im12 = (-m30 * f + m32 * c - m33 * b) * det;
+        float im13 = ( m20 * f - m22 * c + m23 * b) * det;
+        float im20 = ( m10 * k - m11 * i + m13 * g) * det;
+        float im21 = (-m00 * k + m01 * i - m03 * g) * det;
+        float im22 = ( m30 * e - m31 * c + m33 * a) * det;
+        float im23 = (-m20 * e + m21 * c - m23 * a) * det;
+        float im30 = (-m10 * j + m11 * h - m12 * g) * det;
+        float im31 = ( m00 * j - m01 * h + m02 * g) * det;
+        float im32 = (-m30 * d + m31 * b - m32 * a) * det;
+        float im33 = ( m20 * d - m21 * b + m22 * a) * det;
+        float ndcX = (winX-viewport[0])/viewport[2]*2.0f-1.0f;
+        float ndcY = (winY-viewport[1])/viewport[3]*2.0f-1.0f;
+        float ndcZ = 2.0f*winZ-1.0f;
+        dest.x = im00 * ndcX + im10 * ndcY + im20 * ndcZ + im30;
+        dest.y = im01 * ndcX + im11 * ndcY + im21 * ndcZ + im31;
+        dest.z = im02 * ndcX + im12 * ndcY + im22 * ndcZ + im32;
+        float w = im03 * ndcX + im13 * ndcY + im23 * ndcZ + im33;
+        dest.div(w);
+        return dest;
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>this</code> matrix.
+     * In order to avoid computing the matrix inverse with every invocation, the inverse of <code>this</code> matrix can be built
+     * once outside using {@link #invert(Matrix4f)} and then the method {@link #unprojectInv(float, float, float, int[], Vector4f) unprojectInv()} can be invoked on it.
+     * 
+     * @see #unprojectInv(float, float, float, int[], Vector4f)
+     * @see #unproject(float, float, float, int[], Vector4f)
+     * @see #invert(Matrix4f)
+     * 
+     * @param winCoords
+     *          the window coordinates to unproject
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector4f unproject(Vector3f winCoords, int[] viewport, Vector4f dest) {
+        return unproject(winCoords.x, winCoords.y, winCoords.z, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>this</code> matrix.  
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>this</code> matrix.
+     * In order to avoid computing the matrix inverse with every invocation, the inverse of <code>this</code> matrix can be built
+     * once outside using {@link #invert(Matrix4f)} and then the method {@link #unprojectInv(float, float, float, int[], Vector3f) unprojectInv()} can be invoked on it.
+     * 
+     * @see #unprojectInv(float, float, float, int[], Vector3f)
+     * @see #unproject(float, float, float, int[], Vector3f)
+     * @see #invert(Matrix4f)
+     * 
+     * @param winCoords
+     *          the window coordinates to unproject
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector3f unproject(Vector3f winCoords, int[] viewport, Vector3f dest) {
+        return unproject(winCoords.x, winCoords.y, winCoords.z, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method differs from {@link #unproject(Vector3f, int[], Vector4f) unproject()} 
+     * in that it assumes that <code>this</code> is already the inverse matrix of the original projection matrix.
+     * It exists to avoid recomputing the matrix inverse with every invocation.
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * This method reads the four viewport parameters from the current int[]'s {@link Buffer#position() position}
+     * and does not modify the buffer's position.
+     * 
+     * @see #unproject(Vector3f, int[], Vector4f)
+     * 
+     * @param winCoords
+     *          the window coordinates to unproject
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector4f unprojectInv(Vector3f winCoords, int[] viewport, Vector4f dest) {
+        return unprojectInv(winCoords.x, winCoords.y, winCoords.z, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method differs from {@link #unproject(float, float, float, int[], Vector4f) unproject()} 
+     * in that it assumes that <code>this</code> is already the inverse matrix of the original projection matrix.
+     * It exists to avoid recomputing the matrix inverse with every invocation.
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * 
+     * @see #unproject(float, float, float, int[], Vector4f)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector4f unprojectInv(float winX, float winY, float winZ, int[] viewport, Vector4f dest) {
+        float ndcX = (winX-viewport[0])/viewport[2]*2.0f-1.0f;
+        float ndcY = (winY-viewport[1])/viewport[3]*2.0f-1.0f;
+        float ndcZ = 2.0f*winZ-1.0f;
+        dest.x = m00 * ndcX + m10 * ndcY + m20 * ndcZ + m30;
+        dest.y = m01 * ndcX + m11 * ndcY + m21 * ndcZ + m31;
+        dest.z = m02 * ndcX + m12 * ndcY + m22 * ndcZ + m32;
+        dest.w = m03 * ndcX + m13 * ndcY + m23 * ndcZ + m33;
+        dest.div(dest.w);
+        return dest;
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method differs from {@link #unproject(Vector3f, int[], Vector3f) unproject()} 
+     * in that it assumes that <code>this</code> is already the inverse matrix of the original projection matrix.
+     * It exists to avoid recomputing the matrix inverse with every invocation.
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * 
+     * @see #unproject(Vector3f, int[], Vector3f)
+     * 
+     * @param winCoords
+     *          the window coordinates to unproject
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector3f unprojectInv(Vector3f winCoords, int[] viewport, Vector3f dest) {
+        return unprojectInv(winCoords.x, winCoords.y, winCoords.z, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by <code>this</code> matrix using the specified viewport.
+     * <p>
+     * This method differs from {@link #unproject(float, float, float, int[], Vector3f) unproject()} 
+     * in that it assumes that <code>this</code> is already the inverse matrix of the original projection matrix.
+     * It exists to avoid recomputing the matrix inverse with every invocation.
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * 
+     * @see #unproject(float, float, float, int[], Vector3f)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param dest
+     *          will hold the unprojected position
+     * @return dest
+     */
+    public Vector3f unprojectInv(float winX, float winY, float winZ, int[] viewport, Vector3f dest) {
+        float ndcX = (winX-viewport[0])/viewport[2]*2.0f-1.0f;
+        float ndcY = (winY-viewport[1])/viewport[3]*2.0f-1.0f;
+        float ndcZ = 2.0f*winZ-1.0f;
+        dest.x = m00 * ndcX + m10 * ndcY + m20 * ndcZ + m30;
+        dest.y = m01 * ndcX + m11 * ndcY + m21 * ndcZ + m31;
+        dest.z = m02 * ndcX + m12 * ndcY + m22 * ndcZ + m32;
+        float w = m03 * ndcX + m13 * ndcY + m23 * ndcZ + m33;
+        dest.div(w);
+        return dest;
+    }
+
+    /**
+     * Unproject the given window coordinates <tt>(winX, winY, winZ)</tt> by the given <code>view</code> and <code>projection</code> matrices using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>projection * view</code>.
+     * <p>
+     * The depth range of <tt>winZ</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>projection * view</code> and stores
+     * it into the <code>inverseOut</code> parameter matrix. In order to avoid computing the matrix inverse with every
+     * invocation, the inverse of both matrices can be built once outside and then the method {@link #unprojectInv(float, float, float, int[], Vector4f) unprojectInv()}
+     * can be invoked on it.
+     * 
+     * @see #unprojectInv(float, float, float, int[], Vector4f)
+     * 
+     * @param winX
+     *          the x-coordinate in window coordinates (pixels)
+     * @param winY
+     *          the y-coordinate in window coordinates (pixels)
+     * @param winZ
+     *          the z-coordinate, which is the depth value in <tt>[0..1]</tt>
+     * @param projection
+     *          the projection matrix
+     * @param view
+     *          the view matrix
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param inverseOut
+     *          will hold the inverse of <code>projection * view</code> after the method returns
+     * @param dest
+     *          will hold the unprojected position
+     */
+    public static void unproject(float winX, float winY, float winZ, Matrix4f projection, Matrix4f view, int[] viewport, Matrix4f inverseOut, Vector4f dest) {
+        inverseOut.set(projection).mul(view).invert().unprojectInv(winX, winY, winZ, viewport, dest);
+    }
+
+    /**
+     * Unproject the given window coordinates <code>winCoords</code> by the given <code>view</code> and <code>projection</code> matrices using the specified viewport.
+     * <p>
+     * This method first converts the given window coordinates to normalized device coordinates in the range <tt>[-1..1]</tt>
+     * and then transforms those NDC coordinates by the inverse of <code>projection * view</code>.
+     * <p>
+     * The depth range of <tt>winCoords.z</tt> is assumed to be <tt>[0..1]</tt>, which is also the OpenGL default.
+     * <p>
+     * As a necessary computation step for unprojecting, this method computes the inverse of <code>projection * view</code> and stores
+     * it into the <code>inverseOut</code> parameter matrix. In order to avoid computing the matrix inverse with every
+     * invocation, the inverse of both matrices can be built once outside and then the method {@link #unprojectInv(float, float, float, int[], Vector4f) unprojectInv()}
+     * can be invoked on it.
+     * 
+     * @see #unprojectInv(float, float, float, int[], Vector4f)
+     * 
+     * @param winCoords
+     *          the window coordinate to unproject
+     * @param projection
+     *          the projection matrix
+     * @param view
+     *          the view matrix
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param inverseOut
+     *          will hold the inverse of <code>projection * view</code> after the method returns
+     * @param dest
+     *          will hold the unprojected position
+     */
+    public static void unproject(Vector3f winCoords, Matrix4f projection, Matrix4f view, int[] viewport, Matrix4f inverseOut, Vector4f dest) {
+        unproject(winCoords.x, winCoords.y, winCoords.z, projection, view, viewport, inverseOut, dest);
+    }
+
+    /**
+     * Project the given <tt>(x, y, z)</tt> position via <code>this</code> matrix using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>this</code> matrix including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @param x
+     *          the x-coordinate of the position to project
+     * @param y
+     *          the y-coordinate of the position to project
+     * @param z
+     *          the z-coordinate of the position to project
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     * @return winCoordsDest
+     */
+    public Vector4f project(float x, float y, float z, int[] viewport, Vector4f winCoordsDest) {
+        winCoordsDest.x = m00 * x + m10 * y + m20 * z + m30;
+        winCoordsDest.y = m01 * x + m11 * y + m21 * z + m31;
+        winCoordsDest.z = m02 * x + m12 * y + m22 * z + m32;
+        winCoordsDest.w = m03 * x + m13 * y + m23 * z + m33;
+        winCoordsDest.div(winCoordsDest.w);
+        winCoordsDest.x = (winCoordsDest.x*0.5f+0.5f) * viewport[2] + viewport[0];
+        winCoordsDest.y = (winCoordsDest.y*0.5f+0.5f) * viewport[3] + viewport[1];
+        winCoordsDest.z = (1.0f+winCoordsDest.z)*0.5f;
+        return winCoordsDest;
+    }
+
+    /**
+     * Project the given <tt>(x, y, z)</tt> position via <code>this</code> matrix using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>this</code> matrix including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @param x
+     *          the x-coordinate of the position to project
+     * @param y
+     *          the y-coordinate of the position to project
+     * @param z
+     *          the z-coordinate of the position to project
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     * @return winCoordsDest
+     */
+    public Vector3f project(float x, float y, float z, int[] viewport, Vector3f winCoordsDest) {
+        winCoordsDest.x = m00 * x + m10 * y + m20 * z + m30;
+        winCoordsDest.y = m01 * x + m11 * y + m21 * z + m31;
+        winCoordsDest.z = m02 * x + m12 * y + m22 * z + m32;
+        float w = m03 * x + m13 * y + m23 * z + m33;
+        winCoordsDest.div(w);
+        winCoordsDest.x = (winCoordsDest.x*0.5f+0.5f) * viewport[2] + viewport[0];
+        winCoordsDest.y = (winCoordsDest.y*0.5f+0.5f) * viewport[3] + viewport[1];
+        winCoordsDest.z = (1.0f+winCoordsDest.z)*0.5f;
+        return winCoordsDest;
+    }
+
+    /**
+     * Project the given <code>position</code> via <code>this</code> matrix using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>this</code> matrix including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @see #project(float, float, float, int[], Vector4f)
+     * 
+     * @param position
+     *          the position to project into window coordinates
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     * @return winCoordsDest
+     */
+    public Vector4f project(Vector3f position, int[] viewport, Vector4f winCoordsDest) {
+        return project(position.x, position.y, position.z, viewport, winCoordsDest);
+    }
+
+    /**
+     * Project the given <code>position</code> via <code>this</code> matrix using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>this</code> matrix including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @see #project(float, float, float, int[], Vector4f)
+     * 
+     * @param position
+     *          the position to project into window coordinates
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     * @return winCoordsDest
+     */
+    public Vector3f project(Vector3f position, int[] viewport, Vector3f winCoordsDest) {
+        return project(position.x, position.y, position.z, viewport, winCoordsDest);
+    }
+
+    /**
+     * Project the given <tt>(x, y, z)</tt> position via the given <code>view</code> and <code>projection</code> matrices using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>projection * view</code> including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @param x
+     *          the x-coordinate of the position to project
+     * @param y
+     *          the y-coordinate of the position to project
+     * @param z
+     *          the z-coordinate of the position to project
+     * @param projection
+     *          the projection matrix
+     * @param view
+     *          the view matrix
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     */
+    public static void project(float x, float y, float z, Matrix4f projection, Matrix4f view, int[] viewport, Vector4f winCoordsDest) {
+        winCoordsDest.set(x, y, z, 1.0f);
+        view.transform(winCoordsDest);
+        projection.transform(winCoordsDest);
+        winCoordsDest.div(winCoordsDest.w);
+        winCoordsDest.x = (winCoordsDest.x*0.5f+0.5f) * viewport[2] + viewport[0];
+        winCoordsDest.y = (winCoordsDest.y*0.5f+0.5f) * viewport[3] + viewport[1];
+        winCoordsDest.z = (1.0f+winCoordsDest.z)*0.5f;
+    }
+
+    /**
+     * Project the given <code>position</code> via the given <code>view</code> and <code>projection</code> matrices using the specified viewport
+     * and store the resulting window coordinates in <code>winCoordsDest</code>.
+     * <p>
+     * This method transforms the given coordinates by <code>projection * view</code> including perspective division to 
+     * obtain normalized device coordinates, and then translates these into window coordinates by using the
+     * given <code>viewport</code> settings <tt>[x, y, width, height]</tt>.
+     * <p>
+     * The depth range of the returned <code>winCoordsDest.z</code> will be <tt>[0..1]</tt>, which is also the OpenGL default.  
+     * 
+     * @see #project(float, float, float, Matrix4f, Matrix4f, int[], Vector4f)
+     * 
+     * @param position
+     *          the position to project into window coordinates
+     * @param projection
+     *          the projection matrix
+     * @param view
+     *          the view matrix
+     * @param viewport
+     *          the viewport described by <tt>[x, y, width, height]</tt>
+     * @param winCoordsDest
+     *          will hold the projected window coordinates
+     */
+    public static void project(Vector3f position, Matrix4f projection, Matrix4f view, int[] viewport, Vector4f winCoordsDest) {
+        project(position.x, position.y, position.z, projection, view, viewport, winCoordsDest);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the equation <tt>x*a + y*b + z*c + d = 0</tt> and store the result in <code>dest</code>.
+     * <p>
+     * The vector <tt>(a, b, c)</tt> must be a unit vector.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb281733(v=vs.85).aspx">msdn.microsoft.com</a>
+     * 
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f reflect(float a, float b, float c, float d, Matrix4f dest) {
+        float da = 2.0f * a, db = 2.0f * b, dc = 2.0f * c, dd = 2.0f * d;
+        float rm00 = 1.0f - da * a;
+        float rm01 = -da * b;
+        float rm02 = -da * c;
+        float rm10 = -db * a;
+        float rm11 = 1.0f - db * b;
+        float rm12 = -db * c;
+        float rm20 = -dc * a;
+        float rm21 = -dc * b;
+        float rm22 = 1.0f - dc * c;
+        float rm30 = -dd * a;
+        float rm31 = -dd * b;
+        float rm32 = -dd * c;
+
+        // matrix multiplication
+        dest.m30 = m00 * rm30 + m10 * rm31 + m20 * rm32 + m30;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m21 * rm32 + m31;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m22 * rm32 + m32;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m23 * rm32 + m33;
+        float nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02;
+        float nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02;
+        float nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02;
+        float nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02;
+        float nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12;
+        float nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12;
+        float nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12;
+        float nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12;
+        dest.m20 = m00 * rm20 + m10 * rm21 + m20 * rm22;
+        dest.m21 = m01 * rm20 + m11 * rm21 + m21 * rm22;
+        dest.m22 = m02 * rm20 + m12 * rm21 + m22 * rm22;
+        dest.m23 = m03 * rm20 + m13 * rm21 + m23 * rm22;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+
+        return dest;
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the equation <tt>x*a + y*b + z*c + d = 0</tt>.
+     * <p>
+     * The vector <tt>(a, b, c)</tt> must be a unit vector.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb281733(v=vs.85).aspx">msdn.microsoft.com</a>
+     * 
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return this
+     */
+    public Matrix4f reflect(float a, float b, float c, float d) {
+        return reflect(a, b, c, d, this);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param nx
+     *          the x-coordinate of the plane normal
+     * @param ny
+     *          the y-coordinate of the plane normal
+     * @param nz
+     *          the z-coordinate of the plane normal
+     * @param px
+     *          the x-coordinate of a point on the plane
+     * @param py
+     *          the y-coordinate of a point on the plane
+     * @param pz
+     *          the z-coordinate of a point on the plane
+     * @return this
+     */
+    public Matrix4f reflect(float nx, float ny, float nz, float px, float py, float pz) {
+        return reflect(nx, ny, nz, px, py, pz, this);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane, and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param nx
+     *          the x-coordinate of the plane normal
+     * @param ny
+     *          the y-coordinate of the plane normal
+     * @param nz
+     *          the z-coordinate of the plane normal
+     * @param px
+     *          the x-coordinate of a point on the plane
+     * @param py
+     *          the y-coordinate of a point on the plane
+     * @param pz
+     *          the z-coordinate of a point on the plane
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f reflect(float nx, float ny, float nz, float px, float py, float pz, Matrix4f dest) {
+        float invLength = 1.0f / (float) Math.sqrt(nx * nx + ny * ny + nz * nz);
+        float nnx = nx * invLength;
+        float nny = ny * invLength;
+        float nnz = nz * invLength;
+        /* See: http://mathworld.wolfram.com/Plane.html */
+        return reflect(nnx, nny, nnz, -nnx * px - nny * py - nnz * pz, dest);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param normal
+     *          the plane normal
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public Matrix4f reflect(Vector3f normal, Vector3f point) {
+        return reflect(normal.x, normal.y, normal.z, point.x, point.y, point.z);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about a plane
+     * specified via the plane orientation and a point on the plane.
+     * <p>
+     * This method can be used to build a reflection transformation based on the orientation of a mirror object in the scene.
+     * It is assumed that the default mirror plane's normal is <tt>(0, 0, 1)</tt>. So, if the given {@link Quaternionf} is
+     * the identity (does not apply any additional rotation), the reflection plane will be <tt>z=0</tt>, offset by the given <code>point</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param orientation
+     *          the plane orientation
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public Matrix4f reflect(Quaternionf orientation, Vector3f point) {
+        return reflect(orientation, point, this);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about a plane
+     * specified via the plane orientation and a point on the plane, and store the result in <code>dest</code>.
+     * <p>
+     * This method can be used to build a reflection transformation based on the orientation of a mirror object in the scene.
+     * It is assumed that the default mirror plane's normal is <tt>(0, 0, 1)</tt>. So, if the given {@link Quaternionf} is
+     * the identity (does not apply any additional rotation), the reflection plane will be <tt>z=0</tt>, offset by the given <code>point</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param orientation
+     *          the plane orientation relative to an implied normal vector of <tt>(0, 0, 1)</tt>
+     * @param point
+     *          a point on the plane
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f reflect(Quaternionf orientation, Vector3f point, Matrix4f dest) {
+        double num1 = orientation.x * 2.0;
+        double num2 = orientation.y * 2.0;
+        double num3 = orientation.z * 2.0;
+        float normalX = (float) (orientation.x * num3 + orientation.w * num2);
+        float normalY = (float) (orientation.y * num3 - orientation.w * num1);
+        float normalZ = (float) (1.0 - (orientation.x * num1 + orientation.y * num2));
+        return reflect(normalX, normalY, normalZ, point.x, point.y, point.z, dest);
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to this matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane, and store the result in <code>dest</code>.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>M * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param normal
+     *          the plane normal
+     * @param point
+     *          a point on the plane
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f reflect(Vector3f normal, Vector3f point, Matrix4f dest) {
+        return reflect(normal.x, normal.y, normal.z, point.x, point.y, point.z, dest);
+    }
+
+    /**
+     * Set this matrix to a mirror/reflection transformation that reflects about the given plane
+     * specified via the equation <tt>x*a + y*b + z*c + d = 0</tt>.
+     * <p>
+     * The vector <tt>(a, b, c)</tt> must be a unit vector.
+     * <p>
+     * Reference: <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb281733(v=vs.85).aspx">msdn.microsoft.com</a>
+     * 
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return this
+     */
+    public Matrix4f reflection(float a, float b, float c, float d) {
+        float da = 2.0f * a, db = 2.0f * b, dc = 2.0f * c, dd = 2.0f * d;
+        m00 = 1.0f - da * a;
+        m01 = -da * b;
+        m02 = -da * c;
+        m03 = 0.0f;
+        m10 = -db * a;
+        m11 = 1.0f - db * b;
+        m12 = -db * c;
+        m13 = 0.0f;
+        m20 = -dc * a;
+        m21 = -dc * b;
+        m22 = 1.0f - dc * c;
+        m23 = 0.0f;
+        m30 = -dd * a;
+        m31 = -dd * b;
+        m32 = -dd * c;
+        m33 = 1.0f;
+        return this;
+    }
+
+    /**
+     * Set this matrix to a mirror/reflection transformation that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * 
+     * @param nx
+     *          the x-coordinate of the plane normal
+     * @param ny
+     *          the y-coordinate of the plane normal
+     * @param nz
+     *          the z-coordinate of the plane normal
+     * @param px
+     *          the x-coordinate of a point on the plane
+     * @param py
+     *          the y-coordinate of a point on the plane
+     * @param pz
+     *          the z-coordinate of a point on the plane
+     * @return this
+     */
+    public Matrix4f reflection(float nx, float ny, float nz, float px, float py, float pz) {
+        float invLength = 1.0f / (float) Math.sqrt(nx * nx + ny * ny + nz * nz);
+        float nnx = nx * invLength;
+        float nny = ny * invLength;
+        float nnz = nz * invLength;
+        /* See: http://mathworld.wolfram.com/Plane.html */
+        return reflection(nnx, nny, nnz, -nnx * px - nny * py - nnz * pz);
+    }
+
+    /**
+     * Set this matrix to a mirror/reflection transformation that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * 
+     * @param normal
+     *          the plane normal
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public Matrix4f reflection(Vector3f normal, Vector3f point) {
+        return reflection(normal.x, normal.y, normal.z, point.x, point.y, point.z);
+    }
+
+    /**
+     * Set this matrix to a mirror/reflection transformation that reflects about a plane
+     * specified via the plane orientation and a point on the plane.
+     * <p>
+     * This method can be used to build a reflection transformation based on the orientation of a mirror object in the scene.
+     * It is assumed that the default mirror plane's normal is <tt>(0, 0, 1)</tt>. So, if the given {@link Quaternionf} is
+     * the identity (does not apply any additional rotation), the reflection plane will be <tt>z=0</tt>, offset by the given <code>point</code>.
+     * 
+     * @param orientation
+     *          the plane orientation
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public Matrix4f reflection(Quaternionf orientation, Vector3f point) {
+        double num1 = orientation.x * 2.0;
+        double num2 = orientation.y * 2.0;
+        double num3 = orientation.z * 2.0;
+        float normalX = (float) (orientation.x * num3 + orientation.w * num2);
+        float normalY = (float) (orientation.y * num3 - orientation.w * num1);
+        float normalZ = (float) (1.0 - (orientation.x * num1 + orientation.y * num2));
+        return reflection(normalX, normalY, normalZ, point.x, point.y, point.z);
+    }
+
+    /**
+     * Get the row at the given <code>row</code> index, starting with <code>0</code>.
+     * 
+     * @param row
+     *          the row index in <tt>[0..3]</tt>
+     * @param dest
+     *          will hold the row components
+     * @return the passed in destination
+     * @throws IndexOutOfBoundsException if <code>row</code> is not in <tt>[0..3]</tt>
+     */
+    public Vector4f getRow(int row, Vector4f dest) throws IndexOutOfBoundsException {
+        switch (row) {
+        case 0:
+            dest.x = m00;
+            dest.y = m10;
+            dest.z = m20;
+            dest.w = m30;
+            break;
+        case 1:
+            dest.x = m01;
+            dest.y = m11;
+            dest.z = m21;
+            dest.w = m31;
+            break;
+        case 2:
+            dest.x = m02;
+            dest.y = m12;
+            dest.z = m22;
+            dest.w = m32;
+            break;
+        case 3:
+            dest.x = m03;
+            dest.y = m13;
+            dest.z = m23;
+            dest.w = m33;
+            break;
+        default:
+            throw new IndexOutOfBoundsException();
+        }
+        return dest;
+    }
+
+    /**
+     * Get the column at the given <code>column</code> index, starting with <code>0</code>.
+     * 
+     * @param column
+     *          the column index in <tt>[0..3]</tt>
+     * @param dest
+     *          will hold the column components
+     * @return the passed in destination
+     * @throws IndexOutOfBoundsException if <code>column</code> is not in <tt>[0..3]</tt>
+     */
+    public Vector4f getColumn(int column, Vector4f dest) throws IndexOutOfBoundsException {
+        switch (column) {
+        case 0:
+            dest.x = m00;
+            dest.y = m01;
+            dest.z = m02;
+            dest.w = m03;
+            break;
+        case 1:
+            dest.x = m10;
+            dest.y = m11;
+            dest.z = m12;
+            dest.w = m13;
+            break;
+        case 2:
+            dest.x = m20;
+            dest.y = m21;
+            dest.z = m22;
+            dest.w = m23;
+            break;
+        case 3:
+            dest.x = m30;
+            dest.y = m31;
+            dest.z = m32;
+            dest.w = m32;
+            break;
+        default:
+            throw new IndexOutOfBoundsException();
+        }
+        return dest;
+    }
+
+    /**
+     * Compute a normal matrix from the upper left 3x3 submatrix of <code>this</code>
+     * and store it into the upper left 3x3 submatrix of <code>dest</code>.
+     * All other values of <code>dest</code> will be set to {@link #identity() identity}.
+     * <p>
+     * The normal matrix of <tt>m</tt> is the transpose of the inverse of <tt>m</tt>.
+     * <p>
+     * Please note that, if <code>this</code> is an orthogonal matrix or a matrix whose columns are orthogonal vectors, 
+     * then this method <i>need not</i> be invoked, since in that case <code>this</code> itself is its normal matrix.
+     * In that case, use {@link #set3x3(Matrix4f)} to set a given Matrix4f to only the upper left 3x3 submatrix
+     * of this matrix.
+     * 
+     * @see #set3x3(Matrix4f)
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix4f normal(Matrix4f dest) {
+        float det = determinant3x3();
+        float s = 1.0f / det;
+        /* Invert and transpose in one go */
+        dest.set((m11 * m22 - m21 * m12) * s,
+                 (m20 * m12 - m10 * m22) * s,
+                 (m10 * m21 - m20 * m11) * s,
+                 0.0f,
+                 (m21 * m02 - m01 * m22) * s,
+                 (m00 * m22 - m20 * m02) * s,
+                 (m20 * m01 - m00 * m21) * s,
+                 0.0f,
+                 (m01 * m12 - m11 * m02) * s,
+                 (m10 * m02 - m00 * m12) * s,
+                 (m00 * m11 - m10 * m01) * s,
+                 0.0f,
+                 0.0f, 0.0f, 0.0f, 1.0f);
+        return dest;
+    }
+
+    /**
+     * Compute a normal matrix from the upper left 3x3 submatrix of <code>this</code>
+     * and store it into <code>dest</code>.
+     * <p>
+     * The normal matrix of <tt>m</tt> is the transpose of the inverse of <tt>m</tt>.
+     * <p>
+     * Please note that, if <code>this</code> is an orthogonal matrix or a matrix whose columns are orthogonal vectors, 
+     * then this method <i>need not</i> be invoked, since in that case <code>this</code> itself is its normal matrix.
+     * In that case, use {@link Matrix3f#set(Matrix4f)} to set a given Matrix3f to only the upper left 3x3 submatrix
+     * of this matrix.
+     * 
+     * @see Matrix3f#set(Matrix4f)
+     * @see #get3x3(Matrix3f)
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3f normal(Matrix3f dest) {
+        float det = determinant3x3();
+        float s = 1.0f / det;
+        /* Invert and transpose in one go */
+        dest.m00 = (m11 * m22 - m21 * m12) * s;
+        dest.m01 = (m20 * m12 - m10 * m22) * s;
+        dest.m02 = (m10 * m21 - m20 * m11) * s;
+        dest.m10 = (m21 * m02 - m01 * m22) * s;
+        dest.m11 = (m00 * m22 - m20 * m02) * s;
+        dest.m12 = (m20 * m01 - m00 * m21) * s;
+        dest.m20 = (m01 * m12 - m11 * m02) * s;
+        dest.m21 = (m10 * m02 - m00 * m12) * s;
+        dest.m22 = (m00 * m11 - m10 * m01) * s;
+        return dest;
+    }
+
+    /**
+     * Normalize the upper left 3x3 submatrix of this matrix.
+     * <p>
+     * The resulting matrix will map unit vectors to unit vectors, though a pair of orthogonal input unit
+     * vectors need not be mapped to a pair of orthogonal output vectors if the original matrix was not orthogonal itself
+     * (i.e. had <i>skewing</i>).
+     * 
+     * @return this
+     */
+    public Matrix4f normalize3x3() {
+        return normalize3x3(this);
+    }
+
+    /**
+     * Normalize the upper left 3x3 submatrix of this matrix and store the result in <code>dest</code>.
+     * <p>
+     * The resulting matrix will map unit vectors to unit vectors, though a pair of orthogonal input unit
+     * vectors need not be mapped to a pair of orthogonal output vectors if the original matrix was not orthogonal itself
+     * (i.e. had <i>skewing</i>).
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix4f normalize3x3(Matrix4f dest) {
+        float invXlen = (float) (1.0 / Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02));
+        float invYlen = (float) (1.0 / Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12));
+        float invZlen = (float) (1.0 / Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22));
+        dest.m00 = m00 * invXlen; dest.m01 = m01 * invXlen; dest.m02 = m02 * invXlen;
+        dest.m10 = m10 * invYlen; dest.m11 = m11 * invYlen; dest.m12 = m12 * invYlen;
+        dest.m20 = m20 * invZlen; dest.m21 = m21 * invZlen; dest.m22 = m22 * invZlen;
+        return dest;
+    }
+
+    /**
+     * Normalize the upper left 3x3 submatrix of this matrix and store the result in <code>dest</code>.
+     * <p>
+     * The resulting matrix will map unit vectors to unit vectors, though a pair of orthogonal input unit
+     * vectors need not be mapped to a pair of orthogonal output vectors if the original matrix was not orthogonal itself
+     * (i.e. had <i>skewing</i>).
+     * 
+     * @param dest
+     *             will hold the result
+     * @return dest
+     */
+    public Matrix3f normalize3x3(Matrix3f dest) {
+        float invXlen = (float) (1.0 / Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02));
+        float invYlen = (float) (1.0 / Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12));
+        float invZlen = (float) (1.0 / Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22));
+        dest.m00 = m00 * invXlen; dest.m01 = m01 * invXlen; dest.m02 = m02 * invXlen;
+        dest.m10 = m10 * invYlen; dest.m11 = m11 * invYlen; dest.m12 = m12 * invYlen;
+        dest.m20 = m20 * invZlen; dest.m21 = m21 * invZlen; dest.m22 = m22 * invZlen;
+        return dest;
+    }
+
+    /**
+     * Calculate a frustum plane of <code>this</code> matrix, which
+     * can be a projection matrix or a combined modelview-projection matrix, and store the result
+     * in the given <code>planeEquation</code>.
+     * <p>
+     * Generally, this method computes the frustum plane in the local frame of
+     * any coordinate system that existed before <code>this</code>
+     * transformation was applied to it in order to yield homogeneous clipping space.
+     * <p>
+     * The frustum plane will be given in the form of a general plane equation:
+     * <tt>a*x + b*y + c*z + d = 0</tt>, where the given {@link Vector4f} components will
+     * hold the <tt>(a, b, c, d)</tt> values of the equation.
+     * <p>
+     * The plane normal, which is <tt>(a, b, c)</tt>, is directed "inwards" of the frustum.
+     * Any plane/point test using <tt>a*x + b*y + c*z + d</tt> therefore will yield a result greater than zero
+     * if the point is within the frustum (i.e. at the <i>positive</i> side of the frustum plane).
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     *
+     * @param plane
+     *          one of the six possible planes, given as numeric constants
+     *          {@link #PLANE_NX}, {@link #PLANE_PX},
+     *          {@link #PLANE_NY}, {@link #PLANE_PY},
+     *          {@link #PLANE_NZ} and {@link #PLANE_PZ}
+     * @param planeEquation
+     *          will hold the computed plane equation.
+     *          The plane equation will be normalized, meaning that <tt>(a, b, c)</tt> will be a unit vector
+     * @return planeEquation
+     */
+    public Vector4f frustumPlane(int plane, Vector4f planeEquation) {
+        switch (plane) {
+        case PLANE_NX:
+            planeEquation.set(m03 + m00, m13 + m10, m23 + m20, m33 + m30).normalize3();
+            break;
+        case PLANE_PX:
+            planeEquation.set(m03 - m00, m13 - m10, m23 - m20, m33 - m30).normalize3();
+            break;
+        case PLANE_NY:
+            planeEquation.set(m03 + m01, m13 + m11, m23 + m21, m33 + m31).normalize3();
+            break;
+        case PLANE_PY:
+            planeEquation.set(m03 - m01, m13 - m11, m23 - m21, m33 - m31).normalize3();
+            break;
+        case PLANE_NZ:
+            planeEquation.set(m03 + m02, m13 + m12, m23 + m22, m33 + m32).normalize3();
+            break;
+        case PLANE_PZ:
+            planeEquation.set(m03 - m02, m13 - m12, m23 - m22, m33 - m32).normalize3();
+            break;
+        default:
+            throw new IllegalArgumentException("plane"); //$NON-NLS-1$
+        }
+        return planeEquation;
+    }
+
+    /**
+     * Compute the corner coordinates of the frustum defined by <code>this</code> matrix, which
+     * can be a projection matrix or a combined modelview-projection matrix, and store the result
+     * in the given <code>point</code>.
+     * <p>
+     * Generally, this method computes the frustum corners in the local frame of
+     * any coordinate system that existed before <code>this</code>
+     * transformation was applied to it in order to yield homogeneous clipping space.
+     * <p>
+     * Reference: <a href="http://geomalgorithms.com/a05-_intersect-1.html">http://geomalgorithms.com</a>
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * 
+     * @param corner
+     *          one of the eight possible corners, given as numeric constants
+     *          {@link #CORNER_NXNYNZ}, {@link #CORNER_PXNYNZ}, {@link #CORNER_PXPYNZ}, {@link #CORNER_NXPYNZ},
+     *          {@link #CORNER_PXNYPZ}, {@link #CORNER_NXNYPZ}, {@link #CORNER_NXPYPZ}, {@link #CORNER_PXPYPZ}
+     * @param point
+     *          will hold the resulting corner point coordinates
+     * @return point
+     */
+    public Vector3f frustumCorner(int corner, Vector3f point) {
+        float d1, d2, d3;
+        float n1x, n1y, n1z, n2x, n2y, n2z, n3x, n3y, n3z;
+        switch (corner) {
+        case CORNER_NXNYNZ: // left, bottom, near
+            n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+            n2x = m03 + m01; n2y = m13 + m11; n2z = m23 + m21; d2 = m33 + m31; // bottom
+            n3x = m03 + m02; n3y = m13 + m12; n3z = m23 + m22; d3 = m33 + m32; // near
+            break;
+        case CORNER_PXNYNZ: // right, bottom, near
+            n1x = m03 - m00; n1y = m13 - m10; n1z = m23 - m20; d1 = m33 - m30; // right
+            n2x = m03 + m01; n2y = m13 + m11; n2z = m23 + m21; d2 = m33 + m31; // bottom
+            n3x = m03 + m02; n3y = m13 + m12; n3z = m23 + m22; d3 = m33 + m32; // near
+            break;
+        case CORNER_PXPYNZ: // right, top, near
+            n1x = m03 - m00; n1y = m13 - m10; n1z = m23 - m20; d1 = m33 - m30; // right
+            n2x = m03 - m01; n2y = m13 - m11; n2z = m23 - m21; d2 = m33 - m31; // top
+            n3x = m03 + m02; n3y = m13 + m12; n3z = m23 + m22; d3 = m33 + m32; // near
+            break;
+        case CORNER_NXPYNZ: // left, top, near
+            n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+            n2x = m03 - m01; n2y = m13 - m11; n2z = m23 - m21; d2 = m33 - m31; // top
+            n3x = m03 + m02; n3y = m13 + m12; n3z = m23 + m22; d3 = m33 + m32; // near
+            break;
+        case CORNER_PXNYPZ: // right, bottom, far
+            n1x = m03 - m00; n1y = m13 - m10; n1z = m23 - m20; d1 = m33 - m30; // right
+            n2x = m03 + m01; n2y = m13 + m11; n2z = m23 + m21; d2 = m33 + m31; // bottom
+            n3x = m03 - m02; n3y = m13 - m12; n3z = m23 - m22; d3 = m33 - m32; // far
+            break;
+        case CORNER_NXNYPZ: // left, bottom, far
+            n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+            n2x = m03 + m01; n2y = m13 + m11; n2z = m23 + m21; d2 = m33 + m31; // bottom
+            n3x = m03 - m02; n3y = m13 - m12; n3z = m23 - m22; d3 = m33 - m32; // far
+            break;
+        case CORNER_NXPYPZ: // left, top, far
+            n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+            n2x = m03 - m01; n2y = m13 - m11; n2z = m23 - m21; d2 = m33 - m31; // top
+            n3x = m03 - m02; n3y = m13 - m12; n3z = m23 - m22; d3 = m33 - m32; // far
+            break;
+        case CORNER_PXPYPZ: // right, top, far
+            n1x = m03 - m00; n1y = m13 - m10; n1z = m23 - m20; d1 = m33 - m30; // right
+            n2x = m03 - m01; n2y = m13 - m11; n2z = m23 - m21; d2 = m33 - m31; // top
+            n3x = m03 - m02; n3y = m13 - m12; n3z = m23 - m22; d3 = m33 - m32; // far
+            break;
+        default:
+            throw new IllegalArgumentException("corner"); //$NON-NLS-1$
+        }
+        float c23x, c23y, c23z;
+        c23x = n2y * n3z - n2z * n3y;
+        c23y = n2z * n3x - n2x * n3z;
+        c23z = n2x * n3y - n2y * n3x;
+        float c31x, c31y, c31z;
+        c31x = n3y * n1z - n3z * n1y;
+        c31y = n3z * n1x - n3x * n1z;
+        c31z = n3x * n1y - n3y * n1x;
+        float c12x, c12y, c12z;
+        c12x = n1y * n2z - n1z * n2y;
+        c12y = n1z * n2x - n1x * n2z;
+        c12z = n1x * n2y - n1y * n2x;
+        float invDot = 1.0f / (n1x * c23x + n1y * c23y + n1z * c23z);
+        point.x = (-c23x * d1 - c31x * d2 - c12x * d3) * invDot;
+        point.y = (-c23y * d1 - c31y * d2 - c12y * d3) * invDot;
+        point.z = (-c23z * d1 - c31z * d2 - c12z * d3) * invDot;
+        return point;
+    }
+
+    /**
+     * Compute the eye/origin of the perspective frustum transformation defined by <code>this</code> matrix, 
+     * which can be a projection matrix or a combined modelview-projection matrix, and store the result
+     * in the given <code>origin</code>.
+     * <p>
+     * Note that this method will only work using perspective projections obtained via one of the
+     * perspective methods, such as {@link #perspective(float, float, float, float) perspective()}
+     * or {@link #frustum(float, float, float, float, float, float) frustum()}.
+     * <p>
+     * Generally, this method computes the origin in the local frame of
+     * any coordinate system that existed before <code>this</code>
+     * transformation was applied to it in order to yield homogeneous clipping space.
+     * <p>
+     * Reference: <a href="http://geomalgorithms.com/a05-_intersect-1.html">http://geomalgorithms.com</a>
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * 
+     * @param origin
+     *          will hold the origin of the coordinate system before applying <code>this</code>
+     *          perspective projection transformation
+     * @return origin
+     */
+    public Vector3f perspectiveOrigin(Vector3f origin) {
+        /*
+         * Simply compute the intersection point of the left, right and top frustum plane.
+         */
+        float d1, d2, d3;
+        float n1x, n1y, n1z, n2x, n2y, n2z, n3x, n3y, n3z;
+        n1x = m03 + m00; n1y = m13 + m10; n1z = m23 + m20; d1 = m33 + m30; // left
+        n2x = m03 - m00; n2y = m13 - m10; n2z = m23 - m20; d2 = m33 - m30; // right
+        n3x = m03 - m01; n3y = m13 - m11; n3z = m23 - m21; d3 = m33 - m31; // top
+        float c23x, c23y, c23z;
+        c23x = n2y * n3z - n2z * n3y;
+        c23y = n2z * n3x - n2x * n3z;
+        c23z = n2x * n3y - n2y * n3x;
+        float c31x, c31y, c31z;
+        c31x = n3y * n1z - n3z * n1y;
+        c31y = n3z * n1x - n3x * n1z;
+        c31z = n3x * n1y - n3y * n1x;
+        float c12x, c12y, c12z;
+        c12x = n1y * n2z - n1z * n2y;
+        c12y = n1z * n2x - n1x * n2z;
+        c12z = n1x * n2y - n1y * n2x;
+        float invDot = 1.0f / (n1x * c23x + n1y * c23y + n1z * c23z);
+        origin.x = (-c23x * d1 - c31x * d2 - c12x * d3) * invDot;
+        origin.y = (-c23y * d1 - c31y * d2 - c12y * d3) * invDot;
+        origin.z = (-c23z * d1 - c31z * d2 - c12z * d3) * invDot;
+        return origin;
+    }
+
+    /**
+     * Return the vertical field-of-view angle in radians of this perspective transformation matrix.
+     * <p>
+     * Note that this method will only work using perspective projections obtained via one of the
+     * perspective methods, such as {@link #perspective(float, float, float, float) perspective()}
+     * or {@link #frustum(float, float, float, float, float, float) frustum()}.
+     * <p>
+     * For orthogonal transformations this method will return <tt>0.0</tt>.
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * 
+     * @return the vertical field-of-view angle in radians
+     */
+    public float perspectiveFov() {
+        /*
+         * Compute the angle between the bottom and top frustum plane normals.
+         */
+        float n1x, n1y, n1z, n2x, n2y, n2z;
+        n1x = m03 + m01; n1y = m13 + m11; n1z = m23 + m21; // bottom
+        n2x = m01 - m03; n2y = m11 - m13; n2z = m21 - m23; // top
+        float n1len = (float) Math.sqrt(n1x * n1x + n1y * n1y + n1z * n1z);
+        float n2len = (float) Math.sqrt(n2x * n2x + n2y * n2y + n2z * n2z);
+        return (float) Math.acos((n1x * n2x + n1y * n2y + n1z * n2z) / (n1len * n2len));
+    }
+
+    /**
+     * Obtain the direction of a ray starting at the center of the coordinate system and going 
+     * through the near frustum plane.
+     * <p>
+     * This method computes the <code>dir</code> vector in the local frame of
+     * any coordinate system that existed before <code>this</code>
+     * transformation was applied to it in order to yield homogeneous clipping space.
+     * <p>
+     * The parameters <code>x</code> and <code>y</code> are used to interpolate the generated ray direction
+     * from the bottom-left to the top-right frustum corners.
+     * <p>
+     * For optimal efficiency when building many ray directions over the whole frustum,
+     * it is recommended to use this method only in order to compute the four corner rays at
+     * <tt>(0, 0)</tt>, <tt>(1, 0)</tt>, <tt>(0, 1)</tt> and <tt>(1, 1)</tt>
+     * and then bilinearly interpolating between them; or to use the {@link FrustumRayBuilder}.
+     * <p>
+     * Reference: <a href="http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf">
+     * Fast Extraction of Viewing Frustum Planes from the World-View-Projection Matrix</a>
+     * 
+     * @param x
+     *          the interpolation factor along the left-to-right frustum planes, within <tt>[0..1]</tt>
+     * @param y
+     *          the interpolation factor along the bottom-to-top frustum planes, within <tt>[0..1]</tt>
+     * @param dir
+     *          will hold the normalized ray direction in the local frame of the coordinate system before 
+     *          transforming to homogeneous clipping space using <code>this</code> matrix
+     * @return dir
+     */
+    public Vector3f frustumRayDir(float x, float y, Vector3f dir) {
+        /*
+         * This method works by first obtaining the frustum plane normals,
+         * then building the cross product to obtain the corner rays,
+         * and finally bilinearly interpolating to obtain the desired direction.
+         * The code below uses a condense form of doing all this making use 
+         * of some mathematical identities to simplify the overall expression.
+         */
+        float a = m10 * m23, b = m13 * m21, c = m10 * m21, d = m11 * m23, e = m13 * m20, f = m11 * m20;
+        float g = m03 * m20, h = m01 * m23, i = m01 * m20, j = m03 * m21, k = m00 * m23, l = m00 * m21;
+        float m = m00 * m13, n = m03 * m11, o = m00 * m11, p = m01 * m13, q = m03 * m10, r = m01 * m10;
+        float m1x, m1y, m1z;
+        m1x = (d + e + f - a - b - c) * (1.0f - y) + (a - b - c + d - e + f) * y;
+        m1y = (j + k + l - g - h - i) * (1.0f - y) + (g - h - i + j - k + l) * y;
+        m1z = (p + q + r - m - n - o) * (1.0f - y) + (m - n - o + p - q + r) * y;
+        float m2x, m2y, m2z;
+        m2x = (b - c - d + e + f - a) * (1.0f - y) + (a + b - c - d - e + f) * y;
+        m2y = (h - i - j + k + l - g) * (1.0f - y) + (g + h - i - j - k + l) * y;
+        m2z = (n - o - p + q + r - m) * (1.0f - y) + (m + n - o - p - q + r) * y;
+        dir.x = m1x + (m2x - m1x) * x;
+        dir.y = m1y + (m2y - m1y) * x;
+        dir.z = m1z + (m2z - m1z) * x;
+        dir.normalize();
+        return dir;
+    }
+
+    /**
+     * Obtain the direction of <tt>+Z</tt> before the orthogonal transformation represented by
+     * <code>this</code> matrix is applied.
+     * <p>
+     * This method uses the rotation component of the upper left 3x3 submatrix to obtain the direction 
+     * that is transformed to <tt>+Z</tt> by <code>this</code> matrix.
+     * <p>
+     * Reference: <a href="http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/threeD/">http://www.euclideanspace.com</a>
+     * 
+     * @param dir
+     *          will hold the direction of <tt>+Z</tt>
+     * @return dir
+     */
+    public Vector3f positiveZ(Vector3f dir) {
+        dir.x = m10 * m21 - m11 * m20;
+        dir.y = m20 * m01 - m21 * m00;
+        dir.z = m00 * m11 - m01 * m10;
+        dir.normalize();
+        return dir;
+    }
+
+    /**
+     * Obtain the direction of <tt>+X</tt> before the orthogonal transformation represented by
+     * <code>this</code> matrix is applied.
+     * <p>
+     * This method uses the rotation component of the upper left 3x3 submatrix to obtain the direction 
+     * that is transformed to <tt>+X</tt> by <code>this</code> matrix.
+     * <p>
+     * Reference: <a href="http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/threeD/">http://www.euclideanspace.com</a>
+     * 
+     * @param dir
+     *          will hold the direction of <tt>+X</tt>
+     * @return dir
+     */
+    public Vector3f positiveX(Vector3f dir) {
+        dir.x = m11 * m22 - m12 * m21;
+        dir.y = m02 * m21 - m01 * m22;
+        dir.z = m01 * m12 - m02 * m11;
+        dir.normalize();
+        return dir;
+    }
+
+    /**
+     * Obtain the direction of <tt>+Y</tt> before the orthogonal transformation represented by
+     * <code>this</code> matrix is applied.
+     * <p>
+     * This method uses the rotation component of the upper left 3x3 submatrix to obtain the direction 
+     * that is transformed to <tt>+Y</tt> by <code>this</code> matrix.
+     * <p>
+     * Reference: <a href="http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/threeD/">http://www.euclideanspace.com</a>
+     * 
+     * @param dir
+     *          will hold the direction of <tt>+Y</tt>
+     * @return dir
+     */
+    public Vector3f positiveY(Vector3f dir) {
+        dir.x = m12 * m20 - m10 * m22;
+        dir.y = m00 * m22 - m02 * m20;
+        dir.z = m02 * m10 - m00 * m12;
+        dir.normalize();
+        return dir;
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane specified via the general plane equation
+     * <tt>x*a + y*b + z*c + d = 0</tt> as if casting a shadow from a given light position/direction <code>light</code>.
+     * <p>
+     * If <tt>light.w</tt> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="ftp://ftp.sgi.com/opengl/contrib/blythe/advanced99/notes/node192.html">ftp.sgi.com</a>
+     * 
+     * @param light
+     *          the light's vector
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return this
+     */
+    public Matrix4f shadow(Vector4f light, float a, float b, float c, float d) {
+        return shadow(light.x, light.y, light.z, light.w, a, b, c, d, this);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane specified via the general plane equation
+     * <tt>x*a + y*b + z*c + d = 0</tt> as if casting a shadow from a given light position/direction <code>light</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <tt>light.w</tt> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="ftp://ftp.sgi.com/opengl/contrib/blythe/advanced99/notes/node192.html">ftp.sgi.com</a>
+     * 
+     * @param light
+     *          the light's vector
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f shadow(Vector4f light, float a, float b, float c, float d, Matrix4f dest) {
+        return shadow(light.x, light.y, light.z, light.w, a, b, c, d, dest);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane specified via the general plane equation
+     * <tt>x*a + y*b + z*c + d = 0</tt> as if casting a shadow from a given light position/direction <tt>(lightX, lightY, lightZ, lightW)</tt>.
+     * <p>
+     * If <code>lightW</code> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="ftp://ftp.sgi.com/opengl/contrib/blythe/advanced99/notes/node192.html">ftp.sgi.com</a>
+     * 
+     * @param lightX
+     *          the x-component of the light's vector
+     * @param lightY
+     *          the y-component of the light's vector
+     * @param lightZ
+     *          the z-component of the light's vector
+     * @param lightW
+     *          the w-component of the light's vector
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return this
+     */
+    public Matrix4f shadow(float lightX, float lightY, float lightZ, float lightW, float a, float b, float c, float d) {
+        return shadow(lightX, lightY, lightZ, lightW, a, b, c, d, this);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane specified via the general plane equation
+     * <tt>x*a + y*b + z*c + d = 0</tt> as if casting a shadow from a given light position/direction <tt>(lightX, lightY, lightZ, lightW)</tt>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>lightW</code> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * <p>
+     * Reference: <a href="ftp://ftp.sgi.com/opengl/contrib/blythe/advanced99/notes/node192.html">ftp.sgi.com</a>
+     * 
+     * @param lightX
+     *          the x-component of the light's vector
+     * @param lightY
+     *          the y-component of the light's vector
+     * @param lightZ
+     *          the z-component of the light's vector
+     * @param lightW
+     *          the w-component of the light's vector
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f shadow(float lightX, float lightY, float lightZ, float lightW, float a, float b, float c, float d, Matrix4f dest) {
+        // normalize plane
+        float invPlaneLen = (float) (1.0 / Math.sqrt(a*a + b*b + c*c));
+        float an = a * invPlaneLen;
+        float bn = b * invPlaneLen;
+        float cn = c * invPlaneLen;
+        float dn = d * invPlaneLen;
+
+        float dot = an * lightX + bn * lightY + cn * lightZ + dn * lightW;
+
+        // compute right matrix elements
+        float rm00 = dot - an * lightX;
+        float rm01 = -an * lightY;
+        float rm02 = -an * lightZ;
+        float rm03 = -an * lightW;
+        float rm10 = -bn * lightX;
+        float rm11 = dot - bn * lightY;
+        float rm12 = -bn * lightZ;
+        float rm13 = -bn * lightW;
+        float rm20 = -cn * lightX;
+        float rm21 = -cn * lightY;
+        float rm22 = dot - cn * lightZ;
+        float rm23 = -cn * lightW;
+        float rm30 = -dn * lightX;
+        float rm31 = -dn * lightY;
+        float rm32 = -dn * lightZ;
+        float rm33 = dot - dn * lightW;
+
+        // matrix multiplication
+        float nm00 = m00 * rm00 + m10 * rm01 + m20 * rm02 + m30 * rm03;
+        float nm01 = m01 * rm00 + m11 * rm01 + m21 * rm02 + m31 * rm03;
+        float nm02 = m02 * rm00 + m12 * rm01 + m22 * rm02 + m32 * rm03;
+        float nm03 = m03 * rm00 + m13 * rm01 + m23 * rm02 + m33 * rm03;
+        float nm10 = m00 * rm10 + m10 * rm11 + m20 * rm12 + m30 * rm13;
+        float nm11 = m01 * rm10 + m11 * rm11 + m21 * rm12 + m31 * rm13;
+        float nm12 = m02 * rm10 + m12 * rm11 + m22 * rm12 + m32 * rm13;
+        float nm13 = m03 * rm10 + m13 * rm11 + m23 * rm12 + m33 * rm13;
+        float nm20 = m00 * rm20 + m10 * rm21 + m20 * rm22 + m30 * rm23;
+        float nm21 = m01 * rm20 + m11 * rm21 + m21 * rm22 + m31 * rm23;
+        float nm22 = m02 * rm20 + m12 * rm21 + m22 * rm22 + m32 * rm23;
+        float nm23 = m03 * rm20 + m13 * rm21 + m23 * rm22 + m33 * rm23;
+        dest.m30 = m00 * rm30 + m10 * rm31 + m20 * rm32 + m30 * rm33;
+        dest.m31 = m01 * rm30 + m11 * rm31 + m21 * rm32 + m31 * rm33;
+        dest.m32 = m02 * rm30 + m12 * rm31 + m22 * rm32 + m32 * rm33;
+        dest.m33 = m03 * rm30 + m13 * rm31 + m23 * rm32 + m33 * rm33;
+        dest.m00 = nm00;
+        dest.m01 = nm01;
+        dest.m02 = nm02;
+        dest.m03 = nm03;
+        dest.m10 = nm10;
+        dest.m11 = nm11;
+        dest.m12 = nm12;
+        dest.m13 = nm13;
+        dest.m20 = nm20;
+        dest.m21 = nm21;
+        dest.m22 = nm22;
+        dest.m23 = nm23;
+
+        return dest;
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane with the general plane equation
+     * <tt>y = 0</tt> as if casting a shadow from a given light position/direction <code>light</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * Before the shadow projection is applied, the plane is transformed via the specified <code>planeTransformation</code>.
+     * <p>
+     * If <tt>light.w</tt> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param light
+     *          the light's vector
+     * @param planeTransform
+     *          the transformation to transform the implied plane <tt>y = 0</tt> before applying the projection
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f shadow(Vector4f light, Matrix4f planeTransform, Matrix4f dest) {
+        // compute plane equation by transforming (y = 0)
+        float a = planeTransform.m10;
+        float b = planeTransform.m11;
+        float c = planeTransform.m12;
+        float d = -a * planeTransform.m30 - b * planeTransform.m31 - c * planeTransform.m32;
+        return shadow(light.x, light.y, light.z, light.w, a, b, c, d, dest);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane with the general plane equation
+     * <tt>y = 0</tt> as if casting a shadow from a given light position/direction <code>light</code>.
+     * <p>
+     * Before the shadow projection is applied, the plane is transformed via the specified <code>planeTransformation</code>.
+     * <p>
+     * If <tt>light.w</tt> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param light
+     *          the light's vector
+     * @param planeTransform
+     *          the transformation to transform the implied plane <tt>y = 0</tt> before applying the projection
+     * @return this
+     */
+    public Matrix4f shadow(Vector4f light, Matrix4f planeTransform) {
+        return shadow(light, planeTransform, this);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane with the general plane equation
+     * <tt>y = 0</tt> as if casting a shadow from a given light position/direction <tt>(lightX, lightY, lightZ, lightW)</tt>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * Before the shadow projection is applied, the plane is transformed via the specified <code>planeTransformation</code>.
+     * <p>
+     * If <code>lightW</code> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param lightX
+     *          the x-component of the light vector
+     * @param lightY
+     *          the y-component of the light vector
+     * @param lightZ
+     *          the z-component of the light vector
+     * @param lightW
+     *          the w-component of the light vector
+     * @param planeTransform
+     *          the transformation to transform the implied plane <tt>y = 0</tt> before applying the projection
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Matrix4f shadow(float lightX, float lightY, float lightZ, float lightW, Matrix4f planeTransform, Matrix4f dest) {
+        // compute plane equation by transforming (y = 0)
+        float a = planeTransform.m10;
+        float b = planeTransform.m11;
+        float c = planeTransform.m12;
+        float d = -a * planeTransform.m30 - b * planeTransform.m31 - c * planeTransform.m32;
+        return shadow(lightX, lightY, lightZ, lightW, a, b, c, d, dest);
+    }
+
+    /**
+     * Apply a projection transformation to this matrix that projects onto the plane with the general plane equation
+     * <tt>y = 0</tt> as if casting a shadow from a given light position/direction <tt>(lightX, lightY, lightZ, lightW)</tt>.
+     * <p>
+     * Before the shadow projection is applied, the plane is transformed via the specified <code>planeTransformation</code>.
+     * <p>
+     * If <code>lightW</code> is <tt>0.0</tt> the light is being treated as a directional light; if it is <tt>1.0</tt> it is a point light.
+     * <p>
+     * If <code>M</code> is <code>this</code> matrix and <code>S</code> the shadow matrix,
+     * then the new matrix will be <code>M * S</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>M * S * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @param lightX
+     *          the x-component of the light vector
+     * @param lightY
+     *          the y-component of the light vector
+     * @param lightZ
+     *          the z-component of the light vector
+     * @param lightW
+     *          the w-component of the light vector
+     * @param planeTransform
+     *          the transformation to transform the implied plane <tt>y = 0</tt> before applying the projection
+     * @return this
+     */
+    public Matrix4f shadow(float lightX, float lightY, float lightZ, float lightW, Matrix4f planeTransform) {
+        return shadow(lightX, lightY, lightZ, lightW, planeTransform, this);
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/MatrixStack.java
+++ b/GVRf/Framework/src/org/joml/MatrixStack.java
@@ -1,0 +1,859 @@
+/*
+ * (C) Copyright 2015 Kai Burjack
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Serializable;
+import java.nio.FloatBuffer;
+
+/**
+ * Resembles the matrix stack known from legacy OpenGL.
+ * <p>
+ * The operation names and semantics resemble those of the legacy OpenGL matrix
+ * stack.
+ * <p>
+ * As with the OpenGL version there is no way to get a hold of any matrix
+ * instance within the stack. You can only load the current matrix into a
+ * user-supplied {@link Matrix4f} instance.
+ * 
+ * @author Kai Burjack
+ */
+public class MatrixStack implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The matrix stack as a non-growable array. The size of the stack must be
+     * specified in the {@link #MatrixStack(int) constructor}.
+     */
+    private Matrix4f[] mats;
+
+    /**
+     * The index of the "current" matrix within {@link #mats}.
+     */
+    private int curr;
+
+    /**
+     * Create a new {@link MatrixStack} of the given size.
+     * <p>
+     * Initially the stack pointer is at zero and the current matrix is set to
+     * identity.
+     * 
+     * @param stackSize
+     *            the size of the stack. This must be at least 1
+     */
+    public MatrixStack(int stackSize) {
+        if (stackSize < 1) {
+            throw new IllegalArgumentException("stackSize must be >= 1"); //$NON-NLS-1$
+        }
+        mats = new Matrix4f[stackSize];
+        // Allocate all matrices up front to keep the promise of being
+        // "allocation-free"
+        for (int i = 0; i < stackSize; i++) {
+            mats[i] = new Matrix4f();
+        }
+    }
+
+    /**
+     * Dispose of all but the first matrix in this stack and set the stack
+     * counter to zero.
+     * <p>
+     * The first matrix will also be set to identity.
+     * 
+     * @return this
+     */
+    public MatrixStack clear() {
+        curr = 0;
+        mats[0].identity();
+        return this;
+    }
+
+    /**
+     * Load the given {@link Matrix4f} into the current matrix of the stack.
+     * 
+     * @param mat
+     *            the matrix which is stored in the current stack matrix
+     * @return this
+     */
+    public MatrixStack loadMatrix(Matrix4f mat) {
+        if (mat == null) {
+            throw new IllegalArgumentException("mat must not be null"); //$NON-NLS-1$
+        }
+        mats[curr].set(mat);
+        return this;
+    }
+
+    /**
+     * Load the values of a column-major matrix from the given
+     * {@link FloatBuffer} into the current matrix of the stack.
+     * 
+     * @param columnMajorArray
+     *            the values of the 4x4 matrix as a column-major
+     *            {@link FloatBuffer} containing at least 16 floats starting at
+     *            the relative {@link FloatBuffer#position()}
+     * @return this
+     */
+    public MatrixStack loadMatrix(FloatBuffer columnMajorArray) {
+        if (columnMajorArray == null) {
+            throw new IllegalArgumentException("columnMajorArray must not be null"); //$NON-NLS-1$
+        }
+        mats[curr].set(columnMajorArray);
+        return this;
+    }
+
+    /**
+     * Load the values of a column-major matrix from the given float array into
+     * the current matrix of the stack.
+     * 
+     * @param columnMajorArray
+     *            the values of the 4x4 matrix as a column-major float array of
+     *            at least 16 floats
+     * @param offset
+     *            the offset into the array
+     * @return this
+     */
+    public MatrixStack loadMatrix(float[] columnMajorArray, int offset) {
+        if (columnMajorArray == null) {
+            throw new IllegalArgumentException("columnMajorArray must not be null"); //$NON-NLS-1$
+        }
+        if (columnMajorArray.length - offset < 16) {
+            throw new IllegalArgumentException("columnMajorArray does not have enough elements"); //$NON-NLS-1$
+        }
+        mats[curr].set(columnMajorArray, offset);
+        return this;
+    }
+
+    /**
+     * Increment the stack pointer by one and set the values of the new current
+     * matrix to the one directly below it.
+     * 
+     * @return this
+     */
+    public MatrixStack pushMatrix() {
+        if (curr == mats.length - 1) {
+            throw new IllegalStateException("max stack size of " + (curr + 1) + " reached"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        mats[curr + 1].set(mats[curr]);
+        curr++;
+        return this;
+    }
+
+    /**
+     * Decrement the stack pointer by one.
+     * <p>
+     * This will effectively dispose of the current matrix.
+     * 
+     * @return this
+     */
+    public MatrixStack popMatrix() {
+        if (curr == 0) {
+            throw new IllegalStateException("already at the buttom of the stack"); //$NON-NLS-1$
+        }
+        curr--;
+        return this;
+    }
+
+    /**
+     * Store the current matrix of the stack into the supplied <code>dest</code>
+     * matrix.
+     * 
+     * @param dest
+     *            the destination {@link Matrix4f} into which to store the
+     *            current stack matrix
+     * @return <code>dest</code>
+     */
+    public Matrix4f get(Matrix4f dest) {
+        if (dest == null) {
+            throw new IllegalArgumentException("dest must not be null"); //$NON-NLS-1$
+        }
+        dest.set(mats[curr]);
+        return dest;
+    }
+
+    /**
+     * Store the current matrix into the supplied {@link FloatBuffer} at the
+     * current buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given
+     * FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the matrix is stored, use {@link #get(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, FloatBuffer)
+     * @see Matrix4f#get(int, FloatBuffer)
+     * 
+     * @param dest
+     *            the destination FloatBuffer into which to store the
+     *            column-major values of the current stack matrix
+     * @return this
+     */
+    public MatrixStack get(FloatBuffer dest) {
+        if (dest == null) {
+            throw new IllegalArgumentException("dest must not be null"); //$NON-NLS-1$
+        }
+        if (dest.remaining() < 16) {
+            throw new IllegalArgumentException("dest does not have enough space"); //$NON-NLS-1$
+        }
+        mats[curr].get(dest);
+        return this;
+    }
+
+    /**
+     * Store the current matrix into the supplied {@link FloatBuffer} starting
+     * at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given
+     * {@link FloatBuffer}.
+     * <p>
+     * In order to store the matrix at the current buffer's position, use {@link #get(FloatBuffer)} instead.
+     * 
+     * @see #get(FloatBuffer)
+     * @see Matrix4f#get(FloatBuffer)
+     * 
+     * @param index
+     *            the absolute position into the {@link FloatBuffer}
+     * @param dest
+     *            will receive the values of this matrix in column-major order
+     * @return this
+     */
+    public MatrixStack get(int index, FloatBuffer dest) {
+        if (dest == null) {
+            throw new IllegalArgumentException("dest must not be null"); //$NON-NLS-1$
+        }
+        if (dest.remaining() < 16) {
+            throw new IllegalArgumentException("dest does not have enough space"); //$NON-NLS-1$
+        }
+        mats[curr].get(index, dest);
+        return this;
+    }
+
+    /**
+     * Store the column-major values of the current matrix of the stack into the
+     * supplied float array at the given offset.
+     * 
+     * @param dest
+     *            the destination float array into which to store the
+     *            column-major values of the current stack matrix
+     * @param offset
+     *            the array offset
+     * @return <code>dest</code>
+     */
+    public float[] get(float[] dest, int offset) {
+        if (dest == null) {
+            throw new IllegalArgumentException("dest must not be null"); //$NON-NLS-1$
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must not be negative"); //$NON-NLS-1$
+        }
+        if (dest.length - offset < 16) {
+            throw new IllegalArgumentException("dest does not have enough elements"); //$NON-NLS-1$
+        }
+        mats[curr].get(dest, offset);
+        return dest;
+    }
+
+    /**
+     * Get a reference to the current matrix of the stack directly without
+     * copying its values to a user-supplied matrix like in
+     * {@link #get(Matrix4f)}.
+     * <p>
+     * Note that any changes made to this matrix will also change the current
+     * stack matrix!
+     *
+     * @return the current stack matrix
+     */
+    public Matrix4f getDirect() {
+        return mats[curr];
+    }
+
+    /**
+     * Apply a translation to the current matrix by translating by the given
+     * number of units in x, y and z.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>T</code> the
+     * translation matrix, then the new current matrix will be
+     * <code>C * T</code>. So when transforming a vector <code>v</code> with the
+     * new matrix by using <code>C * T * v</code>, the translation will be
+     * applied first!
+     * 
+     * @param x
+     *          the offset in x
+     * @param y
+     *          the offset in y
+     * @param z
+     *          the offset in z
+     * @return this
+     */
+    public MatrixStack translate(float x, float y, float z) {
+        Matrix4f c = mats[curr];
+        c.translate(x, y, z);
+        return this;
+    }
+
+    /**
+     * Apply a translation to the current matrix by translating by the number of
+     * units in the given {@link Vector3f}.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>T</code> the
+     * translation matrix, then the new matrix will be <code>C * T</code>. So
+     * when transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * T * v</code>, the translation will be applied first!
+     * 
+     * @see #translate(float, float, float)
+     * 
+     * @param xyz
+     *            contains the number of units to translate by
+     * @return this
+     */
+    public MatrixStack translate(Vector3f xyz) {
+        if (xyz == null) {
+            throw new IllegalArgumentException("xyz must not be null"); //$NON-NLS-1$
+        }
+        translate(xyz.x, xyz.y, xyz.z);
+        return this;
+    }
+
+    /**
+     * Apply scaling to the current matrix by scaling by the given x, y and z
+     * factors.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>S</code> the scaling
+     * matrix, then the new current matrix will be <code>C * S</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * S * v</code>, the scaling will be applied first!
+     * 
+     * @param x
+     *            the factor of the x component
+     * @param y
+     *            the factor of the y component
+     * @param z
+     *            the factor of the z component
+     * @return this
+     */
+    public MatrixStack scale(float x, float y, float z) {
+        Matrix4f c = mats[curr];
+        c.scale(x, y, z);
+        return this;
+    }
+
+    /**
+     * Apply a scaling transformation to the current matrix by scaling by the
+     * factors in the given {@link Vector3f}.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>S</code> the scaling
+     * matrix, then the new matrix will be <code>C * S</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * S * v</code>, the scaling will be applied first!
+     * 
+     * @see #scale(float, float, float)
+     * 
+     * @param xyz
+     *            contains the factors to scale by
+     * @return this
+     */
+    public MatrixStack scale(Vector3f xyz) {
+        if (xyz == null) {
+            throw new IllegalArgumentException("xyz must not be null"); //$NON-NLS-1$
+        }
+        this.scale(xyz.x, xyz.y, xyz.z);
+        return this;
+    }
+
+    /**
+     * Apply scaling to the current matrix by uniformly scaling all unit axes by
+     * the given <code>xyz</code> factor.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>S</code> the scaling
+     * matrix, then the new matrix will be <code>C * S</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * S * v</code>, the scaling will be applied first!
+     * 
+     * @see #scale(float, float, float)
+     * 
+     * @param xyz
+     *            the factor for all components
+     * @return this
+     */
+    public MatrixStack scale(float xyz) {
+        return scale(xyz, xyz, xyz);
+    }
+
+    /**
+     * Apply rotation to the current matrix by rotating the given amount of
+     * degrees about the given axis specified as x, y and z component.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the rotation
+     * matrix, then the new current matrix will be <code>C * R</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * R * v</code>, the rotation will be applied first!
+     * 
+     * @param ang
+     *            the angle is in degrees
+     * @param x
+     *            the x component of the axis
+     * @param y
+     *            the y component of the axis
+     * @param z
+     *            the z component of the axis
+     * @return this
+     */
+    public MatrixStack rotate(float ang, float x, float y, float z) {
+        Matrix4f c = mats[curr];
+        c.rotate(ang, x, y, z);
+        return this;
+    }
+
+    /**
+     * Apply a rotation transformation to the current matrix by rotating the
+     * given amount of degrees about the given <code>axis</code>
+     * {@link Vector3f}.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the rotation
+     * matrix, then the new current matrix will be <code>C * R</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * R * v</code>, the rotation will be applied first!
+     * 
+     * @see #rotate(float, float, float, float)
+     * 
+     * @param ang
+     *            the angle in degrees
+     * @param axis
+     *            the axis to rotate about
+     * @return this
+     */
+    public MatrixStack rotate(float ang, Vector3f axis) {
+        if (axis == null) {
+            throw new IllegalArgumentException("axis must not be null"); //$NON-NLS-1$
+        }
+        rotate(ang, axis.x, axis.y, axis.z);
+        return this;
+    }
+
+    /**
+     * Apply the rotation transformation of the given {@link Quaternionf} to the
+     * current matrix.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the rotation
+     * matrix, then the new current matrix will be <code>C * R</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * R * v</code>, the rotation will be applied first!
+     * 
+     * @param quat
+     *            the {@link Quaternionf}
+     * @return this
+     */
+    public MatrixStack rotate(Quaternionf quat) {
+        if (quat == null) {
+            throw new IllegalArgumentException("quat must not be null"); //$NON-NLS-1$
+        }
+        mats[curr].rotate(quat);
+        return this;
+    }
+
+    /**
+     * Apply a rotation transformation, rotating about the given
+     * {@link AxisAngle4f}, to the current matrix.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the rotation
+     * matrix, then the new current matrix will be <code>C * R</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * R * v</code>, the rotation will be applied first!
+     * 
+     * @param angleAxis
+     *            the {@link AxisAngle4f} (needs to be
+     *            {@link AxisAngle4f#normalize() normalized})
+     * @return this
+     */
+    public MatrixStack rotate(AxisAngle4f angleAxis) {
+        if (angleAxis == null) {
+            throw new IllegalArgumentException("angleAxis must not be null"); //$NON-NLS-1$
+        }
+        mats[curr].rotate(angleAxis);
+        return this;
+    }
+
+    /**
+     * Apply rotation about the X axis to the current matrix by rotating the
+     * given amount of degrees.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the rotation
+     * matrix, then the new current matrix will be <code>C * R</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * R * v</code>, the rotation will be applied first!
+     * 
+     * @param ang
+     *            the angle in degrees
+     * @return this
+     */
+    public MatrixStack rotateX(float ang) {
+        mats[curr].rotateX(ang);
+        return this;
+    }
+
+    /**
+     * Apply rotation about the Y axis to the current matrix by rotating the
+     * given amount of degrees.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the rotation
+     * matrix, then the new current matrix will be <code>C * R</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * R * v</code>, the rotation will be applied first!
+     * 
+     * @param ang
+     *            the angle in degrees
+     * @return this
+     */
+    public MatrixStack rotateY(float ang) {
+        mats[curr].rotateY(ang);
+        return this;
+    }
+
+    /**
+     * Apply rotation about the X axis to the current matrix by rotating the
+     * given amount of degrees.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the rotation
+     * matrix, then the new current matrix will be <code>C * R</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * R * v</code>, the rotation will be applied first!
+     * 
+     * @param ang
+     *            the angle in degrees
+     * @return this
+     */
+    public MatrixStack rotateZ(float ang) {
+        mats[curr].rotateZ(ang);
+        return this;
+    }
+
+    /**
+     * Set the current matrix to identity.
+     * 
+     * @return this
+     */
+    public MatrixStack loadIdentity() {
+        mats[curr].identity();
+        return this;
+    }
+
+    /**
+     * Post-multiply the given matrix <code>mat</code> against the current
+     * matrix.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>M</code> the supplied
+     * matrix, then the new current matrix will be <code>C * M</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * M * v</code>, the supplied matrix <code>mat</code> will be
+     * applied first!
+     * 
+     * @param mat
+     *            the matrix to multiply this matrix with
+     * @return this
+     */
+    public MatrixStack multMatrix(Matrix4f mat) {
+        if (mat == null) {
+            throw new IllegalArgumentException("mat must not be null"); //$NON-NLS-1$
+        }
+        mats[curr].mul(mat);
+        return this;
+    }
+
+    /**
+     * Apply a "lookat" transformation to the current matrix for a right-handed coordinate system, 
+     * that aligns <code>-z</code> with <code>center - eye</code>.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>L</code> the lookat
+     * matrix, then the new current matrix will be <code>C * L</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * L * v</code>, the lookat transformation will be applied first!
+     * 
+     * @param position
+     *            the position of the camera
+     * @param centre
+     *            the point in space to look at
+     * @param up
+     *            the direction of 'up'. In most cases it is (x=0, y=1, z=0)
+     * @return this
+     */
+    public MatrixStack lookAt(Vector3f position, Vector3f centre, Vector3f up) {
+        mats[curr].lookAt(position, centre, up);
+        return this;
+    }
+
+    /**
+     * Apply a "lookat" transformation to the current matrix for a right-handed
+     * coordinate system, that aligns <code>-z</code> with
+     * <code>center - eye</code>.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>L</code> the lookat
+     * matrix, then the new current matrix will be <code>C * L</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * L * v</code>, the lookat transformation will be applied first!
+     * 
+     * @see #lookAt(Vector3f, Vector3f, Vector3f)
+     * 
+     * @param eyeX
+     *              the x-coordinate of the eye/camera location
+     * @param eyeY
+     *              the y-coordinate of the eye/camera location
+     * @param eyeZ
+     *              the z-coordinate of the eye/camera location
+     * @param centerX
+     *              the x-coordinate of the point to look at
+     * @param centerY
+     *              the y-coordinate of the point to look at
+     * @param centerZ
+     *              the z-coordinate of the point to look at
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public MatrixStack lookAt(float eyeX, float eyeY, float eyeZ, float centerX, float centerY, float centerZ,
+            float upX, float upY, float upZ) {
+        mats[curr].lookAt(eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ);
+        return this;
+    }
+
+    /**
+     * Apply a rotation transformation to the current matrix to make
+     * <code>-z</code> point along <code>dir</code>.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>L</code> the lookalong
+     * matrix, then the new current matrix will be <code>C * L</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * L * v</code>, the lookalong transformation will be applied
+     * first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(float, float, float, float, float, float, float, float, float)
+     * lookAt} with <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public MatrixStack lookAlong(float dirX, float dirY, float dirZ, float upX, float upY, float upZ) {
+        mats[curr].lookAlong(dirX, dirY, dirZ, upX, upY, upZ);
+        return this;
+    }
+
+    /**
+     * Apply a rotation transformation to the current matrix to make
+     * <code>-z</code> point along <code>dir</code>.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>L</code> the lookalong
+     * matrix, then the new current matrix will be <code>C * L</code>. So when
+     * transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * L * v</code>, the lookalong transformation will be applied
+     * first!
+     * <p>
+     * This is equivalent to calling
+     * {@link #lookAt(Vector3f, Vector3f, Vector3f) lookAt} with
+     * <code>eye = (0, 0, 0)</code> and <code>center = dir</code>.
+     * 
+     * @param dir
+     *            the direction in space to look along
+     * @param up
+     *            the direction of 'up'
+     * @return this
+     */
+    public MatrixStack lookAlong(Vector3f dir, Vector3f up) {
+        mats[curr].lookAlong(dir, up);
+        return this;
+    }
+
+    /**
+     * Apply a symmetric perspective projection frustum transformation to the
+     * current matrix.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>P</code> the
+     * perspective projection matrix, then the new matrix will be
+     * <code>C * P</code>. So when transforming a vector <code>v</code> with the
+     * new matrix by using <code>C * P * v</code>, the perspective projection
+     * will be applied first!
+     * 
+     * @param fovy
+     *            the vertical field of view in degrees
+     * @param aspect
+     *            the aspect ratio (i.e. width / height)
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public MatrixStack perspective(float fovy, float aspect, float zNear, float zFar) {
+        mats[curr].perspective(fovy, aspect, zNear, zFar);
+        return this;
+    }
+
+    /**
+     * Apply an orthographic projection transformation to the current matrix.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>O</code> the
+     * orthographic projection matrix, then the new matrix will be
+     * <code>C * O</code>. So when transforming a vector <code>v</code> with the
+     * new matrix by using <code>C * O * v</code>, the orthographic projection
+     * will be applied first!
+     * 
+     * @param left
+     *            the distance from the center to the left frustum edge
+     * @param right
+     *            the distance from the center to the right frustum edge
+     * @param bottom
+     *            the distance from the center to the bottom frustum edge
+     * @param top
+     *            the distance from the center to the top frustum edge
+     * @param zNear
+     *            near clipping plane distance
+     * @param zFar
+     *            far clipping plane distance
+     * @return this
+     */
+    public MatrixStack ortho(float left, float right, float bottom, float top, float zNear, float zFar) {
+        mats[curr].ortho(left, right, bottom, top, zNear, zFar);
+        return this;
+    }
+
+    /**
+     * Apply an arbitrary perspective projection frustum transformation to the
+     * current matrix.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>F</code> the frustum
+     * projection matrix, then the new matrix will be <code>C * F</code>. So
+     * when transforming a vector <code>v</code> with the new matrix by using
+     * <code>C * F * v</code>, the frustum projection will be applied first!
+     * 
+     * @param left
+     *            the distance along the x-axis to the left frustum edge
+     * @param right
+     *            the distance along the x-axis to the right frustum edge
+     * @param bottom
+     *            the distance along the y-axis to the bottom frustum edge
+     * @param top
+     *            the distance along the y-axis to the top frustum edge
+     * @param zNear
+     *            the distance along the z-axis to the near clipping plane
+     * @param zFar
+     *            the distance along the z-axis to the far clipping plane
+     * @return this
+     */
+    public MatrixStack frustum(float left, float right, float bottom, float top, float zNear, float zFar) {
+        mats[curr].frustum(left, right, bottom, top, zNear, zFar);
+        return this;
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to the current matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>C * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>C * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @see Matrix4f#reflect(float, float, float, float, float, float)
+     * 
+     * @param nx
+     *          the x-coordinate of the plane normal
+     * @param ny
+     *          the y-coordinate of the plane normal
+     * @param nz
+     *          the z-coordinate of the plane normal
+     * @param px
+     *          the x-coordinate of a point on the plane
+     * @param py
+     *          the y-coordinate of a point on the plane
+     * @param pz
+     *          the z-coordinate of a point on the plane
+     * @return this
+     */
+    public MatrixStack reflect(float nx, float ny, float nz, float px, float py, float pz) {
+        mats[curr].reflect(nx, ny, nz, px, py, pz);
+        return this;
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to the current matrix that reflects about the given plane
+     * specified via the plane normal and a point on the plane.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>C * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>C * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @see Matrix4f#reflect(Vector3f, Vector3f)
+     * 
+     * @param normal
+     *          the plane normal
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public MatrixStack reflect(Vector3f normal, Vector3f point) {
+        mats[curr].reflect(normal, point);
+        return this;
+    }
+
+    /**
+     * Apply a mirror/reflection transformation to the current matrix that reflects about a plane
+     * specified via the plane orientation and a point on the plane.
+     * <p>
+     * This method can be used to build a reflection transformation based on the orientation of a mirror object in the scene.
+     * It is assumed that the default mirror plane's normal is <tt>(0, 0, 1)</tt>. So, if the given {@link Quaternionf} is
+     * the identity (does not apply any additional rotation), the reflection plane will be <tt>z=0</tt>, offset by the given <code>point</code>.
+     * <p>
+     * If <code>C</code> is the current matrix and <code>R</code> the reflection matrix,
+     * then the new matrix will be <code>C * R</code>. So when transforming a
+     * vector <code>v</code> with the new matrix by using <code>C * R * v</code>, the
+     * reflection will be applied first!
+     * 
+     * @see Matrix4f#reflect(Quaternionf, Vector3f)
+     * 
+     * @param orientation
+     *          the plane orientation
+     * @param point
+     *          a point on the plane
+     * @return this
+     */
+    public MatrixStack reflect(Quaternionf orientation, Vector3f point) {
+        mats[curr].reflect(orientation, point);
+        return this;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Quaterniond.java
+++ b/GVRf/Framework/src/org/joml/Quaterniond.java
@@ -1,0 +1,2553 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Contains the definition and functions for rotations expressed as
+ * 4-dimensional vectors
+ *
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Quaterniond implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The first component of the vector part.
+     */
+    public double x;
+    /**
+     * The second component of the vector part.
+     */
+    public double y;
+    /**
+     * The third component of the vector part.
+     */
+    public double z;
+    /**
+     * The real/scalar part of the quaternion.
+     */
+    public double w;
+
+    /**
+     * Create a new {@link Quaterniond} and initialize it with <tt>(x=0, y=0, z=0, w=1)</tt>, 
+     * where <tt>(x, y, z)</tt> is the vector part of the quaternion and <tt>w</tt> is the real/scalar part.
+     */
+    public Quaterniond() {
+        x = 0.0;
+        y = 0.0;
+        z = 0.0;
+        w = 1.0;
+    }
+
+    /**
+     * Create a new {@link Quaterniond} and initialize its components to the given values.
+     * 
+     * @param x
+     *          the first component of the imaginary part
+     * @param y
+     *          the second component of the imaginary part
+     * @param z
+     *          the third component of the imaginary part
+     * @param w
+     *          the real part
+     */
+    public Quaterniond(double x, double y, double z, double w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Quaterniond} and initialize its imaginary components to the given values,
+     * and its real part to <tt>1.0</tt>.
+     * 
+     * @param x
+     *          the first component of the imaginary part
+     * @param y
+     *          the second component of the imaginary part
+     * @param z
+     *          the third component of the imaginary part
+     */
+    public Quaterniond(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = 1.0;
+    }
+
+    /**
+     * Create a new {@link Quaterniond} and initialize its components to the same values as the given {@link Quaterniond}.
+     * 
+     * @param source
+     *          the {@link Quaterniond} to take the component values from
+     */
+    public Quaterniond(Quaterniond source) {
+        x = source.x;
+        y = source.y;
+        z = source.z;
+        w = source.w;
+    }
+
+    /**
+     * Create a new {@link Quaterniond} and initialize its components to the same values as the given {@link Quaternionf}.
+     * 
+     * @param source
+     *          the {@link Quaternionf} to take the component values from
+     */
+    public Quaterniond(Quaternionf source) {
+        x = source.x;
+        y = source.y;
+        z = source.z;
+        w = source.w;
+    }
+
+    /**
+     * Create a new {@link Quaterniond} and initialize it to represent the same rotation as the given {@link AxisAngle4f}.
+     * 
+     * @param axisAngle
+     *          the axis-angle to initialize this quaternion with
+     */
+    public Quaterniond(AxisAngle4f axisAngle) {
+        double s = Math.sin(axisAngle.angle * 0.5);
+        x = axisAngle.x * s;
+        y = axisAngle.y * s;
+        z = axisAngle.z * s;
+        w = Math.cos(axisAngle.angle * 0.5);
+    }
+
+    /**
+     * Create a new {@link Quaterniond} and initialize it to represent the same rotation as the given {@link AxisAngle4d}.
+     * 
+     * @param axisAngle
+     *          the axis-angle to initialize this quaternion with
+     */
+    public Quaterniond(AxisAngle4d axisAngle) {
+        double s = Math.sin(axisAngle.angle * 0.5);
+        x = axisAngle.x * s;
+        y = axisAngle.y * s;
+        z = axisAngle.z * s;
+        w = Math.cos(axisAngle.angle * 0.5);
+    }
+
+    /**
+     * Normalize this quaternion.
+     * 
+     * @return this
+     */
+    public Quaterniond normalize() {
+        double invNorm = 1.0 / Math.sqrt(x * x + y * y + z * z + w * w);
+        x *= invNorm;
+        y *= invNorm;
+        z *= invNorm;
+        w *= invNorm;
+        return this;
+    }
+
+    /**
+     * Normalize this quaternion and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond normalize(Quaterniond dest) {
+        double invNorm = 1.0 / Math.sqrt(x * x + y * y + z * z + w * w);
+        dest.x = x * invNorm;
+        dest.y = y * invNorm;
+        dest.z = z * invNorm;
+        dest.w = w * invNorm;
+        return dest;
+    }
+
+    /**
+     * Add <code>q2</code> to this quaternion.
+     * 
+     * @param q2
+     *          the quaternion to add to this
+     * @return this
+     */
+    public Quaterniond add(Quaterniond q2) {
+        x += q2.x;
+        y += q2.y;
+        z += q2.z;
+        w += q2.w;
+        return this;
+    }
+
+    /**
+     * Add <code>q2</code> to this quaternion and store the result in <code>dest</code>.
+     * 
+     * @param q2
+     *          the quaternion to add to this
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond add(Quaterniond q2, Quaterniond dest) {
+        dest.x = x + q2.x;
+        dest.y = y + q2.y;
+        dest.z = z + q2.z;
+        dest.w = w + q2.w;
+        return dest;
+    }
+
+    /**
+     * Return the dot product of this {@link Quaterniond} and <code>otherQuat</code>.
+     * 
+     * @param otherQuat
+     *          the other quaternion
+     * @return the dot product
+     */
+    public double dot(Quaterniond otherQuat) {
+        return this.x * otherQuat.x + this.y * otherQuat.y + this.z * otherQuat.z + this.w * otherQuat.w;
+    }
+
+    /**
+     * Return the angle in radians represented by this quaternion rotation.
+     * 
+     * @return the angle in radians
+     */
+    public double angle() {
+        double angle = 2.0 * Math.acos(w);
+        return angle <= Math.PI ? angle : 2.0 * Math.PI - angle;
+    }
+
+    /**
+     * Set the given destination matrix to the rotation represented by <code>this</code>.
+     * 
+     * @param dest
+     *          the matrix to write the rotation into
+     * @return the passed in destination
+     */
+    public Matrix3d get(Matrix3d dest) {
+        double q00 = 2.0 * x * x;
+        double q11 = 2.0 * y * y;
+        double q22 = 2.0 * z * z;
+
+        double q01 = 2.0 * x * y;
+        double q02 = 2.0 * x * z;
+        double q03 = 2.0 * x * w;
+
+        double q12 = 2.0 * y * z;
+        double q13 = 2.0 * y * w;
+
+        double q23 = 2.0 * z * w;
+
+        dest.m00 = 1.0 - q11 - q22;
+        dest.m01 = q01 + q23;
+        dest.m02 = q02 - q13;
+        dest.m10 = q01 - q23;
+        dest.m11 = 1.0 - q22 - q00;
+        dest.m12 = q12 + q03;
+        dest.m20 = q02 + q13;
+        dest.m21 = q12 - q03;
+        dest.m22 = 1.0 - q11 - q00;
+        return dest;
+    }
+
+    /**
+     * Set the given destination matrix to the rotation represented by <code>this</code>.
+     * 
+     * @param dest
+     *          the matrix to write the rotation into
+     * @return the passed in destination
+     */
+    public Matrix3f get(Matrix3f dest) {
+        double q00 = 2.0 * x * x;
+        double q11 = 2.0 * y * y;
+        double q22 = 2.0 * z * z;
+
+        double q01 = 2.0 * x * y;
+        double q02 = 2.0 * x * z;
+        double q03 = 2.0 * x * w;
+
+        double q12 = 2.0 * y * z;
+        double q13 = 2.0 * y * w;
+
+        double q23 = 2.0 * z * w;
+
+        dest.m00 = (float) (1.0 - q11 - q22);
+        dest.m01 = (float) (q01 + q23);
+        dest.m02 = (float) (q02 - q13);
+        dest.m10 = (float) (q01 - q23);
+        dest.m11 = (float) (1.0 - q22 - q00);
+        dest.m12 = (float) (q12 + q03);
+        dest.m20 = (float) (q02 + q13);
+        dest.m21 = (float) (q12 - q03);
+        dest.m22 = (float) (1.0 - q11 - q00);
+        return dest;
+    }
+
+    /**
+     * Set the given destination matrix to the rotation represented by <code>this</code>.
+     * 
+     * @param dest
+     *          the matrix to write the rotation into
+     * @return the passed in destination
+     */
+    public Matrix4d get(Matrix4d dest) {
+        double q00 = 2.0 * x * x;
+        double q11 = 2.0 * y * y;
+        double q22 = 2.0 * z * z;
+
+        double q01 = 2.0 * x * y;
+        double q02 = 2.0 * x * z;
+        double q03 = 2.0 * x * w;
+
+        double q12 = 2.0 * y * z;
+        double q13 = 2.0 * y * w;
+
+        double q23 = 2.0 * z * w;
+
+        dest.m00 = 1.0 - q11 - q22;
+        dest.m01 = q01 + q23;
+        dest.m02 = q02 - q13;
+        dest.m03 = 0.0;
+        dest.m10 = q01 - q23;
+        dest.m11 = 1.0 - q22 - q00;
+        dest.m12 = q12 + q03;
+        dest.m13 = 0.0;
+        dest.m20 = q02 + q13;
+        dest.m21 = q12 - q03;
+        dest.m22 = 1.0 - q11 - q00;
+        dest.m30 = 0.0;
+        dest.m31 = 0.0;
+        dest.m32 = 0.0;
+        dest.m33 = 1.0;
+        return dest;
+    }
+
+    /**
+     * Set the given destination matrix to the rotation represented by <code>this</code>.
+     * 
+     * @param dest
+     *          the matrix to write the rotation into
+     * @return the passed in destination
+     */
+    public Matrix4f get(Matrix4f dest) {
+        double q00 = 2.0 * x * x;
+        double q11 = 2.0 * y * y;
+        double q22 = 2.0 * z * z;
+
+        double q01 = 2.0 * x * y;
+        double q02 = 2.0 * x * z;
+        double q03 = 2.0 * x * w;
+
+        double q12 = 2.0 * y * z;
+        double q13 = 2.0 * y * w;
+
+        double q23 = 2.0 * z * w;
+
+        dest.m00 = (float) (1.0 - q11 - q22);
+        dest.m01 = (float) (q01 + q23);
+        dest.m02 = (float) (q02 - q13);
+        dest.m03 = 0.0f;
+        dest.m10 = (float) (q01 - q23);
+        dest.m11 = (float) (1.0 - q22 - q00);
+        dest.m12 = (float) (q12 + q03);
+        dest.m13 = 0.0f;
+        dest.m20 = (float) (q02 + q13);
+        dest.m21 = (float) (q12 - q03);
+        dest.m22 = (float) (1.0 - q11 - q00);
+        dest.m30 = 0.0f;
+        dest.m31 = 0.0f;
+        dest.m32 = 0.0f;
+        dest.m33 = 1.0f;
+        return dest;
+    }
+
+    /**
+     * Set the given {@link Quaterniond} to the values of <code>this</code>.
+     * 
+     * @see #set(Quaterniond)
+     * 
+     * @param dest
+     *          the {@link Quaterniond} to set
+     * @return the passed in destination
+     */
+    public Quaterniond get(Quaterniond dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Set this quaternion to the new values.
+     * 
+     * @param x
+     *          the new value of x
+     * @param y
+     *          the new value of y
+     * @param z
+     *          the new value of z
+     * @param w
+     *          the new value of w
+     * @return this
+     */
+    public Quaterniond set(double x, double y, double z, double w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Set the x, y and z components of this quaternion to the new values.
+     * 
+     * @param x
+     *          the new value of x
+     * @param y
+     *          the new value of y
+     * @param z
+     *          the new value of z
+     * @return this
+     */
+    public Quaterniond set(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a copy of q.
+     * 
+     * @param q
+     *          the {@link Quaterniond} to copy
+     * @return this
+     */
+    public Quaterniond set(Quaterniond q) {
+        x = q.x;
+        y = q.y;
+        z = q.z;
+        w = q.w;
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a copy of q.
+     * 
+     * @param q
+     *          the {@link Quaternionf} to copy
+     * @return this
+     */
+    public Quaterniond set(Quaternionf q) {
+        x = q.x;
+        y = q.y;
+        z = q.z;
+        w = q.w;
+        return this;
+    }
+
+    /**
+     * Set this {@link Quaterniond} to be equivalent to the given
+     * {@link AxisAngle4f}.
+     * 
+     * @param axisAngle
+     *            the {@link AxisAngle4f}
+     * @return this
+     */
+    public Quaterniond set(AxisAngle4f axisAngle) {
+        return setAngleAxis(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this {@link Quaterniond} to be equivalent to the given
+     * {@link AxisAngle4d}.
+     * 
+     * @param axisAngle
+     *            the {@link AxisAngle4d}
+     * @return this
+     */
+    public Quaterniond set(AxisAngle4d axisAngle) {
+        return setAngleAxis(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this quaternion to a rotation equivalent to the supplied axis and
+     * angle (in radians).
+     * <p>
+     * This method assumes that the given rotation axis <tt>(x, y, z)</tt> is already normalized
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param x
+     *          the x-component of the normalized rotation axis
+     * @param y
+     *          the y-component of the normalized rotation axis
+     * @param z
+     *          the z-component of the normalized rotation axis
+     * @return this
+     */
+    public Quaterniond setAngleAxis(double angle, double x, double y, double z) {
+        double s = Math.sin(angle * 0.5);
+        this.x = x * s;
+        this.y = y * s;
+        this.z = z * s;
+        this.w = Math.cos(angle * 0.5);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the supplied axis and
+     * angle (in radians).
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param axis
+     *          the rotation axis
+     * @return this
+     */
+    public Quaterniond setAngleAxis(double angle, Vector3d axis) {
+        return setAngleAxis(angle, axis.x, axis.y, axis.z);
+    }
+
+    private void setFromUnnormalized(double m00, double m01, double m02, double m10, double m11, double m12, double m20, double m21, double m22) {
+        double nm00 = m00, nm01 = m01, nm02 = m02;
+        double nm10 = m10, nm11 = m11, nm12 = m12;
+        double nm20 = m20, nm21 = m21, nm22 = m22;
+        double lenX = 1.0 / Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02);
+        double lenY = 1.0 / Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12);
+        double lenZ = 1.0 / Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22);
+        nm00 *= lenX; nm01 *= lenX; nm02 *= lenX;
+        nm10 *= lenY; nm11 *= lenY; nm12 *= lenY;
+        nm20 *= lenZ; nm21 *= lenZ; nm22 *= lenZ;
+        setFromNormalized(nm00, nm01, nm02, nm10, nm11, nm12, nm20, nm21, nm22);
+    }
+
+    private void setFromNormalized(double m00, double m01, double m02, double m10, double m11, double m12, double m20, double m21, double m22) {
+        double t;
+        double tr = m00 + m11 + m22;
+        if (tr >= 0.0) {
+            t = Math.sqrt(tr + 1.0);
+            w = t * 0.5;
+            t = 0.5 / t;
+            x = (m12 - m21) * t;
+            y = (m20 - m02) * t;
+            z = (m01 - m10) * t;
+        } else {
+            if (m00 >= m11 && m00 >= m22) {
+                t = Math.sqrt(m00 - (m11 + m22) + 1.0);
+                x = t * 0.5;
+                t = 0.5 / t;
+                y = (m10 + m01) * t;
+                z = (m02 + m20) * t;
+                w = (m12 - m21) * t;
+            } else if (m11 > m22) {
+                t = Math.sqrt(m11 - (m22 + m00) + 1.0);
+                y = t * 0.5;
+                t = 0.5 / t;
+                z = (m21 + m12) * t;
+                x = (m10 + m01) * t;
+                w = (m20 - m02) * t;
+            } else {
+                t = Math.sqrt(m22 - (m00 + m11) + 1.0);
+                z = t * 0.5;
+                t = 0.5 / t;
+                x = (m02 + m20) * t;
+                y = (m21 + m12) * t;
+                w = (m01 - m10) * t;
+            }
+        }
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are no unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaterniond setFromUnnormalized(Matrix4f mat) {
+        setFromUnnormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaterniond setFromNormalized(Matrix4f mat) {
+        setFromNormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are no unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaterniond setFromUnnormalized(Matrix4d mat) {
+        setFromUnnormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaterniond setFromNormalized(Matrix4d mat) {
+        setFromNormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are no unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaterniond setFromUnnormalized(Matrix3f mat) {
+        setFromUnnormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaterniond setFromNormalized(Matrix3f mat) {
+        setFromNormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are no unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaterniond setFromUnnormalized(Matrix3d mat) {
+        setFromUnnormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaterniond setFromNormalized(Matrix3d mat) {
+        setFromNormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the supplied axis and
+     * angle (in radians).
+     * 
+     * @param axis
+     *          the rotation axis
+     * @param angle
+     *          the angle in radians
+     * @return this
+     */
+    public Quaterniond fromAxisAngleRad(Vector3d axis, double angle) {
+        double hangle = angle / 2.0;
+        double sinAngle = Math.sin(hangle);
+        double vLength = axis.length();
+
+        x = axis.x / vLength * sinAngle;
+        y = axis.y / vLength * sinAngle;
+        z = axis.z / vLength * sinAngle;
+        w = Math.cos(hangle);
+        
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the supplied axis and
+     * angle (in radians).
+     * 
+     * @param axisX
+     *          the x component of the rotation axis
+     * @param axisY
+     *          the y component of the rotation axis
+     * @param axisZ
+     *          the z component of the rotation axis         
+     * @param angle
+     *          the angle in radians
+     * @return this
+     */
+    public Quaterniond fromAxisAngleRad(double axisX, double axisY, double axisZ, double angle) {
+        double hangle = angle / 2.0;
+        double sinAngle = Math.sin(hangle);
+        double vLength = Math.sqrt(axisX * axisX + axisY * axisY + axisZ * axisZ);
+
+        x = axisX / vLength * sinAngle;
+        y = axisY / vLength * sinAngle;
+        z = axisZ / vLength * sinAngle;
+        w = Math.cos(hangle);
+        
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the supplied axis and
+     * angle (in radians).
+     * 
+     * @param axis
+     *          the rotation axis
+     * @param angle
+     *          the angle in radians
+     * @return this
+     */
+    public Quaterniond fromAxisAngleDeg(Vector3d axis, double angle) {
+        double hangle = angle / 2.0;
+        double sinAngle = Math.sin(hangle);
+        double vLength = axis.length();
+
+        x = axis.x / vLength * sinAngle;
+        y = axis.y / vLength * sinAngle;
+        z = axis.z / vLength * sinAngle;
+        w = Math.cos(hangle);
+        
+        return this;
+    }
+
+    /**
+     * Multiply this quaternion by <code>q</code>.
+     * <p>
+     * If <tt>T</tt> is <code>this</code> and <tt>Q</tt> is the given
+     * quaternion, then the resulting quaternion <tt>R</tt> is:
+     * <p>
+     * <tt>R = T * Q</tt>
+     * <p>
+     * So, this method uses post-multiplication like the matrix classes, resulting in a
+     * vector to be transformed by <tt>Q</tt> first, and then by <tt>T</tt>.
+     * 
+     * @param q
+     *          the quaternion to multiply <code>this</code> by
+     * @return this
+     */
+    public Quaterniond mul(Quaterniond q) {
+        return mul(q, this);
+    }
+
+    /**
+     * Multiply this quaternion by <code>q</code> and store the result in <code>dest</code>.
+     * <p>
+     * If <tt>T</tt> is <code>this</code> and <tt>Q</tt> is the given
+     * quaternion, then the resulting quaternion <tt>R</tt> is:
+     * <p>
+     * <tt>R = T * Q</tt>
+     * <p>
+     * So, this method uses post-multiplication like the matrix classes, resulting in a
+     * vector to be transformed by <tt>Q</tt> first, and then by <tt>T</tt>.
+     * 
+     * @param q
+     *            the quaternion to multiply <code>this</code> by
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Quaterniond mul(Quaterniond q, Quaterniond dest) {
+        dest.set(w * q.x + x * q.w + y * q.z - z * q.y,
+                 w * q.y - x * q.z + y * q.w + z * q.x,
+                 w * q.z + x * q.y - y * q.x + z * q.w,
+                 w * q.w - x * q.x - y * q.y - z * q.z);
+        return dest;
+    }
+
+    /**
+     * Multiply this quaternion by the quaternion represented via <tt>(qx, qy, qz, qw)</tt>.
+     * <p>
+     * If <tt>T</tt> is <code>this</code> and <tt>Q</tt> is the given
+     * quaternion, then the resulting quaternion <tt>R</tt> is:
+     * <p>
+     * <tt>R = T * Q</tt>
+     * <p>
+     * So, this method uses post-multiplication like the matrix classes, resulting in a
+     * vector to be transformed by <tt>Q</tt> first, and then by <tt>T</tt>.
+     * 
+     * @param qx
+     *          the x component of the quaternion to multiply <code>this</code> by
+     * @param qy
+     *          the y component of the quaternion to multiply <code>this</code> by
+     * @param qz
+     *          the z component of the quaternion to multiply <code>this</code> by
+     * @param qw
+     *          the w component of the quaternion to multiply <code>this</code> by
+     * @return this
+     */
+    public Quaterniond mul(double qx, double qy, double qz, double qw) {
+        set(w * qx + x * qw + y * qz - z * qy,
+            w * qy - x * qz + y * qw + z * qx,
+            w * qz + x * qy - y * qx + z * qw,
+            w * qw - x * qx - y * qy - z * qz);
+        return this;
+    }
+
+    /**
+     * Multiply this quaternion by the quaternion represented via <tt>(qx, qy, qz, qw)</tt> and store the result in <code>dest</code>.
+     * <p>
+     * If <tt>T</tt> is <code>this</code> and <tt>Q</tt> is the given
+     * quaternion, then the resulting quaternion <tt>R</tt> is:
+     * <p>
+     * <tt>R = T * Q</tt>
+     * <p>
+     * So, this method uses post-multiplication like the matrix classes, resulting in a
+     * vector to be transformed by <tt>Q</tt> first, and then by <tt>T</tt>.
+     * 
+     * @param qx
+     *          the x component of the quaternion to multiply <code>this</code> by
+     * @param qy
+     *          the y component of the quaternion to multiply <code>this</code> by
+     * @param qz
+     *          the z component of the quaternion to multiply <code>this</code> by
+     * @param qw
+     *          the w component of the quaternion to multiply <code>this</code> by
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Quaterniond mul(double qx, double qy, double qz, double qw, Quaterniond dest) {
+        dest.set(w * qx + x * qw + y * qz - z * qy,
+                 w * qy - x * qz + y * qw + z * qx,
+                 w * qz + x * qy - y * qx + z * qw,
+                 w * qw - x * qx - y * qy - z * qz);
+        return dest;
+    }
+
+    /**
+     * Transform the given vector by this quaternion.
+     * This will apply the rotation described by this quaternion to the given vector.
+     * 
+     * @param vec
+     *          the vector to transform
+     * @return vec
+     */
+    public Vector3d transform(Vector3d vec){
+        return transform(vec, vec);
+    }
+
+    /**
+     * Transform the given vector by this quaternion and store the result in <code>dest</code>.
+     * This will apply the rotation described by this quaternion to the given vector.
+     * 
+     * @param vec
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d transform(Vector3d vec, Vector3d dest) {
+        double num = x * 2.0;
+        double num2 = y * 2.0;
+        double num3 = z * 2.0;
+        double num4 = x * num;
+        double num5 = y * num2;
+        double num6 = z * num3;
+        double num7 = x * num2;
+        double num8 = x * num3;
+        double num9 = y * num3;
+        double num10 = w * num;
+        double num11 = w * num2;
+        double num12 = w * num3;
+        dest.set((1.0 - (num5 + num6)) * vec.x + (num7 - num12) * vec.y + (num8 + num11) * vec.z,
+                 (num7 + num12) * vec.x + (1.0 - (num4 + num6)) * vec.y + (num9 - num10) * vec.z,
+                 (num8 - num11) * vec.x + (num9 + num10) * vec.y + (1.0 - (num4 + num5)) * vec.z);
+        return dest;
+    }
+
+    /**
+     * Transform the given vector by this quaternion.
+     * This will apply the rotation described by this quaternion to the given vector.
+     * <p>
+     * Only the first three components of the given 4D vector are being used and modified.
+     * 
+     * @param vec
+     *          the vector to transform
+     * @return vec
+     */
+    public Vector4d transform(Vector4d vec){
+        return transform(vec, vec);
+    }
+
+    /**
+     * Transform the given vector by this quaternion and store the result in <code>dest</code>.
+     * This will apply the rotation described by this quaternion to the given vector.
+     * <p>
+     * Only the first three components of the given 4D vector are being used and set on the destination.
+     * 
+     * @param vec
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d transform(Vector4d vec, Vector4d dest) {
+        double num = x * 2.0;
+        double num2 = y * 2.0;
+        double num3 = z * 2.0;
+        double num4 = x * num;
+        double num5 = y * num2;
+        double num6 = z * num3;
+        double num7 = x * num2;
+        double num8 = x * num3;
+        double num9 = y * num3;
+        double num10 = w * num;
+        double num11 = w * num2;
+        double num12 = w * num3;
+        dest.set((1.0 - (num5 + num6)) * vec.x + (num7 - num12) * vec.y + (num8 + num11) * vec.z,
+                 (num7 + num12) * vec.x + (1.0 - (num4 + num6)) * vec.y + (num9 - num10) * vec.z,
+                 (num8 - num11) * vec.x + (num9 + num10) * vec.y + (1.0 - (num4 + num5)) * vec.z,
+                 dest.w);
+        return dest;
+    }
+
+    /**
+     * Invert this quaternion and store the {@link #normalize() normalized} result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond invert(Quaterniond dest) {
+        double invNorm = 1.0 / (x * x + y * y + z * z + w * w);
+        dest.x = -x * invNorm;
+        dest.y = -y * invNorm;
+        dest.z = -z * invNorm;
+        dest.w = w * invNorm;
+        return dest;
+    }
+
+    /**
+     * Invert this quaternion by assuming that it is already {@link #normalize() normalized} and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond unitInvert(Quaterniond dest) {
+        dest.x = -x;
+        dest.y = -y;
+        dest.z = -z;
+        dest.w = w;
+        return dest;
+    }
+
+    /**
+     * Invert this quaternion and {@link #normalize() normalize} it.
+     * 
+     * @return this
+     */
+    public Quaterniond invert() {
+        return invert(this);
+    }
+
+    /**
+     * Invert this quaternion by assuming that it is already {@link #normalize() normalized}.
+     * 
+     * @return this
+     */
+    public Quaterniond unitInvert() {
+        return unitInvert(this);
+    }
+
+    /**
+     * Divide <code>this</code> quaternion by <code>b</code> and store the result in <code>dest</code>.
+     * <p>
+     * The division expressed using the inverse is performed in the following way:
+     * <p>
+     * <tt>dest = this * b^-1</tt>, where <tt>b^-1</tt> is the inverse of <code>b</code>.
+     * 
+     * @param b
+     *          the {@link Quaterniond} to divide this by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond div(Quaterniond b, Quaterniond dest) {
+        double invNorm = 1.0 / (b.x * b.x + b.y * b.y + b.z * b.z + b.w * b.w);
+        double x = -b.x * invNorm;
+        double y = -b.y * invNorm;
+        double z = -b.z * invNorm;
+        double w = b.w * invNorm;
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Divide <code>this</code> quaternion by <code>b</code>.
+     * <p>
+     * The division expressed using the inverse is performed in the following way:
+     * <p>
+     * <tt>this = this * b^-1</tt>, where <tt>b^-1</tt> is the inverse of <code>b</code>.
+     * 
+     * @param b
+     *          the {@link Quaterniond} to divide this by
+     * @return this
+     */
+    public Quaterniond div(Quaterniond b) {
+        return div(b, this);
+    }
+
+    /**
+     * Conjugate this quaternion.
+     * 
+     * @return this
+     */
+    public Quaterniond conjugate() {
+        x = -x;
+        y = -y;
+        z = -z;
+        return this;
+    }
+
+    /**
+     * Conjugate this quaternion and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond conjugate(Quaterniond dest) {
+        dest.x = -x;
+        dest.y = -y;
+        dest.z = -z;
+        dest.w = w;
+        return dest;
+    }
+
+    /**
+     * Set this quaternion to the identity.
+     * 
+     * @return this
+     */
+    public Quaterniond identity() {
+        x = 0.0;
+        y = 0.0;
+        z = 0.0;
+        w = 1.0;
+        return this;
+    }
+
+    /**
+     * Return the square of the length of this quaternion.
+     * 
+     * @return the length
+     */
+    public double lengthSquared() {
+        return x * x + y * y + z * z + w * w;
+    }
+
+
+    /**
+     * Set this quaternion from the supplied euler angles (in radians) with rotation order XYZ.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * <p>
+     * Reference: <a href="http://gamedev.stackexchange.com/questions/13436/glm-euler-angles-to-quaternion#answer-13446">this stackexchange answer</a>
+     * 
+     * @param angleX
+     *          the angle in radians to rotate about x
+     * @param angleY
+     *          the angle in radians to rotate about y
+     * @param angleZ
+     *          the angle in radians to rotate about z
+     * @return this
+     */
+    public Quaterniond rotationXYZ(double angleX, double angleY, double angleZ) {
+        double sx = Math.sin(angleX * 0.5);
+        double cx = Math.cos(angleX * 0.5);
+        double sy = Math.sin(angleY * 0.5);
+        double cy = Math.cos(angleY * 0.5);
+        double sz = Math.sin(angleZ * 0.5);
+        double cz = Math.cos(angleZ * 0.5);
+
+        double cycz = cy * cz;
+        double sysz = sy * sz;
+        double sycz = sy * cz;
+        double cysz = cy * sz;
+        w = cx*cycz - sx*sysz;
+        x = sx*cycz + cx*sysz;
+        y = cx*sycz - sx*cysz;
+        z = cx*cysz + sx*sycz;
+
+        return this;
+    }
+
+    /**
+     * Set this quaternion from the supplied euler angles (in radians) with rotation order ZYX.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * <p>
+     * Reference: <a href="http://gamedev.stackexchange.com/questions/13436/glm-euler-angles-to-quaternion#answer-13446">this stackexchange answer</a>
+     * 
+     * @param angleX
+     *          the angle in radians to rotate about x
+     * @param angleY
+     *          the angle in radians to rotate about y
+     * @param angleZ
+     *          the angle in radians to rotate about z
+     * @return this
+     */
+    public Quaterniond rotationZYX(double angleZ, double angleY, double angleX) {
+        double sx = Math.sin(angleX * 0.5);
+        double cx = Math.cos(angleX * 0.5);
+        double sy = Math.sin(angleY * 0.5);
+        double cy = Math.cos(angleY * 0.5);
+        double sz = Math.sin(angleZ * 0.5);
+        double cz = Math.cos(angleZ * 0.5);
+
+        double cycz = cy * cz;
+        double sysz = sy * sz;
+        double sycz = sy * cz;
+        double cysz = cy * sz;
+        w = cx*cycz + sx*sysz;
+        x = sx*cycz - cx*sysz;
+        y = cx*sycz + sx*cysz;
+        z = cx*cysz - sx*sycz;
+
+        return this;
+    }
+
+    /**
+     * Set this quaternion from the supplied euler angles (in radians) with rotation order YXZ.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * <p>
+     * Reference: <a href="https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles">https://en.wikipedia.org</a>
+     * 
+     * @param angleY
+     *          the angle in radians to rotate about y
+     * @param angleX
+     *          the angle in radians to rotate about x
+     * @param angleZ
+     *          the angle in radians to rotate about z
+     * @return this
+     */
+    public Quaterniond rotationYXZ(double angleY, double angleX, double angleZ) {
+        double sx = Math.sin(angleX * 0.5);
+        double cx = Math.cos(angleX * 0.5);
+        double sy = Math.sin(angleY * 0.5);
+        double cy = Math.cos(angleY * 0.5);
+        double sz = Math.sin(angleZ * 0.5);
+        double cz = Math.cos(angleZ * 0.5);
+
+        double x = cy * sx;
+        double y = sy * cx;
+        double z = sy * sx;
+        double w = cy * cx;
+        this.x = x * cz + y * sz;
+        this.y = y * cz - x * sz;
+        this.z = w * sz - z * cz;
+        this.w = w * cz + z * sz;
+
+        return this;
+    }
+
+    /**
+     * Interpolate between <code>this</code> quaternion and the specified
+     * <code>target</code> using sperical linear interpolation using the specified interpolation factor <code>alpha</code>.
+     * <p>
+     * This method resorts to non-spherical linear interpolation when the absolute dot product between <code>this</code> and <code>target</code> is
+     * below <tt>1E-6</tt>.
+     * 
+     * @param target
+     *          the target of the interpolation, which should be reached with <tt>alpha = 1.0</tt>
+     * @param alpha
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @return this
+     */
+    public Quaterniond slerp(Quaterniond target, double alpha) {
+        return slerp(target, alpha, this);
+    }
+
+    /**
+     * Interpolate between <code>this</code> quaternion and the specified
+     * <code>target</code> using sperical linear interpolation using the specified interpolation factor <code>alpha</code>,
+     * and store the result in <code>dest</code>.
+     * <p>
+     * This method resorts to non-spherical linear interpolation when the absolute dot product between <code>this</code> and <code>target</code> is
+     * below <tt>1E-6</tt>.
+     * <p>
+     * Reference: <a href="http://fabiensanglard.net/doom3_documentation/37725-293747_293747.pdf">http://fabiensanglard.net</a>
+     * 
+     * @param target
+     *          the target of the interpolation, which should be reached with <tt>alpha = 1.0</tt>
+     * @param alpha
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond slerp(Quaterniond target, double alpha, Quaterniond dest) {
+        double cosom = x * target.x + y * target.y + z * target.z + w * target.w;
+        double absCosom = Math.abs(cosom);
+        double scale0, scale1;
+        if (1.0 - absCosom > 1E-6) {
+            double sinSqr = 1.0 - absCosom * absCosom;
+            double sinom = 1.0 / Math.sqrt(sinSqr);
+            double omega = Math.atan2(sinSqr * sinom, absCosom);
+            scale0 = Math.sin((1.0 - alpha) * omega) * sinom;
+            scale1 = Math.sin(alpha * omega) * sinom;
+        } else {
+            scale0 = 1.0 - alpha;
+            scale1 = alpha;
+        }
+        scale1 = cosom >= 0.0 ? scale1 : -scale1;
+        dest.x = scale0 * x + scale1 * target.x;
+        dest.y = scale0 * y + scale1 * target.y;
+        dest.z = scale0 * z + scale1 * target.z;
+        dest.w = scale0 * w + scale1 * target.w;
+        return dest;
+    }
+
+    /**
+     * Compute a linear (non-spherical) interpolation of <code>this</code> and the given quaternion <code>q</code>
+     * and store the result in <code>this</code>.
+     * 
+     * @param q
+     *          the other quaternion
+     * @param factor
+     *          the interpolation factor. It is between 0.0 and 1.0
+     * @return this
+     */
+    public Quaterniond nlerp(Quaterniond q, double factor) {
+        return nlerp(q, factor, this);
+    }
+
+    /**
+     * Compute a linear (non-spherical) interpolation of <code>this</code> and the given quaternion <code>q</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * Reference: <a href="http://fabiensanglard.net/doom3_documentation/37725-293747_293747.pdf">http://fabiensanglard.net</a>
+     * 
+     * @param q
+     *          the other quaternion
+     * @param factor
+     *          the interpolation factor. It is between 0.0 and 1.0
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond nlerp(Quaterniond q, double factor, Quaterniond dest) {
+        double cosom = x * q.x + y * q.y + z * q.z + w * q.w;
+        double scale0 = 1.0 - factor;
+        double scale1 = (cosom >= 0.0) ? factor : -factor;
+        dest.x = scale0 * x + scale1 * q.x;
+        dest.y = scale0 * y + scale1 * q.y;
+        dest.z = scale0 * z + scale1 * q.z;
+        dest.w = scale0 * w + scale1 * q.w;
+        double s = 1.0 / Math.sqrt(dest.x * dest.x + dest.y * dest.y + dest.z * dest.z + dest.w * dest.w);
+        dest.x *= s;
+        dest.y *= s;
+        dest.z *= s;
+        dest.w *= s;
+        return dest;
+    }
+
+    /**
+     * Compute linear (non-spherical) interpolations of <code>this</code> and the given quaternion <code>q</code>
+     * iteratively and store the result in <code>dest</code>.
+     * <p>
+     * This method performs a series of small-step nlerp interpolations to avoid doing a costly spherical linear interpolation, like
+     * {@link #slerp(Quaterniond, double, Quaterniond) slerp},
+     * by subdividing the rotation arc between <code>this</code> and <code>q</code> via non-spherical linear interpolations as long as
+     * the absolute dot product of <code>this</code> and <code>q</code> is greater than the given <code>dotThreshold</code> parameter.
+     * <p>
+     * Thanks to <tt>@theagentd</tt> at <a href="http://www.java-gaming.org/">http://www.java-gaming.org/</a> for providing the code.
+     * 
+     * @param q
+     *          the other quaternion
+     * @param alpha
+     *          the interpolation factor, between 0.0 and 1.0
+     * @param dotThreshold
+     *          the threshold for the dot product of <code>this</code> and <code>q</code> above which this method performs another iteration
+     *          of a small-step linear interpolation
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond nlerpIterative(Quaterniond q, double alpha, double dotThreshold, Quaterniond dest) {
+        double q1x = x, q1y = y, q1z = z, q1w = w;
+        double q2x = q.x, q2y = q.y, q2z = q.z, q2w = q.w;
+        double dot = q1x * q2x + q1y * q2y + q1z * q2z + q1w * q2w;
+        double absDot = Math.abs(dot);
+        if (1.0 - 1E-6 < absDot) {
+            return dest.set(this);
+        }
+        double alphaN = alpha;
+        while (absDot < dotThreshold) {
+            double scale0 = 0.5;
+            double scale1 = dot >= 0.0 ? 0.5 : -0.5;
+            if (alphaN < 0.5) {
+                q2x = scale0 * q2x + scale1 * q1x;
+                q2y = scale0 * q2y + scale1 * q1y;
+                q2z = scale0 * q2z + scale1 * q1z;
+                q2w = scale0 * q2w + scale1 * q1w;
+                double s = 1.0 / Math.sqrt(q2x * q2x + q2y * q2y + q2z * q2z + q2w * q2w);
+                q2x *= s;
+                q2y *= s;
+                q2z *= s;
+                q2w *= s;
+                alphaN = alphaN * 2.0;
+            } else {
+                q1x = scale0 * q1x + scale1 * q2x;
+                q1y = scale0 * q1y + scale1 * q2y;
+                q1z = scale0 * q1z + scale1 * q2z;
+                q1w = scale0 * q1w + scale1 * q2w;
+                double s = 1.0 / Math.sqrt(q1x * q1x + q1y * q1y + q1z * q1z + q1w * q1w);
+                q1x *= s;
+                q1y *= s;
+                q1z *= s;
+                q1w *= s;
+                alphaN = alphaN * 2.0 - 1.0;
+            }
+            dot = q1x * q2x + q1y * q2y + q1z * q2z + q1w * q2w;
+            absDot = Math.abs(dot);
+        }
+        double scale0 = 1.0 - alphaN;
+        double scale1 = dot >= 0.0 ? alphaN : -alphaN;
+        double destX = scale0 * q1x + scale1 * q2x;
+        double destY = scale0 * q1y + scale1 * q2y;
+        double destZ = scale0 * q1z + scale1 * q2z;
+        double destW = scale0 * q1w + scale1 * q2w;
+        double s = 1.0 / Math.sqrt(destX * destX + destY * destY + destZ * destZ + destW * destW);
+        dest.x *= s;
+        dest.y *= s;
+        dest.z *= s;
+        dest.w *= s;
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to this quaternion that maps the given direction to the positive Z axis.
+     * <p>
+     * Because there are multiple possibilities for such a rotation, this method will choose the one that ensures the given up direction to remain
+     * parallel to the plane spanned by the <code>up</code> and <code>dir</code> vectors. 
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://answers.unity3d.com/questions/467614/what-is-the-source-code-of-quaternionlookrotation.html">http://answers.unity3d.com</a>
+     * 
+     * @see #lookRotate(double, double, double, double, double, double, Quaterniond)
+     * 
+     * @param dir
+     *              the direction to map to the positive Z axis
+     * @param up
+     *              the vector which will be mapped to a vector parallel to the plane
+     *              spanned by the given <code>dir</code> and <code>up</code>
+     * @return this
+     */
+    public Quaterniond lookRotate(Vector3d dir, Vector3d up) {
+        return lookRotate(dir.x, dir.y, dir.z, up.x, up.y, up.z, this);
+    }
+
+    /**
+     * Apply a rotation to this quaternion that maps the given direction to the positive Z axis, and store the result in <code>dest</code>.
+     * <p>
+     * Because there are multiple possibilities for such a rotation, this method will choose the one that ensures the given up direction to remain
+     * parallel to the plane spanned by the <code>up</code> and <code>dir</code> vectors. 
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://answers.unity3d.com/questions/467614/what-is-the-source-code-of-quaternionlookrotation.html">http://answers.unity3d.com</a>
+     * 
+     * @see #lookRotate(double, double, double, double, double, double, Quaterniond)
+     * 
+     * @param dir
+     *              the direction to map to the positive Z axis
+     * @param up
+     *              the vector which will be mapped to a vector parallel to the plane 
+     *              spanned by the given <code>dir</code> and <code>up</code>
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond lookRotate(Vector3d dir, Vector3d up, Quaterniond dest) {
+        return lookRotate(dir.x, dir.y, dir.z, up.x, up.y, up.z, dest);
+    }
+
+    /**
+     * Apply a rotation to this quaternion that maps the given direction to the positive Z axis.
+     * <p>
+     * Because there are multiple possibilities for such a rotation, this method will choose the one that ensures the given up direction to remain
+     * parallel to the plane spanned by the <tt>up</tt> and <tt>dir</tt> vectors. 
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://answers.unity3d.com/questions/467614/what-is-the-source-code-of-quaternionlookrotation.html">http://answers.unity3d.com</a>
+     * 
+     * @see #lookRotate(double, double, double, double, double, double, Quaterniond)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Quaterniond lookRotate(double dirX, double dirY, double dirZ, double upX, double upY, double upZ) {
+        return lookRotate(dirX, dirY, dirZ, upX, upY, upZ, this);
+    }
+
+    /**
+     * Apply a rotation to this quaternion that maps the given direction to the positive Z axis, and store the result in <code>dest</code>.
+     * <p>
+     * Because there are multiple possibilities for such a rotation, this method will choose the one that ensures the given up direction to remain
+     * parallel to the plane spanned by the <tt>up</tt> and <tt>dir</tt> vectors. 
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://answers.unity3d.com/questions/467614/what-is-the-source-code-of-quaternionlookrotation.html">http://answers.unity3d.com</a>
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond lookRotate(double dirX, double dirY, double dirZ, double upX, double upY, double upZ, Quaterniond dest) {
+        // Normalize direction
+        double invDirLength = 1.0 / Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
+        double dirnX = dirX * invDirLength;
+        double dirnY = dirY * invDirLength;
+        double dirnZ = dirZ * invDirLength;
+        // left = up x dir
+        double leftX, leftY, leftZ;
+        leftX = upY * dirnZ - upZ * dirnY;
+        leftY = upZ * dirnX - upX * dirnZ;
+        leftZ = upX * dirnY - upY * dirnX;
+        // normalize left
+        double invLeftLength = 1.0 / Math.sqrt(leftX * leftX + leftY * leftY + leftZ * leftZ);
+        leftX *= invLeftLength;
+        leftY *= invLeftLength;
+        leftZ *= invLeftLength;
+        // up = direction x left
+        double upnX = dirnY * leftZ - dirnZ * leftY;
+        double upnY = dirnZ * leftX - dirnX * leftZ;
+        double upnZ = dirnX * leftY - dirnY * leftX;
+
+        /* Convert orthonormal basis vectors to quaternion */
+        double x, y, z, w;
+        double t;
+        double tr = leftX + upnY + dirnZ;
+        if (tr >= 0.0) {
+            t = Math.sqrt(tr + 1.0);
+            w = t * 0.5;
+            t = 0.5 / t;
+            x = (dirnY - upnZ) * t;
+            y = (leftZ - dirnX) * t;
+            z = (upnX - leftY) * t;
+        } else {
+            if (leftX > upnY && leftX > dirnZ) {
+                t = Math.sqrt(1.0 + leftX - upnY - dirnZ);
+                x = t * 0.5;
+                t = 0.5 / t;
+                y = (leftY + upnX) * t;
+                z = (dirnX + leftZ) * t;
+                w = (dirnY - upnZ) * t;
+            } else if (upnY > dirnZ) {
+                t = Math.sqrt(1.0 + upnY - leftX - dirnZ);
+                y = t * 0.5;
+                t = 0.5 / t;
+                x = (leftY + upnX) * t;
+                z = (upnZ + dirnY) * t;
+                w = (leftZ - dirnX) * t;
+            } else {
+                t = Math.sqrt(1.0 + dirnZ - leftX - upnY);
+                z = t * 0.5;
+                t = 0.5 / t;
+                x = (dirnX + leftZ) * t;
+                y = (upnZ + dirnY) * t;
+                w = (upnX - leftY) * t;
+            }
+        }
+        /* Multiply */
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Return a string representation of this quaternion.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this quaternion by formatting the components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the quaternion components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + " " + formatter.format(y) + " " + formatter.format(z) + " " + formatter.format(w) + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeDouble(x);
+        out.writeDouble(y);
+        out.writeDouble(z);
+        out.writeDouble(w);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        x = in.readDouble();
+        y = in.readDouble();
+        z = in.readDouble();
+        w = in.readDouble();
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(w);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(x);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(y);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(z);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Quaterniond other = (Quaterniond) obj;
+        if (Double.doubleToLongBits(w) != Double.doubleToLongBits(other.w))
+            return false;
+        if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+            return false;
+        if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
+            return false;
+        if (Double.doubleToLongBits(z) != Double.doubleToLongBits(other.z))
+            return false;
+        return true;
+    }
+
+    /**
+     * Compute the difference between <code>this</code> and the <code>other</code> quaternion
+     * and store the result in <code>this</code>.
+     * <p>
+     * The difference is the rotation that has to be applied to get from
+     * <code>this</code> rotation to <code>other</code>. If <tt>T</tt> is <code>this</code>, <tt>Q</tt>
+     * is <code>other</code> and <tt>D</tt> is the computed difference, then the following equation holds:
+     * <p>
+     * <tt>T * D = Q</tt>
+     * <p>
+     * It is defined as: <tt>D = T^-1 * Q</tt>, where <tt>T^-1</tt> denotes the {@link #invert() inverse} of <tt>T</tt>.
+     * 
+     * @param other
+     *          the other quaternion
+     * @return this
+     */
+    public Quaterniond difference(Quaterniond other) {
+        return difference(other, this);
+    }
+
+    /**
+     * Compute the difference between <code>this</code> and the <code>other</code> quaternion
+     * and store the result in <code>dest</code>.
+     * <p>
+     * The difference is the rotation that has to be applied to get from
+     * <code>this</code> rotation to <code>other</code>. If <tt>T</tt> is <code>this</code>, <tt>Q</tt>
+     * is <code>other</code> and <tt>D</tt> is the computed difference, then the following equation holds:
+     * <p>
+     * <tt>T * D = Q</tt>
+     * <p>
+     * It is defined as: <tt>D = T^-1 * Q</tt>, where <tt>T^-1</tt> denotes the {@link #invert() inverse} of <tt>T</tt>.
+     * 
+     * @param other
+     *          the other quaternion
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond difference(Quaterniond other, Quaterniond dest) {
+        double invNorm = 1.0 / (x * x + y * y + z * z + w * w);
+        double x = -this.x * invNorm;
+        double y = -this.y * invNorm;
+        double z = -this.z * invNorm;
+        double w = this.w * invNorm;
+        dest.set(w * other.x + x * other.w + y * other.z - z * other.y,
+                 w * other.y - x * other.z + y * other.w + z * other.x,
+                 w * other.z + x * other.y - y * other.x + z * other.w,
+                 w * other.w - x * other.x - y * other.y - z * other.z);
+        return dest;
+    }
+    
+
+    /**
+     * Set <code>this</code> quaternion to a rotation that rotates the <tt>fromDir</tt> vector to point along <tt>toDir</tt>.
+     * <p>
+     * Since there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/1171849/finding-quaternion-representing-the-rotation-from-one-vector-to-another#answer-1171995">stackoverflow.com</a>
+     * 
+     * @param fromDirX
+     *              the x-coordinate of the direction to rotate into the destination direction
+     * @param fromDirY
+     *              the y-coordinate of the direction to rotate into the destination direction
+     * @param fromDirZ
+     *              the z-coordinate of the direction to rotate into the destination direction
+     * @param toDirX
+     *              the x-coordinate of the direction to rotate to
+     * @param toDirY
+     *              the y-coordinate of the direction to rotate to
+     * @param toDirZ
+     *              the z-coordinate of the direction to rotate to
+     * @return this
+     */
+    public Quaterniond rotationTo(double fromDirX, double fromDirY, double fromDirZ, double toDirX, double toDirY, double toDirZ) {
+        double ax = fromDirY * toDirZ - fromDirZ * toDirY;
+        double ay = fromDirZ * toDirX - fromDirX * toDirZ;
+        double az = fromDirX * toDirY - fromDirY * toDirX;
+        x = ax;
+        y = ay;
+        z = az;
+        w = Math.sqrt((fromDirX * fromDirX + fromDirY * fromDirY + fromDirZ * fromDirZ) *
+                      (toDirX * toDirX + toDirY * toDirY + toDirZ * toDirZ)) +
+                 (fromDirX * toDirX + fromDirY * toDirY + fromDirZ * toDirZ);
+        normalize();
+        return this;
+    }
+
+    /**
+     * Set <code>this</code> quaternion to a rotation that rotates the <code>fromDir</code> vector to point along <code>toDir</code>.
+     * <p>
+     * Because there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * 
+     * @see #rotationTo(double, double, double, double, double, double)
+     * 
+     * @param fromDir
+     *          the starting direction
+     * @param toDir
+     *          the destination direction
+     * @return this
+     */
+    public Quaterniond rotationTo(Vector3d fromDir, Vector3d toDir) {
+        return rotationTo(fromDir.x, fromDir.y, fromDir.z, toDir.x, toDir.y, toDir.z);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> that rotates the <tt>fromDir</tt> vector to point along <tt>toDir</tt> and
+     * store the result in <code>dest</code>.
+     * <p>
+     * Since there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/1171849/finding-quaternion-representing-the-rotation-from-one-vector-to-another#answer-1171995">stackoverflow.com</a>
+     * 
+     * @param fromDirX
+     *              the x-coordinate of the direction to rotate into the destination direction
+     * @param fromDirY
+     *              the y-coordinate of the direction to rotate into the destination direction
+     * @param fromDirZ
+     *              the z-coordinate of the direction to rotate into the destination direction
+     * @param toDirX
+     *              the x-coordinate of the direction to rotate to
+     * @param toDirY
+     *              the y-coordinate of the direction to rotate to
+     * @param toDirZ
+     *              the z-coordinate of the direction to rotate to
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateTo(double fromDirX, double fromDirY, double fromDirZ,
+                                double toDirX, double toDirY, double toDirZ, Quaterniond dest) {
+        double ax = fromDirY * toDirZ - fromDirZ * toDirY;
+        double ay = fromDirZ * toDirX - fromDirX * toDirZ;
+        double az = fromDirX * toDirY - fromDirY * toDirX;
+        double x = ax;
+        double y = ay;
+        double z = az;
+        double w = Math.sqrt((fromDirX * fromDirX + fromDirY * fromDirY + fromDirZ * fromDirZ) *
+                             (toDirX * toDirX + toDirY * toDirY + toDirZ * toDirZ)) +
+                 (fromDirX * toDirX + fromDirY * toDirY + fromDirZ * toDirZ);
+        double invNorm = (float) (1.0 / Math.sqrt(x * x + y * y + z * z + w * w));
+        x *= invNorm;
+        y *= invNorm;
+        z *= invNorm;
+        w *= invNorm;
+        /* Multiply */
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Set this {@link Quaterniond} to a rotation of the given angle in radians about the supplied
+     * axis, all of which are specified via the {@link AxisAngle4f}.
+     * 
+     * @see #rotationAxis(double, double, double, double)
+     * 
+     * @param axisAngle
+     *            the {@link AxisAngle4f} giving the rotation angle in radians and the axis to rotate about
+     * @return this
+     */
+    public Quaterniond rotationAxis(AxisAngle4f axisAngle) {
+        return rotationAxis(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this quaternion to a rotation of the given angle in radians about the supplied axis.
+     * 
+     * @param angle
+     *          the rotation angle in radians
+     * @param axisX
+     *          the x-coordinate of the rotation axis
+     * @param axisY
+     *          the y-coordinate of the rotation axis
+     * @param axisZ
+     *          the z-coordinate of the rotation axis
+     * @return this
+     */
+    public Quaterniond rotationAxis(double angle, double axisX, double axisY, double axisZ) {
+        double hangle = angle / 2.0;
+        double sinAngle = Math.sin(hangle);
+        double invVLength = 1.0 / Math.sqrt(axisX * axisX + axisY * axisY + axisZ * axisZ);
+
+        x = axisX * invVLength * sinAngle;
+        y = axisY * invVLength * sinAngle;
+        z = axisZ * invVLength * sinAngle;
+        w = (float) Math.cos(hangle);
+
+        return this;
+    }
+
+    /**
+     * Set this quaternion to represent a rotation of the given angles in radians about the basis unit axes of the cartesian space.
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaterniond rotation(double angleX, double angleY, double angleZ) {
+        double thetaX = angleX * 0.5;
+        double thetaY = angleY * 0.5;
+        double thetaZ = angleZ * 0.5;
+        double thetaMagSq = thetaX * thetaX + thetaY * thetaY + thetaZ * thetaZ;
+        double s;
+        if (thetaMagSq * thetaMagSq / 24.0f < 1E-8f) {
+            w = 1.0 - thetaMagSq / 2.0;
+            s = 1.0 - thetaMagSq / 6.0;
+        } else {
+            double thetaMag = Math.sqrt(thetaMagSq);
+            w = Math.cos(thetaMag);
+            s = Math.sin(thetaMag) / thetaMag;
+        }
+        x = thetaX * s;
+        y = thetaY * s;
+        z = thetaZ * s;
+        return this;
+    }
+
+    /**
+     * Set this quaternion to represent a rotation of the given radians about the x axis.
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the x axis
+     * @return this
+     */
+    public Quaterniond rotationX(double angle) {
+        double cos = Math.cos(angle * 0.5);
+        double sin = Math.sin(angle * 0.5);
+        w = cos;
+        x = sin;
+        y = 0.0;
+        z = 0.0;
+        return this;
+    }
+
+    /**
+     * Set this quaternion to represent a rotation of the given radians about the y axis.
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the y axis
+     * @return this
+     */
+    public Quaterniond rotationY(double angle) {
+        double cos = Math.cos(angle * 0.5);
+        double sin = Math.sin(angle * 0.5);
+        w = cos;
+        x = 0.0;
+        y = sin;
+        z = 0.0;
+        return this;
+    }
+
+    /**
+     * Set this quaternion to represent a rotation of the given radians about the z axis.
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaterniond rotationZ(double angle) {
+        double cos = Math.cos(angle * 0.5);
+        double sin = Math.sin(angle * 0.5);
+        w = cos;
+        x = 0.0;
+        y = 0.0;
+        z = sin;
+        return this;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> that rotates the <tt>fromDir</tt> vector to point along <tt>toDir</tt>.
+     * <p>
+     * Since there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateTo(double, double, double, double, double, double, Quaterniond)
+     * 
+     * @param fromDirX
+     *              the x-coordinate of the direction to rotate into the destination direction
+     * @param fromDirY
+     *              the y-coordinate of the direction to rotate into the destination direction
+     * @param fromDirZ
+     *              the z-coordinate of the direction to rotate into the destination direction
+     * @param toDirX
+     *              the x-coordinate of the direction to rotate to
+     * @param toDirY
+     *              the y-coordinate of the direction to rotate to
+     * @param toDirZ
+     *              the z-coordinate of the direction to rotate to
+     * @return this
+     */
+    public Quaterniond rotateTo(double fromDirX, double fromDirY, double fromDirZ, double toDirX, double toDirY, double toDirZ) {
+        return rotateTo(fromDirX, fromDirY, fromDirZ, toDirX, toDirY, toDirZ, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> that rotates the <code>fromDir</code> vector to point along <code>toDir</code> and
+     * store the result in <code>dest</code>.
+     * <p>
+     * Because there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateTo(double, double, double, double, double, double, Quaterniond)
+     * 
+     * @param fromDir
+     *          the starting direction
+     * @param toDir
+     *          the destination direction
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateTo(Vector3d fromDir, Vector3d toDir, Quaterniond dest) {
+        return rotateTo(fromDir.x, fromDir.y, fromDir.z, toDir.x, toDir.y, toDir.z, dest);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> that rotates the <code>fromDir</code> vector to point along <code>toDir</code>.
+     * <p>
+     * Because there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateTo(double, double, double, double, double, double, Quaterniond)
+     * 
+     * @param fromDir
+     *          the starting direction
+     * @param toDir
+     *          the destination direction
+     * @return this
+     */
+    public Quaterniond rotateTo(Vector3d fromDir, Vector3d toDir) {
+        return rotateTo(fromDir.x, fromDir.y, fromDir.z, toDir.x, toDir.y, toDir.z, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the basis unit axes of the
+     * cartesian space and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param anglesXYZ
+     *              the angles in radians to rotate about the x, y and z axes, respectively
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotate(Vector3d anglesXYZ, Quaterniond dest) {
+        return rotate(anglesXYZ.x, anglesXYZ.y, anglesXYZ.z, dest);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the basis unit axes
+     * of the cartesian space.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param anglesXYZ
+     *              the angles in radians to rotate about the x, y and z axes, respectively
+     * @return this
+     */
+    public Quaterniond rotate(Vector3d anglesXYZ) {
+        return rotate(anglesXYZ.x, anglesXYZ.y, anglesXYZ.z, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the basis unit axes of the cartesian space.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaterniond rotate(double angleX, double angleY, double angleZ) {
+        return rotate(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the basis unit axes of the
+     * cartesian space and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotate(double angleX, double angleY, double angleZ, Quaterniond dest) {
+        double thetaX = angleX * 0.5;
+        double thetaY = angleY * 0.5;
+        double thetaZ = angleZ * 0.5;
+        double thetaMagSq = thetaX * thetaX + thetaY * thetaY + thetaZ * thetaZ;
+        double s;
+        double dqX, dqY, dqZ, dqW;
+        if (thetaMagSq * thetaMagSq / 24.0 < 1E-8f) {
+            dqW = 1.0 - thetaMagSq / 2.0;
+            s = 1.0 - thetaMagSq / 6.0;
+        } else {
+            double thetaMag = Math.sqrt(thetaMagSq);
+            dqW = Math.cos(thetaMag);
+            s = Math.sin(thetaMag) / thetaMag;
+        }
+        dqX = thetaX * s;
+        dqY = thetaY * s;
+        dqZ = thetaZ * s;
+        /* Post-multiplication (like matrices multiply) */
+        dest.set(w * dqX + x * dqW + y * dqZ - z * dqY,
+                 w * dqY - x * dqZ + y * dqW + z * dqX,
+                 w * dqZ + x * dqY - y * dqX + z * dqW,
+                 w * dqW - x * dqX - y * dqY - z * dqZ);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the x axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the x axis
+     * @return this
+     */
+    public Quaterniond rotateX(double angle) {
+        return rotateX(angle, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the x axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the x axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateX(double angle, Quaterniond dest) {
+        double cos = Math.cos(angle * 0.5);
+        double sin = Math.sin(angle * 0.5);
+        dest.set(w * sin + x * cos,
+                 y * cos + z * sin,
+                 z * cos - y * sin,
+                 w * cos - x * sin);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the y axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the y axis
+     * @return this
+     */
+    public Quaterniond rotateY(double angle) {
+        return rotateY(angle, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the y axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the y axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateY(double angle, Quaterniond dest) {
+        double cos = Math.cos(angle * 0.5);
+        double sin = Math.sin(angle * 0.5);
+        dest.set(x * cos - z * sin,
+                 w * sin + y * cos,
+                 x * sin + z * cos,
+                 w * cos - y * sin);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the z axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaterniond rotateZ(double angle) {
+        return rotateZ(angle, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the z axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(double, double, double, Quaterniond)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the z axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateZ(double angle, Quaterniond dest) {
+        double cos = Math.cos(angle * 0.5);
+        double sin = Math.sin(angle * 0.5);
+        dest.set(x * cos + y * sin,
+                 y * cos - x * sin,
+                 w * sin + z * cos,
+                 w * cos - z * sin);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles using rotation sequence <tt>XYZ</tt>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaterniond rotateXYZ(double angleX, double angleY, double angleZ) {
+        return rotateXYZ(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles using rotation sequence <tt>XYZ</tt> and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateXYZ(double angleX, double angleY, double angleZ, Quaterniond dest) {
+        double sx =  Math.sin(angleX * 0.5);
+        double cx =  Math.cos(angleX * 0.5);
+        double sy =  Math.sin(angleY * 0.5);
+        double cy =  Math.cos(angleY * 0.5);
+        double sz =  Math.sin(angleZ * 0.5);
+        double cz =  Math.cos(angleZ * 0.5);
+
+        double cycz = cy * cz;
+        double sysz = sy * sz;
+        double sycz = sy * cz;
+        double cysz = cy * sz;
+        double w = cx*cycz - sx*sysz;
+        double x = sx*cycz + cx*sysz;
+        double y = cx*sycz - sx*cysz;
+        double z = cx*cysz + sx*sycz;
+        // right-multiply
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles, using the rotation sequence <tt>ZYX</tt>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @return this
+     */
+    public Quaterniond rotateZYX(double angleZ, double angleY, double angleX) {
+        return rotateZYX(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles, using the rotation sequence <tt>ZYX</tt> and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateZYX(double angleZ, double angleY, double angleX, Quaterniond dest) {
+        double sx =  Math.sin(angleX * 0.5);
+        double cx =  Math.cos(angleX * 0.5);
+        double sy =  Math.sin(angleY * 0.5);
+        double cy =  Math.cos(angleY * 0.5);
+        double sz =  Math.sin(angleZ * 0.5);
+        double cz =  Math.cos(angleZ * 0.5);
+
+        double cycz = cy * cz;
+        double sysz = sy * sz;
+        double sycz = sy * cz;
+        double cysz = cy * sz;
+        double w = cx*cycz + sx*sysz;
+        double x = sx*cycz - cx*sysz;
+        double y = cx*sycz + sx*cysz;
+        double z = cx*cysz - sx*sycz;
+        // right-multiply
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles, using the rotation sequence <tt>YXZ</tt>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaterniond rotateYXZ(double angleZ, double angleY, double angleX) {
+        return rotateYXZ(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles, using the rotation sequence <tt>YXZ</tt> and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateYXZ(double angleY, double angleX, double angleZ, Quaterniond dest) {
+        double sx = Math.sin(angleX * 0.5);
+        double cx = Math.cos(angleX * 0.5);
+        double sy = Math.sin(angleY * 0.5);
+        double cy = Math.cos(angleY * 0.5);
+        double sz = Math.sin(angleZ * 0.5);
+        double cz = Math.cos(angleZ * 0.5);
+
+        double yx = cy * sx;
+        double yy = sy * cx;
+        double yz = sy * sx;
+        double yw = cy * cx;
+        double x = yx * cz + yy * sz;
+        double y = yy * cz - yx * sz;
+        double z = yw * sz - yz * cz;
+        double w = yw * cz + yz * sz;
+        // right-multiply
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Get the euler angles in radians in rotation sequence <tt>XYZ</tt> of this quaternion and store them in the 
+     * provided parameter <code>eulerAngles</code>.
+     * 
+     * @param eulerAngles
+     *          will hold the euler angles in radians
+     * @return the passed in vector
+     */
+    public Vector3d getEulerAnglesXYZ(Vector3d eulerAngles) {
+        eulerAngles.x = Math.atan2(2.0 * (x*w - y*z), 1.0 - 2.0 * (x*x + y*y));
+        eulerAngles.y = Math.asin(2.0 * (x*z + y*w));
+        eulerAngles.z = Math.atan2(2.0 * (z*w - x*y), 1.0 - 2.0 * (y*y + z*z));
+        return eulerAngles;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the specified axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the specified axis
+     * @param axisX
+     *              the x coordinate of the rotation axis
+     * @param axisY
+     *              the y coordinate of the rotation axis
+     * @param axisZ
+     *              the z coordinate of the rotation axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateAxis(double angle, double axisX, double axisY, double axisZ, Quaterniond dest) {
+        double hangle = angle / 2.0;
+        double sinAngle = Math.sin(hangle);
+        double invVLength = 1.0 / Math.sqrt(axisX * axisX + axisY * axisY + axisZ * axisZ);
+
+        double rx = axisX * invVLength * sinAngle;
+        double ry = axisY * invVLength * sinAngle;
+        double rz = axisZ * invVLength * sinAngle;
+        double rw = Math.cos(hangle);
+
+        dest.set(w * rx + x * rw + y * rz - z * ry,
+                 w * ry - x * rz + y * rw + z * rx,
+                 w * rz + x * ry - y * rx + z * rw,
+                 w * rw - x * rx - y * ry - z * rz);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the specified axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateAxis(double, double, double, double, Quaterniond)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the specified axis
+     * @param axis
+     *              the rotation axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaterniond rotateAxis(double angle, Vector3d axis, Quaterniond dest) {
+        return rotateAxis(angle, axis.x, axis.y, axis.z, dest);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the specified axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateAxis(double, double, double, double, Quaterniond)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the specified axis
+     * @param axis
+     *              the rotation axis
+     * @return this
+     */
+    public Quaterniond rotateAxis(double angle, Vector3d axis) {
+        return rotateAxis(angle, axis.x, axis.y, axis.z, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the specified axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateAxis(double, double, double, double, Quaterniond)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the specified axis
+     * @param axisX
+     *              the x coordinate of the rotation axis
+     * @param axisY
+     *              the y coordinate of the rotation axis
+     * @param axisZ
+     *              the z coordinate of the rotation axis
+     * @return this
+     */
+    public Quaterniond rotateAxis(double angle, double axisX, double axisY, double axisZ) {
+        return rotateAxis(angle, axisX, axisY, axisZ, this);
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Quaternionf.java
+++ b/GVRf/Framework/src/org/joml/Quaternionf.java
@@ -1,0 +1,2517 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Contains the definition and functions for rotations expressed as
+ * 4-dimensional vectors
+ *
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Quaternionf implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The first component of the vector part.
+     */
+    public float x;
+    /**
+     * The second component of the vector part.
+     */
+    public float y;
+    /**
+     * The third component of the vector part.
+     */
+    public float z;
+    /**
+     * The real/scalar part of the quaternion.
+     */
+    public float w;
+
+    /**
+     * Create a new {@link Quaternionf} and initialize it with <tt>(x=0, y=0, z=0, w=1)</tt>, 
+     * where <tt>(x, y, z)</tt> is the vector part of the quaternion and <tt>w</tt> is the real/scalar part.
+     */
+    public Quaternionf() {
+        x = 0.0f;
+        y = 0.0f;
+        z = 0.0f;
+        w = 1.0f;
+    }
+
+    /**
+     * Create a new {@link Quaternionf} and initialize its components to the given values.
+     * 
+     * @param x
+     *          the first component of the imaginary part
+     * @param y
+     *          the second component of the imaginary part
+     * @param z
+     *          the third component of the imaginary part
+     * @param w
+     *          the real part
+     */
+    public Quaternionf(float x, float y, float z, float w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Quaternionf} and initialize its imaginary components to the given values,
+     * and its real part to <tt>1.0</tt>.
+     * 
+     * @param x
+     *          the first component of the imaginary part
+     * @param y
+     *          the second component of the imaginary part
+     * @param z
+     *          the third component of the imaginary part
+     */
+    public Quaternionf(float x, float y, float z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        w = 1.0f;
+    }
+
+    /**
+     * Create a new {@link Quaternionf} and initialize its components to the same values as the given {@link Quaternionf}.
+     * 
+     * @param source
+     *          the {@link Quaternionf} to take the component values from
+     */
+    public Quaternionf(Quaternionf source) {
+        x = source.x;
+        y = source.y;
+        z = source.z;
+        w = source.w;
+    }
+
+    /**
+     * Create a new {@link Quaternionf} which represents the rotation of the given {@link AxisAngle4f}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f}
+     */
+    public Quaternionf(AxisAngle4f axisAngle) {
+        float sin = (float) Math.sin(axisAngle.angle / 2.0);
+        float cos = (float) Math.cos(axisAngle.angle / 2.0);
+        x = axisAngle.x * sin;
+        y = axisAngle.y * sin;
+        z = axisAngle.z * sin;
+        w = cos;
+    }
+
+    /**
+     * Normalize this quaternion.
+     * 
+     * @return this
+     */
+    public Quaternionf normalize() {
+        float invNorm = (float) (1.0 / Math.sqrt(x * x + y * y + z * z + w * w));
+        x *= invNorm;
+        y *= invNorm;
+        z *= invNorm;
+        w *= invNorm;
+        return this;
+    }
+
+    /**
+     * Normalize this quaternion and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf normalize(Quaternionf dest) {
+        float invNorm = (float) (1.0 / Math.sqrt(x * x + y * y + z * z + w * w));
+        dest.x = x * invNorm;
+        dest.y = y * invNorm;
+        dest.z = z * invNorm;
+        dest.w = w * invNorm;
+        return dest;
+    }
+
+    /**
+     * Add <code>q2</code> to this quaternion.
+     * 
+     * @param q2
+     *          the quaternion to add to this
+     * @return this
+     */
+    public Quaternionf add(Quaternionf q2) {
+        x += q2.x;
+        y += q2.y;
+        z += q2.z;
+        w += q2.w;
+        return this;
+    }
+
+    /**
+     * Add <code>q2</code> to this quaternion and store the result in <code>dest</code>.
+     * 
+     * @param q2
+     *          the quaternion to add to this
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf add(Quaternionf q2, Quaternionf dest) {
+        dest.x = x + q2.x;
+        dest.y = y + q2.y;
+        dest.z = z + q2.z;
+        dest.w = w + q2.w;
+        return dest;
+    }
+
+    /**
+     * Return the dot of this quaternion and <code>otherQuat</code>.
+     * 
+     * @param otherQuat
+     *          the other quaternion
+     * @return the dot product
+     */
+    public float dot(Quaternionf otherQuat) {
+        return this.x * otherQuat.x + this.y * otherQuat.y + this.z * otherQuat.z + this.w * otherQuat.w;
+    }
+
+    /**
+     * Return the angle in radians represented by this quaternion rotation.
+     * 
+     * @return the angle in radians
+     */
+    public float angle() {
+        float angle = (float) (2.0 * Math.acos(w));
+        return (float) (angle <= Math.PI ? angle : 2.0 * Math.PI - angle);
+    }
+
+    /**
+     * Set the given destination matrix to the rotation represented by <code>this</code>.
+     * 
+     * @param dest
+     *          the matrix to write the rotation into
+     * @return the passed in destination
+     */
+    public Matrix3f get(Matrix3f dest) {
+        float q00 = 2.0f * x * x;
+        float q11 = 2.0f * y * y;
+        float q22 = 2.0f * z * z;
+
+        float q01 = 2.0f * x * y;
+        float q02 = 2.0f * x * z;
+        float q03 = 2.0f * x * w;
+
+        float q12 = 2.0f * y * z;
+        float q13 = 2.0f * y * w;
+
+        float q23 = 2.0f * z * w;
+
+        dest.m00 = 1.0f - q11 - q22;
+        dest.m01 = q01 + q23;
+        dest.m02 = q02 - q13;
+        dest.m10 = q01 - q23;
+        dest.m11 = 1.0f - q22 - q00;
+        dest.m12 = q12 + q03;
+        dest.m20 = q02 + q13;
+        dest.m21 = q12 - q03;
+        dest.m22 = 1.0f - q11 - q00;
+        return dest;
+    }
+
+    /**
+     * Set the given destination matrix to the rotation represented by <code>this</code>.
+     * 
+     * @param dest
+     *          the matrix to write the rotation into
+     * @return the passed in destination
+     */
+    public Matrix3d get(Matrix3d dest) {
+        double q00 = 2.0 * x * x;
+        double q11 = 2.0 * y * y;
+        double q22 = 2.0 * z * z;
+
+        double q01 = 2.0 * x * y;
+        double q02 = 2.0 * x * z;
+        double q03 = 2.0 * x * w;
+
+        double q12 = 2.0 * y * z;
+        double q13 = 2.0 * y * w;
+
+        double q23 = 2.0 * z * w;
+
+        dest.m00 = 1.0 - q11 - q22;
+        dest.m01 = q01 + q23;
+        dest.m02 = q02 - q13;
+        dest.m10 = q01 - q23;
+        dest.m11 = 1.0 - q22 - q00;
+        dest.m12 = q12 + q03;
+        dest.m20 = q02 + q13;
+        dest.m21 = q12 - q03;
+        dest.m22 = 1.0 - q11 - q00;
+        return dest;
+    }
+
+    /**
+     * Set the given destination matrix to the rotation represented by <code>this</code>.
+     * 
+     * @param dest
+     *          the matrix to write the rotation into
+     * @return the passed in destination
+     */
+    public Matrix4f get(Matrix4f dest) {
+        float q00 = 2.0f * x * x;
+        float q11 = 2.0f * y * y;
+        float q22 = 2.0f * z * z;
+
+        float q01 = 2.0f * x * y;
+        float q02 = 2.0f * x * z;
+        float q03 = 2.0f * x * w;
+
+        float q12 = 2.0f * y * z;
+        float q13 = 2.0f * y * w;
+
+        float q23 = 2.0f * z * w;
+
+        dest.m00 = 1.0f - q11 - q22;
+        dest.m01 = q01 + q23;
+        dest.m02 = q02 - q13;
+        dest.m03 = 0.0f;
+        dest.m10 = q01 - q23;
+        dest.m11 = 1.0f - q22 - q00;
+        dest.m12 = q12 + q03;
+        dest.m13 = 0.0f;
+        dest.m20 = q02 + q13;
+        dest.m21 = q12 - q03;
+        dest.m22 = 1.0f - q11 - q00;
+        dest.m30 = 0.0f;
+        dest.m31 = 0.0f;
+        dest.m32 = 0.0f;
+        dest.m33 = 1.0f;
+        return dest;
+    }
+
+    /**
+     * Set the given destination matrix to the rotation represented by <code>this</code>.
+     * 
+     * @param dest
+     *          the matrix to write the rotation into
+     * @return the passed in destination
+     */
+    public Matrix4d get(Matrix4d dest) {
+        float q00 = 2.0f * x * x;
+        float q11 = 2.0f * y * y;
+        float q22 = 2.0f * z * z;
+
+        float q01 = 2.0f * x * y;
+        float q02 = 2.0f * x * z;
+        float q03 = 2.0f * x * w;
+
+        float q12 = 2.0f * y * z;
+        float q13 = 2.0f * y * w;
+
+        float q23 = 2.0f * z * w;
+
+        dest.m00 = 1.0 - q11 - q22;
+        dest.m01 = q01 + q23;
+        dest.m02 = q02 - q13;
+        dest.m03 = 0.0;
+        dest.m10 = q01 - q23;
+        dest.m11 = 1.0 - q22 - q00;
+        dest.m12 = q12 + q03;
+        dest.m13 = 0.0;
+        dest.m20 = q02 + q13;
+        dest.m21 = q12 - q03;
+        dest.m22 = 1.0 - q11 - q00;
+        dest.m30 = 0.0;
+        dest.m31 = 0.0;
+        dest.m32 = 0.0;
+        dest.m33 = 1.0;
+        return dest;
+    }
+
+    /**
+     * Set the given {@link AxisAngle4f} to represent the rotation of
+     * <code>this</code> quaternion.
+     * 
+     * @param dest
+     *            the {@link AxisAngle4f} to set
+     * @return the passed in destination
+     */
+    public AxisAngle4f get(AxisAngle4f dest) {
+        float x = this.x;
+        float y = this.y;
+        float z = this.z;
+        float w = this.w;
+        if (w > 1.0f) {
+            float invNorm = (float) (1.0 / Math.sqrt(x * x + y * y + z * z + w * w));
+            x *= invNorm;
+            y *= invNorm;
+            z *= invNorm;
+            w *= invNorm;
+        }
+        dest.angle = (float) (2.0f * Math.acos(w));
+        float s = (float) Math.sqrt(1.0 - w * w);
+        if (s < 0.001f) {
+            dest.x = x;
+            dest.y = y;
+            dest.z = z;
+        } else {
+            s = 1.0f / s;
+            dest.x = x * s;
+            dest.y = y * s;
+            dest.z = z * s;
+        }
+        return dest;
+    }
+
+    /**
+     * Set the given {@link Quaterniond} to the values of <code>this</code>.
+     * 
+     * @see Quaterniond#set(Quaterniond)
+     * 
+     * @param dest
+     *          the {@link Quaterniond} to set
+     * @return the passed in destination
+     */
+    public Quaterniond get(Quaterniond dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Set the given {@link Quaternionf} to the values of <code>this</code>.
+     * 
+     * @see #set(Quaternionf)
+     * 
+     * @param dest
+     *          the {@link Quaternionf} to set
+     * @return the passed in destination
+     */
+    public Quaternionf get(Quaternionf dest) {
+        return dest.set(this);
+    }
+
+    /**
+     * Set this quaternion to the given values.
+     * 
+     * @param x
+     *          the new value of x
+     * @param y
+     *          the new value of y
+     * @param z
+     *          the new value of z
+     * @param w
+     *          the new value of w
+     * @return this
+     */
+    public Quaternionf set(float x, float y, float z, float w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Set the x, y and z components of this quaternion to the given values.
+     * 
+     * @param x
+     *          the new value of x
+     * @param y
+     *          the new value of y
+     * @param z
+     *          the new value of z
+     * @return this
+     */
+    public Quaternionf set(float x, float y, float z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a copy of q.
+     * 
+     * @param q
+     *          the {@link Quaternionf} to copy
+     * @return this
+     */
+    public Quaternionf set(Quaternionf q) {
+        x = q.x;
+        y = q.y;
+        z = q.z;
+        w = q.w;
+        return this;
+    }
+
+    /**
+     * Set this quaternion to a rotation equivalent to the given {@link AxisAngle4f}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4f}
+     * @return this
+     */
+    public Quaternionf set(AxisAngle4f axisAngle) {
+        return setAngleAxis(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this quaternion to a rotation equivalent to the given {@link AxisAngle4d}.
+     * 
+     * @param axisAngle
+     *          the {@link AxisAngle4d}
+     * @return this
+     */
+    public Quaternionf set(AxisAngle4d axisAngle) {
+        return setAngleAxis(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this quaternion to a rotation equivalent to the supplied axis and
+     * angle (in radians).
+     * <p>
+     * This method assumes that the given rotation axis <tt>(x, y, z)</tt> is already normalized
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param x
+     *          the x-component of the normalized rotation axis
+     * @param y
+     *          the y-component of the normalized rotation axis
+     * @param z
+     *          the z-component of the normalized rotation axis
+     * @return this
+     */
+    public Quaternionf setAngleAxis(float angle, float x, float y, float z) {
+        float s = (float) Math.sin(angle * 0.5);
+        this.x = x * s;
+        this.y = y * s;
+        this.z = z * s;
+        this.w = (float) Math.cos(angle * 0.5);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to a rotation equivalent to the supplied axis and
+     * angle (in radians).
+     * <p>
+     * This method assumes that the given rotation axis <tt>(x, y, z)</tt> is already normalized
+     * 
+     * @param angle
+     *          the angle in radians
+     * @param x
+     *          the x-component of the normalized rotation axis
+     * @param y
+     *          the y-component of the normalized rotation axis
+     * @param z
+     *          the z-component of the normalized rotation axis
+     * @return this
+     */
+    public Quaternionf setAngleAxis(double angle, double x, double y, double z) {
+        double s = Math.sin(angle * 0.5);
+        this.x = (float) (x * s);
+        this.y = (float) (y * s);
+        this.z = (float) (z * s);
+        this.w = (float) Math.cos(angle * 0.5);
+        return this;
+    }
+
+    /**
+     * Set this {@link Quaternionf} to a rotation of the given angle in radians about the supplied
+     * axis, all of which are specified via the {@link AxisAngle4f}.
+     * 
+     * @see #rotationAxis(float, float, float, float)
+     * 
+     * @param axisAngle
+     *            the {@link AxisAngle4f} giving the rotation angle in radians and the axis to rotate about
+     * @return this
+     */
+    public Quaternionf rotationAxis(AxisAngle4f axisAngle) {
+        return rotationAxis(axisAngle.angle, axisAngle.x, axisAngle.y, axisAngle.z);
+    }
+
+    /**
+     * Set this quaternion to a rotation of the given angle in radians about the supplied axis.
+     * 
+     * @param angle
+     *          the rotation angle in radians
+     * @param axisX
+     *          the x-coordinate of the rotation axis
+     * @param axisY
+     *          the y-coordinate of the rotation axis
+     * @param axisZ
+     *          the z-coordinate of the rotation axis
+     * @return this
+     */
+    public Quaternionf rotationAxis(float angle, float axisX, float axisY, float axisZ) {
+        float hangle = angle / 2.0f;
+        float sinAngle = (float) Math.sin(hangle);
+        float invVLength = (float) (1.0 / Math.sqrt(axisX * axisX + axisY * axisY + axisZ * axisZ));
+
+        x = axisX * invVLength * sinAngle;
+        y = axisY * invVLength * sinAngle;
+        z = axisZ * invVLength * sinAngle;
+        w = (float) Math.cos(hangle);
+
+        return this;
+    }
+
+    /**
+     * Set this quaternion to a rotation of the given angle in radians about the supplied axis.
+     * 
+     * @see #rotationAxis(float, float, float, float)
+     * 
+     * @param angle
+     *          the rotation angle in radians
+     * @param axis
+     *          the axis to rotate about
+     * @return this
+     */
+    public Quaternionf rotationAxis(float angle, Vector3f axis) {
+        return rotationAxis(angle, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Set this quaternion to represent a rotation of the given angles in radians about the basis unit axes of the cartesian space.
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaternionf rotation(float angleX, float angleY, float angleZ) {
+        double thetaX = angleX * 0.5;
+        double thetaY = angleY * 0.5;
+        double thetaZ = angleZ * 0.5;
+        double thetaMagSq = thetaX * thetaX + thetaY * thetaY + thetaZ * thetaZ;
+        double s;
+        if (thetaMagSq * thetaMagSq / 24.0f < 1E-8f) {
+            w = (float) (1.0 - thetaMagSq / 2.0);
+            s = 1.0 - thetaMagSq / 6.0;
+        } else {
+            double thetaMag = Math.sqrt(thetaMagSq);
+            w = (float) Math.cos(thetaMag);
+            s = Math.sin(thetaMag) / thetaMag;
+        }
+        x = (float) (thetaX * s);
+        y = (float) (thetaY * s);
+        z = (float) (thetaZ * s);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to represent a rotation of the given radians about the x axis.
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the x axis
+     * @return this
+     */
+    public Quaternionf rotationX(float angle) {
+        float cos = (float) Math.cos(angle * 0.5);
+        float sin = (float) Math.sin(angle * 0.5);
+        w = cos;
+        x = sin;
+        y = 0.0f;
+        z = 0.0f;
+        return this;
+    }
+
+    /**
+     * Set this quaternion to represent a rotation of the given radians about the y axis.
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the y axis
+     * @return this
+     */
+    public Quaternionf rotationY(float angle) {
+        float cos = (float) Math.cos(angle * 0.5);
+        float sin = (float) Math.sin(angle * 0.5);
+        w = cos;
+        x = 0.0f;
+        y = sin;
+        z = 0.0f;
+        return this;
+    }
+
+    /**
+     * Set this quaternion to represent a rotation of the given radians about the z axis.
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaternionf rotationZ(float angle) {
+        float cos = (float) Math.cos(angle * 0.5);
+        float sin = (float) Math.sin(angle * 0.5);
+        w = cos;
+        x = 0.0f;
+        y = 0.0f;
+        z = sin;
+        return this;
+    }
+
+    private void setFromUnnormalized(float m00, float m01, float m02, float m10, float m11, float m12, float m20, float m21, float m22) {
+        float nm00 = m00, nm01 = m01, nm02 = m02;
+        float nm10 = m10, nm11 = m11, nm12 = m12;
+        float nm20 = m20, nm21 = m21, nm22 = m22;
+        float lenX = (float) (1.0 / Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02));
+        float lenY = (float) (1.0 / Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12));
+        float lenZ = (float) (1.0 / Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22));
+        nm00 *= lenX; nm01 *= lenX; nm02 *= lenX;
+        nm10 *= lenY; nm11 *= lenY; nm12 *= lenY;
+        nm20 *= lenZ; nm21 *= lenZ; nm22 *= lenZ;
+        setFromNormalized(nm00, nm01, nm02, nm10, nm11, nm12, nm20, nm21, nm22);
+    }
+
+    private void setFromNormalized(float m00, float m01, float m02, float m10, float m11, float m12, float m20, float m21, float m22) {
+        float t;
+        float tr = m00 + m11 + m22;
+        if (tr >= 0.0f) {
+            t = (float) Math.sqrt(tr + 1.0f);
+            w = t * 0.5f;
+            t = 0.5f / t;
+            x = (m12 - m21) * t;
+            y = (m20 - m02) * t;
+            z = (m01 - m10) * t;
+        } else {
+            if (m00 >= m11 && m00 >= m22) {
+                t = (float) Math.sqrt(m00 - (m11 + m22) + 1.0);
+                x = t * 0.5f;
+                t = 0.5f / t;
+                y = (m10 + m01) * t;
+                z = (m02 + m20) * t;
+                w = (m12 - m21) * t;
+            } else if (m11 > m22) {
+                t = (float) Math.sqrt(m11 - (m22 + m00) + 1.0);
+                y = t * 0.5f;
+                t = 0.5f / t;
+                z = (m21 + m12) * t;
+                x = (m10 + m01) * t;
+                w = (m20 - m02) * t;
+            } else {
+                t = (float) Math.sqrt(m22 - (m00 + m11) + 1.0);
+                z = t * 0.5f;
+                t = 0.5f / t;
+                x = (m02 + m20) * t;
+                y = (m21 + m12) * t;
+                w = (m01 - m10) * t;
+            }
+        }
+    }
+
+    private void setFromUnnormalized(double m00, double m01, double m02, double m10, double m11, double m12, double m20, double m21, double m22) {
+        double nm00 = m00, nm01 = m01, nm02 = m02;
+        double nm10 = m10, nm11 = m11, nm12 = m12;
+        double nm20 = m20, nm21 = m21, nm22 = m22;
+        double lenX = 1.0 / Math.sqrt(m00 * m00 + m01 * m01 + m02 * m02);
+        double lenY = 1.0 / Math.sqrt(m10 * m10 + m11 * m11 + m12 * m12);
+        double lenZ = 1.0 / Math.sqrt(m20 * m20 + m21 * m21 + m22 * m22);
+        nm00 *= lenX; nm01 *= lenX; nm02 *= lenX;
+        nm10 *= lenY; nm11 *= lenY; nm12 *= lenY;
+        nm20 *= lenZ; nm21 *= lenZ; nm22 *= lenZ;
+        setFromNormalized(nm00, nm01, nm02, nm10, nm11, nm12, nm20, nm21, nm22);
+    }
+
+    private void setFromNormalized(double m00, double m01, double m02, double m10, double m11, double m12, double m20, double m21, double m22) {
+        double t;
+        double tr = m00 + m11 + m22;
+        if (tr >= 0.0) {
+            t = Math.sqrt(tr + 1.0);
+            w = (float) (t * 0.5);
+            t = 0.5 / t;
+            x = (float) ((m12 - m21) * t);
+            y = (float) ((m20 - m02) * t);
+            z = (float) ((m01 - m10) * t);
+        } else {
+            if (m00 >= m11 && m00 >= m22) {
+                t = Math.sqrt(m00 - (m11 + m22) + 1.0);
+                x = (float) (t * 0.5);
+                t = 0.5 / t;
+                y = (float) ((m10 + m01) * t);
+                z = (float) ((m02 + m20) * t);
+                w = (float) ((m12 - m21) * t);
+            } else if (m11 > m22) {
+                t = (float) Math.sqrt(m11 - (m22 + m00) + 1.0);
+                y = (float) (t * 0.5);
+                t = 0.5 / t;
+                z = (float) ((m21 + m12) * t);
+                x = (float) ((m10 + m01) * t);
+                w = (float) ((m20 - m02) * t);
+            } else {
+                t = (float) Math.sqrt(m22 - (m00 + m11) + 1.0);
+                z = (float) (t * 0.5);
+                t = 0.5 / t;
+                x = (float) ((m02 + m20) * t);
+                y = (float) ((m21 + m12) * t);
+                w = (float) ((m01 - m10) * t);
+            }
+        }
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are no unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaternionf setFromUnnormalized(Matrix4f mat) {
+        setFromUnnormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaternionf setFromNormalized(Matrix4f mat) {
+        setFromNormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are no unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaternionf setFromUnnormalized(Matrix4d mat) {
+        setFromUnnormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaternionf setFromNormalized(Matrix4d mat) {
+        setFromNormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are no unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaternionf setFromUnnormalized(Matrix3f mat) {
+        setFromUnnormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaternionf setFromNormalized(Matrix3f mat) {
+        setFromNormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * <p>
+     * This method assumes that the first three columns of the upper left 3x3 submatrix are no unit vectors.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaternionf setFromUnnormalized(Matrix3d mat) {
+        setFromUnnormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Set this quaternion to be a representation of the rotational component of the given matrix.
+     * 
+     * @param mat
+     *          the matrix whose rotational component is used to set this quaternion
+     * @return this
+     */
+    public Quaternionf setFromNormalized(Matrix3d mat) {
+        setFromNormalized(mat.m00, mat.m01, mat.m02, mat.m10, mat.m11, mat.m12, mat.m20, mat.m21, mat.m22);
+        return this;
+    }
+
+    /**
+     * Multiply this quaternion by <code>q</code>.
+     * <p>
+     * If <tt>T</tt> is <code>this</code> and <tt>Q</tt> is the given
+     * quaternion, then the resulting quaternion <tt>R</tt> is:
+     * <p>
+     * <tt>R = T * Q</tt>
+     * <p>
+     * So, this method uses post-multiplication like the matrix classes, resulting in a
+     * vector to be transformed by <tt>Q</tt> first, and then by <tt>T</tt>.
+     * 
+     * @param q
+     *          the quaternion to multiply <code>this</code> by
+     * @return this
+     */
+    public Quaternionf mul(Quaternionf q) {
+        return mul(q, this);
+    }
+
+    /**
+     * Multiply this quaternion by <code>q</code> and store the result in <code>dest</code>.
+     * <p>
+     * If <tt>T</tt> is <code>this</code> and <tt>Q</tt> is the given
+     * quaternion, then the resulting quaternion <tt>R</tt> is:
+     * <p>
+     * <tt>R = T * Q</tt>
+     * <p>
+     * So, this method uses post-multiplication like the matrix classes, resulting in a
+     * vector to be transformed by <tt>Q</tt> first, and then by <tt>T</tt>.
+     * 
+     * @param q
+     *            the quaternion to multiply <code>this</code> by
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Quaternionf mul(Quaternionf q, Quaternionf dest) {
+        dest.set(w * q.x + x * q.w + y * q.z - z * q.y,
+                 w * q.y - x * q.z + y * q.w + z * q.x,
+                 w * q.z + x * q.y - y * q.x + z * q.w,
+                 w * q.w - x * q.x - y * q.y - z * q.z);
+        return dest;
+    }
+
+    /**
+     * Multiply this quaternion by the quaternion represented via <tt>(qx, qy, qz, qw)</tt>.
+     * <p>
+     * If <tt>T</tt> is <code>this</code> and <tt>Q</tt> is the given
+     * quaternion, then the resulting quaternion <tt>R</tt> is:
+     * <p>
+     * <tt>R = T * Q</tt>
+     * <p>
+     * So, this method uses post-multiplication like the matrix classes, resulting in a
+     * vector to be transformed by <tt>Q</tt> first, and then by <tt>T</tt>.
+     * 
+     * @param qx
+     *          the x component of the quaternion to multiply <code>this</code> by
+     * @param qy
+     *          the y component of the quaternion to multiply <code>this</code> by
+     * @param qz
+     *          the z component of the quaternion to multiply <code>this</code> by
+     * @param qw
+     *          the w component of the quaternion to multiply <code>this</code> by
+     * @return this
+     */
+    public Quaternionf mul(float qx, float qy, float qz, float qw) {
+        set(w * qx + x * qw + y * qz - z * qy,
+            w * qy - x * qz + y * qw + z * qx,
+            w * qz + x * qy - y * qx + z * qw,
+            w * qw - x * qx - y * qy - z * qz);
+        return this;
+    }
+
+    /**
+     * Multiply this quaternion by the quaternion represented via <tt>(qx, qy, qz, qw)</tt> and store the result in <code>dest</code>.
+     * <p>
+     * If <tt>T</tt> is <code>this</code> and <tt>Q</tt> is the given
+     * quaternion, then the resulting quaternion <tt>R</tt> is:
+     * <p>
+     * <tt>R = T * Q</tt>
+     * <p>
+     * So, this method uses post-multiplication like the matrix classes, resulting in a
+     * vector to be transformed by <tt>Q</tt> first, and then by <tt>T</tt>.
+     * 
+     * @param qx
+     *          the x component of the quaternion to multiply <code>this</code> by
+     * @param qy
+     *          the y component of the quaternion to multiply <code>this</code> by
+     * @param qz
+     *          the z component of the quaternion to multiply <code>this</code> by
+     * @param qw
+     *          the w component of the quaternion to multiply <code>this</code> by
+     * @param dest
+     *            will hold the result
+     * @return dest
+     */
+    public Quaternionf mul(float qx, float qy, float qz, float qw, Quaternionf dest) {
+        dest.set(w * qx + x * qw + y * qz - z * qy,
+                 w * qy - x * qz + y * qw + z * qx,
+                 w * qz + x * qy - y * qx + z * qw,
+                 w * qw - x * qx - y * qy - z * qz);
+        return dest;
+    }
+
+    /**
+     * Transform the given vector by this quaternion.
+     * This will apply the rotation described by this quaternion to the given vector.
+     * 
+     * @param vec
+     *          the vector to transform
+     * @return vec
+     */
+    public Vector3f transform(Vector3f vec){
+        return transform(vec, vec);
+    }
+
+    /**
+     * Transform the given vector by this quaternion.
+     * This will apply the rotation described by this quaternion to the given vector.
+     * <p>
+     * Only the first three components of the given 4D vector are being used and modified.
+     * 
+     * @param vec
+     *          the vector to transform
+     * @return vec
+     */
+    public Vector4f transform(Vector4f vec){
+        return transform(vec, vec);
+    }
+
+    /**
+     * Transform the given vector by this quaternion and store the result in <code>dest</code>.
+     * This will apply the rotation described by this quaternion to the given vector.
+     * 
+     * @param vec
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f transform(Vector3f vec, Vector3f dest) {
+        double num = x * 2.0;
+        double num2 = y * 2.0;
+        double num3 = z * 2.0;
+        double num4 = x * num;
+        double num5 = y * num2;
+        double num6 = z * num3;
+        double num7 = x * num2;
+        double num8 = x * num3;
+        double num9 = y * num3;
+        double num10 = w * num;
+        double num11 = w * num2;
+        double num12 = w * num3;
+        dest.set((float) ((1.0 - (num5 + num6)) * vec.x + (num7 - num12) * vec.y + (num8 + num11) * vec.z),
+                 (float) ((num7 + num12) * vec.x + (1.0 - (num4 + num6)) * vec.y + (num9 - num10) * vec.z),
+                 (float) ((num8 - num11) * vec.x + (num9 + num10) * vec.y + (1.0 - (num4 + num5)) * vec.z));
+        return dest;
+    }
+
+    /**
+     * Transform the given vector by this quaternion and store the result in <code>dest</code>.
+     * This will apply the rotation described by this quaternion to the given vector.
+     * <p>
+     * Only the first three components of the given 4D vector are being used and set on the destination.
+     * 
+     * @param vec
+     *          the vector to transform
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f transform(Vector4f vec, Vector4f dest) {
+        double num = x * 2.0;
+        double num2 = y * 2.0;
+        double num3 = z * 2.0;
+        double num4 = x * num;
+        double num5 = y * num2;
+        double num6 = z * num3;
+        double num7 = x * num2;
+        double num8 = x * num3;
+        double num9 = y * num3;
+        double num10 = w * num;
+        double num11 = w * num2;
+        double num12 = w * num3;
+        dest.set((float) ((1.0 - (num5 + num6)) * vec.x + (num7 - num12) * vec.y + (num8 + num11) * vec.z),
+                 (float) ((num7 + num12) * vec.x + (1.0 - (num4 + num6)) * vec.y + (num9 - num10) * vec.z),
+                 (float) ((num8 - num11) * vec.x + (num9 + num10) * vec.y + (1.0 - (num4 + num5)) * vec.z),
+                 dest.w);
+        return dest;
+    }
+
+    /**
+     * Invert this quaternion and store the {@link #normalize() normalized} result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf invert(Quaternionf dest) {
+        float invNorm = 1.0f / (x * x + y * y + z * z + w * w);
+        dest.x = -x * invNorm;
+        dest.y = -y * invNorm;
+        dest.z = -z * invNorm;
+        dest.w = w * invNorm;
+        return dest;
+    }
+
+    /**
+     * Invert this quaternion by assuming that it is already {@link #normalize() normalized} and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf unitInvert(Quaternionf dest) {
+        dest.x = -x;
+        dest.y = -y;
+        dest.z = -z;
+        dest.w = w;
+        return dest;
+    }
+
+    /**
+     * Invert this quaternion and {@link #normalize() normalize} it.
+     * 
+     * @return this
+     */
+    public Quaternionf invert() {
+        return invert(this);
+    }
+
+    /**
+     * Invert this quaternion by assuming that it is already {@link #normalize() normalized}.
+     * 
+     * @return this
+     */
+    public Quaternionf unitInvert() {
+        return unitInvert(this);
+    }
+
+    /**
+     * Divide <code>this</code> quaternion by <code>b</code> and store the result in <code>dest</code>.
+     * <p>
+     * The division expressed using the inverse is performed in the following way:
+     * <p>
+     * <tt>dest = this * b^-1</tt>, where <tt>b^-1</tt> is the inverse of <code>b</code>.
+     * 
+     * @param b
+     *          the {@link Quaternionf} to divide this by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf div(Quaternionf b, Quaternionf dest) {
+        float invNorm = 1.0f / (b.x * b.x + b.y * b.y + b.z * b.z + b.w * b.w);
+        float x = -b.x * invNorm;
+        float y = -b.y * invNorm;
+        float z = -b.z * invNorm;
+        float w = b.w * invNorm;
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Divide <code>this</code> quaternion by <code>b</code>.
+     * <p>
+     * The division expressed using the inverse is performed in the following way:
+     * <p>
+     * <tt>this = this * b^-1</tt>, where <tt>b^-1</tt> is the inverse of <code>b</code>.
+     * 
+     * @param b
+     *          the {@link Quaternionf} to divide this by
+     * @return this
+     */
+    public Quaternionf div(Quaternionf b) {
+        return div(b, this);
+    }
+
+    /**
+     * Conjugate this quaternion.
+     * 
+     * @return this
+     */
+    public Quaternionf conjugate() {
+        x = -x;
+        y = -y;
+        z = -z;
+        return this;
+    }
+
+    /**
+     * Conjugate this quaternion and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf conjugate(Quaternionf dest) {
+        dest.x = -x;
+        dest.y = -y;
+        dest.z = -z;
+        dest.w = w;
+        return dest;
+    }
+
+    /**
+     * Set this quaternion to the identity.
+     * 
+     * @return this
+     */
+    public Quaternionf identity() {
+        x = 0.0f;
+        y = 0.0f;
+        z = 0.0f;
+        w = 1.0f;
+        return this;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles using rotation sequence <tt>XYZ</tt>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaternionf rotateXYZ(float angleX, float angleY, float angleZ) {
+        return rotateXYZ(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles using rotation sequence <tt>XYZ</tt> and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateXYZ(float angleX, float angleY, float angleZ, Quaternionf dest) {
+        float sx = (float) Math.sin(angleX * 0.5);
+        float cx = (float) Math.cos(angleX * 0.5);
+        float sy = (float) Math.sin(angleY * 0.5);
+        float cy = (float) Math.cos(angleY * 0.5);
+        float sz = (float) Math.sin(angleZ * 0.5);
+        float cz = (float) Math.cos(angleZ * 0.5);
+
+        float cycz = cy * cz;
+        float sysz = sy * sz;
+        float sycz = sy * cz;
+        float cysz = cy * sz;
+        float w = cx*cycz - sx*sysz;
+        float x = sx*cycz + cx*sysz;
+        float y = cx*sycz - sx*cysz;
+        float z = cx*cysz + sx*sycz;
+        // right-multiply
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles, using the rotation sequence <tt>ZYX</tt>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @return this
+     */
+    public Quaternionf rotateZYX(float angleZ, float angleY, float angleX) {
+        return rotateZYX(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles, using the rotation sequence <tt>ZYX</tt> and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateZYX(float angleZ, float angleY, float angleX, Quaternionf dest) {
+        float sx = (float) Math.sin(angleX * 0.5);
+        float cx = (float) Math.cos(angleX * 0.5);
+        float sy = (float) Math.sin(angleY * 0.5);
+        float cy = (float) Math.cos(angleY * 0.5);
+        float sz = (float) Math.sin(angleZ * 0.5);
+        float cz = (float) Math.cos(angleZ * 0.5);
+
+        float cycz = cy * cz;
+        float sysz = sy * sz;
+        float sycz = sy * cz;
+        float cysz = cy * sz;
+        float w = cx*cycz + sx*sysz;
+        float x = sx*cycz - cx*sysz;
+        float y = cx*sycz + sx*cysz;
+        float z = cx*cysz - sx*sycz;
+        // right-multiply
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles, using the rotation sequence <tt>YXZ</tt>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaternionf rotateYXZ(float angleZ, float angleY, float angleX) {
+        return rotateYXZ(angleZ, angleY, angleX, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the cartesian base unit axes,
+     * called the euler angles, using the rotation sequence <tt>YXZ</tt> and store the result in <code>dest</code>.
+     * <p>
+     * This method is equivalent to calling: <tt>rotateY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateYXZ(float angleY, float angleX, float angleZ, Quaternionf dest) {
+        float sx = (float) Math.sin(angleX * 0.5);
+        float cx = (float) Math.cos(angleX * 0.5);
+        float sy = (float) Math.sin(angleY * 0.5);
+        float cy = (float) Math.cos(angleY * 0.5);
+        float sz = (float) Math.sin(angleZ * 0.5);
+        float cz = (float) Math.cos(angleZ * 0.5);
+
+        float yx = cy * sx;
+        float yy = sy * cx;
+        float yz = sy * sx;
+        float yw = cy * cx;
+        float x = yx * cz + yy * sz;
+        float y = yy * cz - yx * sz;
+        float z = yw * sz - yz * cz;
+        float w = yw * cz + yz * sz;
+        // right-multiply
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Get the euler angles in radians in rotation sequence <tt>XYZ</tt> of this quaternion and store them in the 
+     * provided parameter <code>eulerAngles</code>.
+     * 
+     * @param eulerAngles
+     *          will hold the euler angles in radians
+     * @return the passed in vector
+     */
+    public Vector3f getEulerAnglesXYZ(Vector3f eulerAngles) {
+        eulerAngles.x = (float) Math.atan2(2.0 * (x*w - y*z), 1.0 - 2.0 * (x*x + y*y));
+        eulerAngles.y = (float) Math.asin(2.0 * (x*z + y*w));
+        eulerAngles.z = (float) Math.atan2(2.0 * (z*w - x*y), 1.0 - 2.0 * (y*y + z*z));
+        return eulerAngles;
+    }
+
+    /**
+     * Return the square of the length of this quaternion.
+     * 
+     * @return the length
+     */
+    public float lengthSquared() {
+        return x * x + y * y + z * z + w * w;
+    }
+
+    /**
+     * Set this quaternion from the supplied euler angles (in radians) with rotation order XYZ.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationX(angleX).rotateY(angleY).rotateZ(angleZ)</tt>
+     * <p>
+     * Reference: <a href="http://gamedev.stackexchange.com/questions/13436/glm-euler-angles-to-quaternion#answer-13446">this stackexchange answer</a>
+     * 
+     * @param angleX
+     *          the angle in radians to rotate about x
+     * @param angleY
+     *          the angle in radians to rotate about y
+     * @param angleZ
+     *          the angle in radians to rotate about z
+     * @return this
+     */
+    public Quaternionf rotationXYZ(float angleX, float angleY, float angleZ) {
+        float sx = (float) Math.sin(angleX * 0.5);
+        float cx = (float) Math.cos(angleX * 0.5);
+        float sy = (float) Math.sin(angleY * 0.5);
+        float cy = (float) Math.cos(angleY * 0.5);
+        float sz = (float) Math.sin(angleZ * 0.5);
+        float cz = (float) Math.cos(angleZ * 0.5);
+
+        float cycz = cy * cz;
+        float sysz = sy * sz;
+        float sycz = sy * cz;
+        float cysz = cy * sz;
+        w = cx*cycz - sx*sysz;
+        x = sx*cycz + cx*sysz;
+        y = cx*sycz - sx*cysz;
+        z = cx*cysz + sx*sycz;
+
+        return this;
+    }
+
+    /**
+     * Set this quaternion from the supplied euler angles (in radians) with rotation order ZYX.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationZ(angleZ).rotateY(angleY).rotateX(angleX)</tt>
+     * <p>
+     * Reference: <a href="http://gamedev.stackexchange.com/questions/13436/glm-euler-angles-to-quaternion#answer-13446">this stackexchange answer</a>
+     * 
+     * @param angleX
+     *          the angle in radians to rotate about x
+     * @param angleY
+     *          the angle in radians to rotate about y
+     * @param angleZ
+     *          the angle in radians to rotate about z
+     * @return this
+     */
+    public Quaternionf rotationZYX(float angleZ, float angleY, float angleX) {
+        float sx = (float) Math.sin(angleX * 0.5);
+        float cx = (float) Math.cos(angleX * 0.5);
+        float sy = (float) Math.sin(angleY * 0.5);
+        float cy = (float) Math.cos(angleY * 0.5);
+        float sz = (float) Math.sin(angleZ * 0.5);
+        float cz = (float) Math.cos(angleZ * 0.5);
+
+        float cycz = cy * cz;
+        float sysz = sy * sz;
+        float sycz = sy * cz;
+        float cysz = cy * sz;
+        w = cx*cycz + sx*sysz;
+        x = sx*cycz - cx*sysz;
+        y = cx*sycz + sx*cysz;
+        z = cx*cysz - sx*sycz;
+
+        return this;
+    }
+
+    /**
+     * Set this quaternion from the supplied euler angles (in radians) with rotation order YXZ.
+     * <p>
+     * This method is equivalent to calling: <tt>rotationY(angleY).rotateX(angleX).rotateZ(angleZ)</tt>
+     * <p>
+     * Reference: <a href="https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles">https://en.wikipedia.org</a>
+     * 
+     * @param angleY
+     *          the angle in radians to rotate about y
+     * @param angleX
+     *          the angle in radians to rotate about x
+     * @param angleZ
+     *          the angle in radians to rotate about z
+     * @return this
+     */
+    public Quaternionf rotationYXZ(float angleY, float angleX, float angleZ) {
+        float sx = (float) Math.sin(angleX * 0.5);
+        float cx = (float) Math.cos(angleX * 0.5);
+        float sy = (float) Math.sin(angleY * 0.5);
+        float cy = (float) Math.cos(angleY * 0.5);
+        float sz = (float) Math.sin(angleZ * 0.5);
+        float cz = (float) Math.cos(angleZ * 0.5);
+
+        float x = cy * sx;
+        float y = sy * cx;
+        float z = sy * sx;
+        float w = cy * cx;
+        this.x = x * cz + y * sz;
+        this.y = y * cz - x * sz;
+        this.z = w * sz - z * cz;
+        this.w = w * cz + z * sz;
+
+        return this;
+    }
+
+    /**
+     * Interpolate between <code>this</code> quaternion and the specified
+     * <code>target</code> using sperical linear interpolation using the specified interpolation factor <code>alpha</code>.
+     * <p>
+     * This method resorts to non-spherical linear interpolation when the absolute dot product of <code>this</code> and <code>target</code> is
+     * below <tt>1E-6f</tt>.
+     * 
+     * @param target
+     *          the target of the interpolation, which should be reached with <tt>alpha = 1.0</tt>
+     * @param alpha
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @return this
+     */
+    public Quaternionf slerp(Quaternionf target, float alpha) {
+        return slerp(target, alpha, this);
+    }
+
+    /**
+     * Interpolate between <code>this</code> quaternion and the specified
+     * <code>target</code> using sperical linear interpolation using the specified interpolation factor <code>alpha</code>,
+     * and store the result in <code>dest</code>.
+     * <p>
+     * This method resorts to non-spherical linear interpolation when the absolute dot product of <code>this</code> and <code>target</code> is
+     * below <tt>1E-6f</tt>.
+     * <p>
+     * Reference: <a href="http://fabiensanglard.net/doom3_documentation/37725-293747_293747.pdf">http://fabiensanglard.net</a>
+     * 
+     * @param target
+     *          the target of the interpolation, which should be reached with <tt>alpha = 1.0</tt>
+     * @param alpha
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf slerp(Quaternionf target, float alpha, Quaternionf dest) {
+        float cosom = x * target.x + y * target.y + z * target.z + w * target.w;
+        float absCosom = Math.abs(cosom);
+        float scale0, scale1;
+        if (1.0f - absCosom > 1E-6f) {
+            float sinSqr = 1.0f - absCosom * absCosom;
+            float sinom = (float) (1.0 / Math.sqrt(sinSqr));
+            float omega = (float) Math.atan2(sinSqr * sinom, absCosom);
+            scale0 = (float) (Math.sin((1.0 - alpha) * omega) * sinom);
+            scale1 = (float) (Math.sin(alpha * omega) * sinom);
+        } else {
+            scale0 = 1.0f - alpha;
+            scale1 = alpha;
+        }
+        scale1 = cosom >= 0.0f ? scale1 : -scale1;
+        dest.x = scale0 * x + scale1 * target.x;
+        dest.y = scale0 * y + scale1 * target.y;
+        dest.z = scale0 * z + scale1 * target.z;
+        dest.w = scale0 * w + scale1 * target.w;
+        return dest;
+    }
+
+    /**
+     * Compute a linear (non-spherical) interpolation of <code>this</code> and the given quaternion <code>q</code>
+     * and store the result in <code>this</code>.
+     * 
+     * @param q
+     *          the other quaternion
+     * @param factor
+     *          the interpolation factor. It is between 0.0 and 1.0
+     * @return this
+     */
+    public Quaternionf nlerp(Quaternionf q, float factor) {
+        return nlerp(q, factor, this);
+    }
+
+    /**
+     * Compute a linear (non-spherical) interpolation of <code>this</code> and the given quaternion <code>q</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * Reference: <a href="http://fabiensanglard.net/doom3_documentation/37725-293747_293747.pdf">http://fabiensanglard.net</a>
+     * 
+     * @param q
+     *          the other quaternion
+     * @param factor
+     *          the interpolation factor. It is between 0.0 and 1.0
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf nlerp(Quaternionf q, float factor, Quaternionf dest) {
+        float cosom = x * q.x + y * q.y + z * q.z + w * q.w;
+        float scale0 = 1.0f - factor;
+        float scale1 = (cosom >= 0.0f) ? factor : -factor;
+        dest.x = scale0 * x + scale1 * q.x;
+        dest.y = scale0 * y + scale1 * q.y;
+        dest.z = scale0 * z + scale1 * q.z;
+        dest.w = scale0 * w + scale1 * q.w;
+        float s = (float) (1.0 / Math.sqrt(dest.x * dest.x + dest.y * dest.y + dest.z * dest.z + dest.w * dest.w));
+        dest.x *= s;
+        dest.y *= s;
+        dest.z *= s;
+        dest.w *= s;
+        return dest;
+    }
+
+    /**
+     * Compute linear (non-spherical) interpolations of <code>this</code> and the given quaternion <code>q</code>
+     * iteratively and store the result in <code>dest</code>.
+     * <p>
+     * This method performs a series of small-step nlerp interpolations to avoid doing a costly spherical linear interpolation, like
+     * {@link #slerp(Quaternionf, float, Quaternionf) slerp},
+     * by subdividing the rotation arc between <code>this</code> and <code>q</code> via non-spherical linear interpolations as long as
+     * the absolute dot product of <code>this</code> and <code>q</code> is greater than the given <code>dotThreshold</code> parameter.
+     * <p>
+     * Thanks to <tt>@theagentd</tt> at <a href="http://www.java-gaming.org/">http://www.java-gaming.org/</a> for providing the code.
+     * 
+     * @param q
+     *          the other quaternion
+     * @param alpha
+     *          the interpolation factor, between 0.0 and 1.0
+     * @param dotThreshold
+     *          the threshold for the dot product of <code>this</code> and <code>q</code> above which this method performs another iteration
+     *          of a small-step linear interpolation
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf nlerpIterative(Quaternionf q, float alpha, float dotThreshold, Quaternionf dest) {
+        float q1x = x, q1y = y, q1z = z, q1w = w;
+        float q2x = q.x, q2y = q.y, q2z = q.z, q2w = q.w;
+        float dot = q1x * q2x + q1y * q2y + q1z * q2z + q1w * q2w;
+        float absDot = Math.abs(dot);
+        if (1.0f - 1E-6f < absDot) {
+            return dest.set(this);
+        }
+        float alphaN = alpha;
+        while (absDot < dotThreshold) {
+            float scale0 = 0.5f;
+            float scale1 = dot >= 0.0f ? 0.5f : -0.5f;
+            if (alphaN < 0.5f) {
+                q2x = scale0 * q2x + scale1 * q1x;
+                q2y = scale0 * q2y + scale1 * q1y;
+                q2z = scale0 * q2z + scale1 * q1z;
+                q2w = scale0 * q2w + scale1 * q1w;
+                float s = (float) (1.0 / Math.sqrt(q2x * q2x + q2y * q2y + q2z * q2z + q2w * q2w));
+                q2x *= s;
+                q2y *= s;
+                q2z *= s;
+                q2w *= s;
+                alphaN = alphaN * 2.0f;
+            } else {
+                q1x = scale0 * q1x + scale1 * q2x;
+                q1y = scale0 * q1y + scale1 * q2y;
+                q1z = scale0 * q1z + scale1 * q2z;
+                q1w = scale0 * q1w + scale1 * q2w;
+                float s = (float) (1.0 / Math.sqrt(q1x * q1x + q1y * q1y + q1z * q1z + q1w * q1w));
+                q1x *= s;
+                q1y *= s;
+                q1z *= s;
+                q1w *= s;
+                alphaN = alphaN * 2.0f - 1.0f;
+            }
+            dot = q1x * q2x + q1y * q2y + q1z * q2z + q1w * q2w;
+            absDot = Math.abs(dot);
+        }
+        float scale0 = 1.0f - alphaN;
+        float scale1 = dot >= 0.0f ? alphaN : -alphaN;
+        float resX = scale0 * q1x + scale1 * q2x;
+        float resY = scale0 * q1y + scale1 * q2y;
+        float resZ = scale0 * q1z + scale1 * q2z;
+        float resW = scale0 * q1w + scale1 * q2w;
+        float s = (float) (1.0 / Math.sqrt(resX * resX + resY * resY + resZ * resZ + resW * resW));
+        dest.x = resX * s;
+        dest.y = resY * s;
+        dest.z = resZ * s;
+        dest.w = resW * s;
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to this quaternion that maps the given direction to the positive Z axis.
+     * <p>
+     * Because there are multiple possibilities for such a rotation, this method will choose the one that ensures the given up direction to remain
+     * parallel to the plane spanned by the <code>up</code> and <code>dir</code> vectors. 
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://answers.unity3d.com/questions/467614/what-is-the-source-code-of-quaternionlookrotation.html">http://answers.unity3d.com</a>
+     * 
+     * @see #lookRotate(float, float, float, float, float, float, Quaternionf)
+     * 
+     * @param dir
+     *              the direction to map to the positive Z axis
+     * @param up
+     *              the vector which will be mapped to a vector parallel to the plane
+     *              spanned by the given <code>dir</code> and <code>up</code>
+     * @return this
+     */
+    public Quaternionf lookRotate(Vector3f dir, Vector3f up) {
+        return lookRotate(dir.x, dir.y, dir.z, up.x, up.y, up.z, this);
+    }
+
+    /**
+     * Apply a rotation to this quaternion that maps the given direction to the positive Z axis, and store the result in <code>dest</code>.
+     * <p>
+     * Because there are multiple possibilities for such a rotation, this method will choose the one that ensures the given up direction to remain
+     * parallel to the plane spanned by the <code>up</code> and <code>dir</code> vectors. 
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://answers.unity3d.com/questions/467614/what-is-the-source-code-of-quaternionlookrotation.html">http://answers.unity3d.com</a>
+     * 
+     * @see #lookRotate(float, float, float, float, float, float, Quaternionf)
+     * 
+     * @param dir
+     *              the direction to map to the positive Z axis
+     * @param up
+     *              the vector which will be mapped to a vector parallel to the plane 
+     *              spanned by the given <code>dir</code> and <code>up</code>
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf lookRotate(Vector3f dir, Vector3f up, Quaternionf dest) {
+        return lookRotate(dir.x, dir.y, dir.z, up.x, up.y, up.z, dest);
+    }
+
+    /**
+     * Apply a rotation to this quaternion that maps the given direction to the positive Z axis.
+     * <p>
+     * Because there are multiple possibilities for such a rotation, this method will choose the one that ensures the given up direction to remain
+     * parallel to the plane spanned by the <tt>up</tt> and <tt>dir</tt> vectors. 
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://answers.unity3d.com/questions/467614/what-is-the-source-code-of-quaternionlookrotation.html">http://answers.unity3d.com</a>
+     * 
+     * @see #lookRotate(float, float, float, float, float, float, Quaternionf)
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @return this
+     */
+    public Quaternionf lookRotate(float dirX, float dirY, float dirZ, float upX, float upY, float upZ) {
+        return lookRotate(dirX, dirY, dirZ, upX, upY, upZ, this);
+    }
+
+    /**
+     * Apply a rotation to this quaternion that maps the given direction to the positive Z axis, and store the result in <code>dest</code>.
+     * <p>
+     * Because there are multiple possibilities for such a rotation, this method will choose the one that ensures the given up direction to remain
+     * parallel to the plane spanned by the <tt>up</tt> and <tt>dir</tt> vectors. 
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://answers.unity3d.com/questions/467614/what-is-the-source-code-of-quaternionlookrotation.html">http://answers.unity3d.com</a>
+     * 
+     * @param dirX
+     *              the x-coordinate of the direction to look along
+     * @param dirY
+     *              the y-coordinate of the direction to look along
+     * @param dirZ
+     *              the z-coordinate of the direction to look along
+     * @param upX
+     *              the x-coordinate of the up vector
+     * @param upY
+     *              the y-coordinate of the up vector
+     * @param upZ
+     *              the z-coordinate of the up vector
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf lookRotate(float dirX, float dirY, float dirZ, float upX, float upY, float upZ, Quaternionf dest) {
+        // Normalize direction
+        float invDirLength = (float) (1.0 / Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ));
+        float dirnX = dirX * invDirLength;
+        float dirnY = dirY * invDirLength;
+        float dirnZ = dirZ * invDirLength;
+        // left = up x dir
+        float leftX, leftY, leftZ;
+        leftX = upY * dirnZ - upZ * dirnY;
+        leftY = upZ * dirnX - upX * dirnZ;
+        leftZ = upX * dirnY - upY * dirnX;
+        // normalize left
+        float invLeftLength = (float) (1.0 / Math.sqrt(leftX * leftX + leftY * leftY + leftZ * leftZ));
+        leftX *= invLeftLength;
+        leftY *= invLeftLength;
+        leftZ *= invLeftLength;
+        // up = direction x left
+        float upnX = dirnY * leftZ - dirnZ * leftY;
+        float upnY = dirnZ * leftX - dirnX * leftZ;
+        float upnZ = dirnX * leftY - dirnY * leftX;
+
+        /* Convert orthonormal basis vectors to quaternion */
+        float x, y, z, w;
+        double t;
+        double tr = leftX + upnY + dirnZ;
+        if (tr >= 0.0) {
+            t = Math.sqrt(tr + 1.0);
+            w = (float) (t * 0.5);
+            t = 0.5 / t;
+            x = (float) ((dirnY - upnZ) * t);
+            y = (float) ((leftZ - dirnX) * t);
+            z = (float) ((upnX - leftY) * t);
+        } else {
+            if (leftX > upnY && leftX > dirnZ) {
+                t = Math.sqrt(1.0 + leftX - upnY - dirnZ);
+                x = (float) (t * 0.5);
+                t = 0.5 / t;
+                y = (float) ((leftY + upnX) * t);
+                z = (float) ((dirnX + leftZ) * t);
+                w = (float) ((dirnY - upnZ) * t);
+            } else if (upnY > dirnZ) {
+                t = Math.sqrt(1.0 + upnY - leftX - dirnZ);
+                y = (float) (t * 0.5);
+                t = 0.5 / t;
+                x = (float) ((leftY + upnX) * t);
+                z = (float) ((upnZ + dirnY) * t);
+                w = (float) ((leftZ - dirnX) * t);
+            } else {
+                t = Math.sqrt(1.0 + dirnZ - leftX - upnY);
+                z = (float) (t * 0.5);
+                t = 0.5 / t;
+                x = (float) ((dirnX + leftZ) * t);
+                y = (float) ((upnZ + dirnY) * t);
+                w = (float) ((upnX - leftY) * t);
+            }
+        }
+        /* Multiply */
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Set <code>this</code> quaternion to a rotation that rotates the <tt>fromDir</tt> vector to point along <tt>toDir</tt>.
+     * <p>
+     * Since there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/1171849/finding-quaternion-representing-the-rotation-from-one-vector-to-another#answer-1171995">stackoverflow.com</a>
+     * 
+     * @param fromDirX
+     *              the x-coordinate of the direction to rotate into the destination direction
+     * @param fromDirY
+     *              the y-coordinate of the direction to rotate into the destination direction
+     * @param fromDirZ
+     *              the z-coordinate of the direction to rotate into the destination direction
+     * @param toDirX
+     *              the x-coordinate of the direction to rotate to
+     * @param toDirY
+     *              the y-coordinate of the direction to rotate to
+     * @param toDirZ
+     *              the z-coordinate of the direction to rotate to
+     * @return this
+     */
+    public Quaternionf rotationTo(float fromDirX, float fromDirY, float fromDirZ, float toDirX, float toDirY, float toDirZ) {
+        float ax = fromDirY * toDirZ - fromDirZ * toDirY;
+        float ay = fromDirZ * toDirX - fromDirX * toDirZ;
+        float az = fromDirX * toDirY - fromDirY * toDirX;
+        x = ax;
+        y = ay;
+        z = az;
+        w = (float) Math.sqrt((fromDirX * fromDirX + fromDirY * fromDirY + fromDirZ * fromDirZ) *
+                              (toDirX * toDirX + toDirY * toDirY + toDirZ * toDirZ)) +
+                 (fromDirX * toDirX + fromDirY * toDirY + fromDirZ * toDirZ);
+        normalize();
+        return this;
+    }
+
+    /**
+     * Set <code>this</code> quaternion to a rotation that rotates the <code>fromDir</code> vector to point along <code>toDir</code>.
+     * <p>
+     * Because there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * 
+     * @see #rotationTo(float, float, float, float, float, float)
+     * 
+     * @param fromDir
+     *          the starting direction
+     * @param toDir
+     *          the destination direction
+     * @return this
+     */
+    public Quaternionf rotationTo(Vector3f fromDir, Vector3f toDir) {
+        return rotationTo(fromDir.x, fromDir.y, fromDir.z, toDir.x, toDir.y, toDir.z);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> that rotates the <tt>fromDir</tt> vector to point along <tt>toDir</tt> and
+     * store the result in <code>dest</code>.
+     * <p>
+     * Since there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/1171849/finding-quaternion-representing-the-rotation-from-one-vector-to-another#answer-1171995">stackoverflow.com</a>
+     * 
+     * @param fromDirX
+     *              the x-coordinate of the direction to rotate into the destination direction
+     * @param fromDirY
+     *              the y-coordinate of the direction to rotate into the destination direction
+     * @param fromDirZ
+     *              the z-coordinate of the direction to rotate into the destination direction
+     * @param toDirX
+     *              the x-coordinate of the direction to rotate to
+     * @param toDirY
+     *              the y-coordinate of the direction to rotate to
+     * @param toDirZ
+     *              the z-coordinate of the direction to rotate to
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateTo(float fromDirX, float fromDirY, float fromDirZ, float toDirX, float toDirY, float toDirZ, Quaternionf dest) {
+        float ax = fromDirY * toDirZ - fromDirZ * toDirY;
+        float ay = fromDirZ * toDirX - fromDirX * toDirZ;
+        float az = fromDirX * toDirY - fromDirY * toDirX;
+        float x = ax;
+        float y = ay;
+        float z = az;
+        float w = (float) Math.sqrt((fromDirX * fromDirX + fromDirY * fromDirY + fromDirZ * fromDirZ) *
+                                    (toDirX * toDirX + toDirY * toDirY + toDirZ * toDirZ)) +
+                  (fromDirX * toDirX + fromDirY * toDirY + fromDirZ * toDirZ);
+        float invNorm = (float) (1.0 / Math.sqrt(x * x + y * y + z * z + w * w));
+        x *= invNorm;
+        y *= invNorm;
+        z *= invNorm;
+        w *= invNorm;
+        /* Multiply */
+        dest.set(this.w * x + this.x * w + this.y * z - this.z * y,
+                 this.w * y - this.x * z + this.y * w + this.z * x,
+                 this.w * z + this.x * y - this.y * x + this.z * w,
+                 this.w * w - this.x * x - this.y * y - this.z * z);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> that rotates the <tt>fromDir</tt> vector to point along <tt>toDir</tt>.
+     * <p>
+     * Since there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateTo(float, float, float, float, float, float, Quaternionf)
+     * 
+     * @param fromDirX
+     *              the x-coordinate of the direction to rotate into the destination direction
+     * @param fromDirY
+     *              the y-coordinate of the direction to rotate into the destination direction
+     * @param fromDirZ
+     *              the z-coordinate of the direction to rotate into the destination direction
+     * @param toDirX
+     *              the x-coordinate of the direction to rotate to
+     * @param toDirY
+     *              the y-coordinate of the direction to rotate to
+     * @param toDirZ
+     *              the z-coordinate of the direction to rotate to
+     * @return this
+     */
+    public Quaternionf rotateTo(float fromDirX, float fromDirY, float fromDirZ, float toDirX, float toDirY, float toDirZ) {
+        return rotateTo(fromDirX, fromDirY, fromDirZ, toDirX, toDirY, toDirZ, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> that rotates the <code>fromDir</code> vector to point along <code>toDir</code> and
+     * store the result in <code>dest</code>.
+     * <p>
+     * Because there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateTo(float, float, float, float, float, float, Quaternionf)
+     * 
+     * @param fromDir
+     *          the starting direction
+     * @param toDir
+     *          the destination direction
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateTo(Vector3f fromDir, Vector3f toDir, Quaternionf dest) {
+        return rotateTo(fromDir.x, fromDir.y, fromDir.z, toDir.x, toDir.y, toDir.z, dest);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> that rotates the <code>fromDir</code> vector to point along <code>toDir</code>.
+     * <p>
+     * Because there can be multiple possible rotations, this method chooses the one with the shortest arc.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateTo(float, float, float, float, float, float, Quaternionf)
+     * 
+     * @param fromDir
+     *          the starting direction
+     * @param toDir
+     *          the destination direction
+     * @return this
+     */
+    public Quaternionf rotateTo(Vector3f fromDir, Vector3f toDir) {
+        return rotateTo(fromDir.x, fromDir.y, fromDir.z, toDir.x, toDir.y, toDir.z, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the basis unit axes of the cartesian space.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(float, float, float, Quaternionf)
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaternionf rotate(float angleX, float angleY, float angleZ) {
+        return rotate(angleX, angleY, angleZ, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the basis unit axes of the
+     * cartesian space and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(float, float, float, Quaternionf)
+     * 
+     * @param angleX
+     *              the angle in radians to rotate about the x axis
+     * @param angleY
+     *              the angle in radians to rotate about the y axis
+     * @param angleZ
+     *              the angle in radians to rotate about the z axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf rotate(float angleX, float angleY, float angleZ, Quaternionf dest) {
+        double thetaX = angleX * 0.5;
+        double thetaY = angleY * 0.5;
+        double thetaZ = angleZ * 0.5;
+        double thetaMagSq = thetaX * thetaX + thetaY * thetaY + thetaZ * thetaZ;
+        double s;
+        double dqX, dqY, dqZ, dqW;
+        if (thetaMagSq * thetaMagSq / 24.0f < 1E-8f) {
+            dqW = 1.0 - thetaMagSq / 2.0;
+            s = 1.0 - thetaMagSq / 6.0;
+        } else {
+            double thetaMag = Math.sqrt(thetaMagSq);
+            dqW = Math.cos(thetaMag);
+            s = Math.sin(thetaMag) / thetaMag;
+        }
+        dqX = thetaX * s;
+        dqY = thetaY * s;
+        dqZ = thetaZ * s;
+        /* Pre-multiplication */
+//        dest.set((float) (dqW * x + dqX * w + dqY * z - dqZ * y),
+//                 (float) (dqW * y - dqX * z + dqY * w + dqZ * x),
+//                 (float) (dqW * z + dqX * y - dqY * x + dqZ * w),
+//                 (float) (dqW * w - dqX * x - dqY * y - dqZ * z));
+        /* Post-multiplication (like matrices multiply) */
+        dest.set((float) (w * dqX + x * dqW + y * dqZ - z * dqY),
+                 (float) (w * dqY - x * dqZ + y * dqW + z * dqX),
+                 (float) (w * dqZ + x * dqY - y * dqX + z * dqW),
+                 (float) (w * dqW - x * dqX - y * dqY - z * dqZ));
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the x axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(float, float, float, Quaternionf)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the x axis
+     * @return this
+     */
+    public Quaternionf rotateX(float angle) {
+        return rotateX(angle, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the x axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(float, float, float, Quaternionf)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the x axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateX(float angle, Quaternionf dest) {
+        float cos = (float) Math.cos(angle * 0.5);
+        float sin = (float) Math.sin(angle * 0.5);
+        dest.set(w * sin + x * cos,
+                 y * cos + z * sin,
+                 z * cos - y * sin,
+                 w * cos - x * sin);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the y axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(float, float, float, Quaternionf)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the y axis
+     * @return this
+     */
+    public Quaternionf rotateY(float angle) {
+        return rotateY(angle, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the y axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(float, float, float, Quaternionf)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the y axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateY(float angle, Quaternionf dest) {
+        float cos = (float) Math.cos(angle * 0.5);
+        float sin = (float) Math.sin(angle * 0.5);
+        dest.set(x * cos - z * sin,
+                 w * sin + y * cos,
+                 x * sin + z * cos,
+                 w * cos - y * sin);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the z axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(float, float, float, Quaternionf)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the z axis
+     * @return this
+     */
+    public Quaternionf rotateZ(float angle) {
+        return rotateZ(angle, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the z axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotate(float, float, float, Quaternionf)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the z axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateZ(float angle, Quaternionf dest) {
+        float cos = (float) Math.cos(angle * 0.5);
+        float sin = (float) Math.sin(angle * 0.5);
+        dest.set(x * cos + y * sin,
+                 y * cos - x * sin,
+                 w * sin + z * cos,
+                 w * cos - z * sin);
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the specified axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the specified axis
+     * @param axisX
+     *              the x coordinate of the rotation axis
+     * @param axisY
+     *              the y coordinate of the rotation axis
+     * @param axisZ
+     *              the z coordinate of the rotation axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateAxis(float angle, float axisX, float axisY, float axisZ, Quaternionf dest) {
+        double hangle = angle / 2.0;
+        double sinAngle = Math.sin(hangle);
+        double invVLength = 1.0 / Math.sqrt(axisX * axisX + axisY * axisY + axisZ * axisZ);
+
+        double rx = axisX * invVLength * sinAngle;
+        double ry = axisY * invVLength * sinAngle;
+        double rz = axisZ * invVLength * sinAngle;
+        double rw = Math.cos(hangle);
+
+        dest.set((float) (w * rx + x * rw + y * rz - z * ry),
+                 (float) (w * ry - x * rz + y * rw + z * rx),
+                 (float) (w * rz + x * ry - y * rx + z * rw),
+                 (float) (w * rw - x * rx - y * ry - z * rz));
+        return dest;
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the specified axis
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateAxis(float, float, float, float, Quaternionf)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the specified axis
+     * @param axis
+     *              the rotation axis
+     * @param dest
+     *              will hold the result
+     * @return dest
+     */
+    public Quaternionf rotateAxis(float angle, Vector3f axis, Quaternionf dest) {
+        return rotateAxis(angle, axis.x, axis.y, axis.z, dest);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the specified axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateAxis(float, float, float, float, Quaternionf)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the specified axis
+     * @param axis
+     *              the rotation axis
+     * @return this
+     */
+    public Quaternionf rotateAxis(float angle, Vector3f axis) {
+        return rotateAxis(angle, axis.x, axis.y, axis.z, this);
+    }
+
+    /**
+     * Apply a rotation to <code>this</code> quaternion rotating the given radians about the specified axis.
+     * <p>
+     * If <code>Q</code> is <code>this</code> quaternion and <code>R</code> the quaternion representing the 
+     * specified rotation, then the new quaternion will be <code>Q * R</code>. So when transforming a
+     * vector <code>v</code> with the new quaternion by using <code>Q * R * v</code>, the
+     * rotation added by this method will be applied first!
+     * 
+     * @see #rotateAxis(float, float, float, float, Quaternionf)
+     * 
+     * @param angle
+     *              the angle in radians to rotate about the specified axis
+     * @param axisX
+     *              the x coordinate of the rotation axis
+     * @param axisY
+     *              the y coordinate of the rotation axis
+     * @param axisZ
+     *              the z coordinate of the rotation axis
+     * @return this
+     */
+    public Quaternionf rotateAxis(float angle, float axisX, float axisY, float axisZ) {
+        return rotateAxis(angle, axisX, axisY, axisZ, this);
+    }
+
+    /**
+     * Return a string representation of this quaternion.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this quaternion by formatting the components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the quaternion components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + " " + formatter.format(y) + " " + formatter.format(z) + " " + formatter.format(w) + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeFloat(x);
+        out.writeFloat(y);
+        out.writeFloat(z);
+        out.writeFloat(w);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        x = in.readFloat();
+        y = in.readFloat();
+        z = in.readFloat();
+        w = in.readFloat();
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Float.floatToIntBits(w);
+        result = prime * result + Float.floatToIntBits(x);
+        result = prime * result + Float.floatToIntBits(y);
+        result = prime * result + Float.floatToIntBits(z);
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Quaternionf other = (Quaternionf) obj;
+        if (Float.floatToIntBits(w) != Float.floatToIntBits(other.w))
+            return false;
+        if (Float.floatToIntBits(x) != Float.floatToIntBits(other.x))
+            return false;
+        if (Float.floatToIntBits(y) != Float.floatToIntBits(other.y))
+            return false;
+        if (Float.floatToIntBits(z) != Float.floatToIntBits(other.z))
+            return false;
+        return true;
+    }
+
+    /**
+     * Compute the difference between <code>this</code> and the <code>other</code> quaternion
+     * and store the result in <code>this</code>.
+     * <p>
+     * The difference is the rotation that has to be applied to get from
+     * <code>this</code> rotation to <code>other</code>. If <tt>T</tt> is <code>this</code>, <tt>Q</tt>
+     * is <code>other</code> and <tt>D</tt> is the computed difference, then the following equation holds:
+     * <p>
+     * <tt>T * D = Q</tt>
+     * <p>
+     * It is defined as: <tt>D = T^-1 * Q</tt>, where <tt>T^-1</tt> denotes the {@link #invert() inverse} of <tt>T</tt>.
+     * 
+     * @param other
+     *          the other quaternion
+     * @return this
+     */
+    public Quaternionf difference(Quaternionf other) {
+        return difference(other, this);
+    }
+
+    /**
+     * Compute the difference between <code>this</code> and the <code>other</code> quaternion
+     * and store the result in <code>dest</code>.
+     * <p>
+     * The difference is the rotation that has to be applied to get from
+     * <code>this</code> rotation to <code>other</code>. If <tt>T</tt> is <code>this</code>, <tt>Q</tt>
+     * is <code>other</code> and <tt>D</tt> is the computed difference, then the following equation holds:
+     * <p>
+     * <tt>T * D = Q</tt>
+     * <p>
+     * It is defined as: <tt>D = T^-1 * Q</tt>, where <tt>T^-1</tt> denotes the {@link #invert() inverse} of <tt>T</tt>.
+     * 
+     * @param other
+     *          the other quaternion
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Quaternionf difference(Quaternionf other, Quaternionf dest) {
+        float invNorm = 1.0f / (x * x + y * y + z * z + w * w);
+        float x = -this.x * invNorm;
+        float y = -this.y * invNorm;
+        float z = -this.z * invNorm;
+        float w = this.w * invNorm;
+        dest.set(w * other.x + x * other.w + y * other.z - z * other.y,
+                 w * other.y - x * other.z + y * other.w + z * other.x,
+                 w * other.z + x * other.y - y * other.x + z * other.w,
+                 w * other.w - x * other.x - y * other.y - z * other.z);
+        return dest;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Vector2d.java
+++ b/GVRf/Framework/src/org/joml/Vector2d.java
@@ -1,0 +1,884 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Represents a 2D vector with double-precision.
+ *
+ * @author RGreenlees
+ * @author Kai Burjack
+ */
+public class Vector2d implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The x component of the vector.
+     */
+    public double x;
+    /**
+     * The y component of the vector.
+     */
+    public double y;
+
+    /**
+     * Create a new {@link Vector2d} and initialize its components to zero.
+     */
+    public Vector2d() {
+    }
+
+    /**
+     * Create a new {@link Vector2d} and initialize both of its components with the given value.
+     * 
+     * @param d    
+     *          the value of both components
+     */
+    public Vector2d(double d) {
+        this(d, d);
+    }
+
+    /**
+     * Create a new {@link Vector2d} and initialize its components to the given values.
+     * 
+     * @param x
+     *          the x value
+     * @param y
+     *          the y value
+     */
+    public Vector2d(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    /**
+     * Create a new {@link Vector2d} and initialize its components to the one of the given vector.
+     * 
+     * @param v
+     *          the {@link Vector2d} to copy the values from
+     */
+    public Vector2d(Vector2d v) {
+        x = v.x;
+        y = v.y;
+    }
+
+    /**
+     * Create a new {@link Vector2d} and initialize its components to the one of the given vector.
+     * 
+     * @param v
+     *          the {@link Vector2f} to copy the values from
+     */
+    public Vector2d(Vector2f v) {
+        x = v.x;
+        y = v.y;
+    }
+
+    /**
+     * Create a new {@link Vector2d} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #Vector2d(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y</tt> order
+     * @see #Vector2d(int, ByteBuffer)
+     */
+    public Vector2d(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector2d} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y</tt> order
+     */
+    public Vector2d(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+    }
+
+    /**
+     * Create a new {@link Vector2d} and read this vector from the supplied {@link DoubleBuffer}
+     * at the current buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the vector is read, use {@link #Vector2d(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y</tt> order
+     * @see #Vector2d(int, DoubleBuffer)
+     */
+    public Vector2d(DoubleBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector2d} and read this vector from the supplied {@link DoubleBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index
+     *          the absolute position into the DoubleBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y</tt> order
+     */
+    public Vector2d(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+    }
+
+    /**
+     * Set the x and y components to the supplied value.
+     *
+     * @param d
+     *          the value of both components
+     * @return this
+     */
+    public Vector2d set(double d) {
+        return set(d, d);
+    }
+
+    /**
+     * Set the x and y components to the supplied values.
+     * 
+     * @param x
+     *          the x value
+     * @param y
+     *          the y value
+     * @return this
+     */
+    public Vector2d set(double x, double y) {
+        this.x = x;
+        this.y = y;
+        return this;
+    }
+
+    /**
+     * Set this {@link Vector2d} to the values of v.
+     * 
+     * @param v
+     *          the vector to copy from
+     * @return this
+     */
+    public Vector2d set(Vector2d v) {
+        x = v.x;
+        y = v.y;
+        return this;
+    }
+
+    /**
+     * Set this {@link Vector2d} to be a clone of <code>v</code>.
+     * 
+     * @param v
+     *          the vector to copy from
+     * @return this
+     */
+    public Vector2d set(Vector2f v) {
+        x = v.x;
+        y = v.y;
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector2d set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2d set(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the vector is read, use {@link #set(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y</tt> order
+     * @return this
+     * @see #set(int, DoubleBuffer)
+     */
+    public Vector2d set(DoubleBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index 
+     *          the absolute position into the DoubleBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2d set(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        return this;
+    }
+    
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y</tt> order
+     * @return the passed in buffer
+     * @see #get(int, ByteBuffer)
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index 
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y</tt> order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putDouble(index,      x);
+        buffer.putDouble(index + 8,  y);
+        return buffer;
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the vector is stored, use {@link #get(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y</tt> order
+     * @return the passed in buffer
+     * @see #get(int, DoubleBuffer)
+     */
+    public DoubleBuffer get(DoubleBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index
+     *          the absolute position into the DoubleBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y</tt> order
+     * @return the passed in buffer
+     */
+    public DoubleBuffer get(int index, DoubleBuffer buffer) {
+        buffer.put(index,      x);
+        buffer.put(index + 1,  y);
+        return buffer;
+    }
+
+    /**
+     * Store one perpendicular vector of <code>v</code> in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to build one perpendicular vector of
+     * @param dest
+     *          will hold the result
+     */
+    public static void perpendicular(Vector2d v, Vector2d dest) {
+        dest.x = v.y;
+        dest.y = v.x * -1;
+    }
+
+    /**
+     * Set this vector to be one of its perpendicular vectors.
+     * 
+     * @return this
+     */
+    public Vector2d perpendicular() {
+        return set(y, x * -1);
+    }
+
+    /**
+     * Subtract <code>v</code> from this vector.
+     * 
+     * @param v
+     *          the vector to subtract
+     * @return this
+     */
+    public Vector2d sub(Vector2d v) {
+        x -= v.x;
+        y -= v.y;
+        return this;
+    }
+
+    /**
+     * Subtract <tt>(x, y)</tt> from this vector.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @return this
+     */
+    public Vector2d sub(double x, double y) {
+        this.x -= x;
+        this.y -= y;
+        return this;
+    }
+
+    /**
+     * Subtract <tt>(x, y)</tt> from this vector and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param dest
+     *          will hold the result         
+     * @return dest
+     */
+    public Vector2d sub(double x, double y, Vector2d dest) {
+        dest.x = this.x - x;
+        dest.y = this.y - y;
+        return dest;
+    }
+
+    /**
+     * Subtract <code>v</code> from this vector.
+     * 
+     * @param v
+     *          the vector to subtract
+     * @return this
+     */
+    public Vector2d sub(Vector2f v) {
+        x -= v.x;
+        y -= v.y;
+        return this;
+    }
+
+    /**
+     * Subtract <code>v</code> from <code>this</code> vector and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to subtract
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d sub(Vector2d v, Vector2d dest) {
+        dest.x = x - v.x;
+        dest.y = y - v.y;
+        return dest;
+    }
+
+    /**
+     * Subtract <code>v</code> from <code>this</code> vector and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to subtract
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d sub(Vector2f v, Vector2d dest) {
+        dest.x = x + v.x;
+        dest.y = y + v.y;
+        return dest;
+    }
+
+    /**
+     * Subtract <code>b</code> from <code>a</code> and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the vector to subtract from
+     * @param b
+     *          the vector to subtract
+     * @param dest
+     *          will hold the result
+     */
+    public static void sub(Vector2f a, Vector2d b, Vector2d dest) {
+        dest.x = a.x - b.x;
+        dest.y = a.y - b.y;
+    }
+
+    /**
+     * Return the dot product of this vector and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the dot product
+     */
+    public double dot(Vector2d v) {
+        return x * v.x + y * v.y;
+    }
+
+    /**
+     * Return the angle between this vector and the supplied vector.
+     * 
+     * @param v
+     *          the other vector
+     * @return the angle, in radians
+     */
+    public double angle(Vector2d v) {
+        double dot = x*v.x + y*v.y;
+        double det = x*v.y - y*v.x;
+        return Math.atan2(det, dot);
+    }
+
+    /**
+     * Return the length of this vector.
+     * 
+     * @return the length
+     */
+    public double length() {
+        return Math.sqrt(x * x + y * y);
+    }
+
+    /**
+     * Return the distance between <code>this</code> and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the euclidean distance
+     */
+    public double distance(Vector2d v) {
+        double dx = v.x - x;
+        double dy = v.y - y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    /**
+     * Return the distance between <code>this</code> and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the euclidean distance
+     */
+    public double distance(Vector2f v) {
+        double dx = v.x - x;
+        double dy = v.y - y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    /**
+     * Normalize this vector.
+     * 
+     * @return this
+     */
+    public Vector2d normalize() {
+        double invLength = 1.0 / Math.sqrt(x * x + y * y);
+        x *= invLength;
+        y *= invLength;
+        return this;
+    }
+
+    /**
+     * Normalize this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d normalize(Vector2d dest) {
+        double invLength = 1.0 / Math.sqrt(x * x + y * y);
+        dest.x = x * invLength;
+        dest.y = y * invLength;
+        return dest;
+    }
+
+    /**
+     * Add <code>v</code> to this vector.
+     * 
+     * @param v
+     *          the vector to add
+     * @return this
+     */
+    public Vector2d add(Vector2d v) {
+        x += v.x;
+        y += v.y;
+        return this;
+    }
+
+    /**
+     * Add <code>(x, y)</code> to this vector.
+     * 
+     * @param x
+     *          the x component to add
+     * @param y
+     *          the y component to add
+     * @return this
+     */
+    public Vector2d add(double x, double y) {
+        this.x += x;
+        this.y += y;
+        return this;
+    }
+
+    /**
+     * Add <code>(x, y)</code> to this vector and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to add
+     * @param y
+     *          the y component to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d add(double x, double y, Vector2d dest) {
+        dest.x = this.x + x;
+        dest.y = this.y + y;
+        return dest;
+    }
+
+    /**
+     * Add <code>v</code> to this vector.
+     * 
+     * @param v
+     *          the vector to add
+     * @return this
+     */
+    public Vector2d add(Vector2f v) {
+        x += v.x;
+        y += v.y;
+        return this;
+    }
+
+    /**
+     * Add <code>v</code> to this vector and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d add(Vector2d v, Vector2d dest) {
+        dest.x = x + v.x;
+        dest.y = y + v.y;
+        return dest;
+    }
+
+    /**
+     * Add <code>v</code> to this vector and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d add(Vector2f v, Vector2d dest) {
+        dest.x = x + v.x;
+        dest.y = y + v.y;
+        return dest;
+    }
+
+    /**
+     * Add <code>a</code> to <code>b</code> and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first addend
+     * @param b
+     *          the second addend
+     * @param dest
+     *          will hold the result
+     */
+    public static void add(Vector2f a, Vector2d b, Vector2d dest) {
+        dest.x = a.x + b.x;
+        dest.y = a.y + b.y;
+    }
+
+    /**
+     * Set all components to zero.
+     * 
+     * @return this
+     */
+    public Vector2d zero() {
+        x = 0.0;
+        y = 0.0;
+        return this;
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeDouble(x);
+        out.writeDouble(y);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        x = in.readDouble();
+        y = in.readDouble();
+    }
+
+    /**
+     * Negate this vector.
+     * 
+     * @return this
+     */
+    public Vector2d negate() {
+        x = -x;
+        y = -y;
+        return this;
+    }
+
+    /**
+     * Negate this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d negate(Vector2d dest) {
+        dest.x = -x;
+        dest.y = -y;
+        return dest;
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>this</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @return this
+     */
+    public Vector2d lerp(Vector2d other, double t) {
+        return lerp(other, t, this);
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d lerp(Vector2d other, double t, Vector2d dest) {
+        dest.x = x + (other.x - x) * t;
+        dest.y = y + (other.y - y) * t;
+        return dest;
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(x);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(y);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Vector2d other = (Vector2d) obj;
+        if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+            return false;
+        if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
+            return false;
+        return true;
+    }
+
+    /**
+     * Return a string representation of this vector.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this vector by formatting the vector components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the vector components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + " " + formatter.format(y) + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector2d fma(Vector2d a, Vector2d b) {
+        x += a.x * b.x;
+        y += a.y * b.y;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector2d fma(double a, Vector2d b) {
+        x += a * b.x;
+        y += a * b.y;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d fma(Vector2d a, Vector2d b, Vector2d dest) {
+        dest.x = x + a.x * b.x;
+        dest.y = y + a.y * b.y;
+        return dest;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2d fma(double a, Vector2d b, Vector2d dest) {
+        dest.x = x + a * b.x;
+        dest.y = y + a * b.y;
+        return dest;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Vector2f.java
+++ b/GVRf/Framework/src/org/joml/Vector2f.java
@@ -1,0 +1,761 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Represents a 2D vector with single-precision.
+ *
+ * @author RGreenlees
+ * @author Kai Burjack
+ */
+public class Vector2f implements Externalizable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The x component of the vector.
+     */
+    public float x;
+    /**
+     * The y component of the vector.
+     */
+    public float y;
+
+    /**
+     * Create a new {@link Vector2f} and initialize its components to zero.
+     */
+    public Vector2f() {
+    }
+
+    /**
+     * Create a new {@link Vector2f} and initialize both of its components with the given value.
+     *
+     * @param d
+     *        the value of both components
+     */
+    public Vector2f(float d) {
+        this(d, d);
+    }
+
+    /**
+     * Create a new {@link Vector2f} and initialize its components to the given values.
+     * 
+     * @param x
+     *        the x component
+     * @param y
+     *        the y component
+     */
+    public Vector2f(float x, float y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    /**
+     * Create a new {@link Vector2f} and initialize its components to the one of the given vector.
+     * 
+     * @param v
+     *        the {@link Vector2f} to copy the values from
+     */
+    public Vector2f(Vector2f v) {
+        x = v.x;
+        y = v.y;
+    }
+
+    /**
+     * Create a new {@link Vector2f} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #Vector2f(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
+     * @see #Vector2f(int, ByteBuffer)
+     */
+    public Vector2f(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector2f} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *        the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y</tt> order
+     */
+    public Vector2f(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+    }
+
+    /**
+     * Create a new {@link Vector2f} and read this vector from the supplied {@link FloatBuffer}
+     * at the current buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the vector is read, use {@link #Vector2f(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
+     * @see #Vector2f(int, FloatBuffer)
+     */
+    public Vector2f(FloatBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector2f} and read this vector from the supplied {@link FloatBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index 
+     *        the absolute position into the FloatBuffer
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
+     */
+    public Vector2f(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+    }
+
+    /**
+     * Set the x and y components to the supplied value.
+     *
+     * @param d
+     *        the value of both components
+     * @return this
+     */
+    public Vector2f set(float d) {
+        return set(d, d);
+    }
+    
+    /**
+     * Set the x and y components to the supplied values.
+     * 
+     * @param x
+     *        the x component
+     * @param y
+     *        the y component
+     * @return this
+     */
+    public Vector2f set(float x, float y) {
+        this.x = x;
+        this.y = y;
+        return this;
+    }
+
+    /**
+     * Set this {@link Vector2f} to the values of v.
+     * 
+     * @param v
+     *        the vector to copy from
+     * @return this
+     */
+    public Vector2f set(Vector2f v) {
+        x = v.x;
+        y = v.y;
+        return this;
+    }
+
+    /**
+     * Set this {@link Vector2f} to the values of v.
+     * <p>
+     * Note that due to the given vector <code>v</code> storing the components in double-precision,
+     * there is the possibility to lose precision.
+     * 
+     * @param v
+     *        the vector to copy from
+     * @return this
+     */
+    public Vector2f set(Vector2d v) {
+        x = (float) v.x;
+        y = (float) v.y;
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector2f set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *        the absolute position into the ByteBuffer
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2f set(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the vector is read, use {@link #set(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
+     * @return this
+     * @see #set(int, FloatBuffer)
+     */
+    public Vector2f set(FloatBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index 
+     *        the absolute position into the FloatBuffer
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2f set(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        return this;
+    }
+    
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *        will receive the values of this vector in <tt>x, y</tt> order
+     * @return the passed in buffer
+     * @see #get(int, ByteBuffer)
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *        the absolute position into the ByteBuffer
+     * @param buffer
+     *        will receive the values of this vector in <tt>x, y</tt> order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putFloat(index,      x);
+        buffer.putFloat(index + 4,  y);
+        return buffer;
+    }
+
+    /**
+     * Store this vector into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the vector is stored, use {@link #get(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *        will receive the values of this vector in <tt>x, y</tt> order
+     * @return the passed in buffer
+     * @see #get(int, FloatBuffer)
+     */
+    public FloatBuffer get(FloatBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index
+     *        the absolute position into the FloatBuffer
+     * @param buffer
+     *        will receive the values of this vector in <tt>x, y</tt> order
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(int index, FloatBuffer buffer) {
+        buffer.put(index,      x);
+        buffer.put(index + 1,  y);
+        return buffer;
+    }
+
+    /**
+     * Store one perpendicular vector of <code>v</code> in <code>dest</code>.
+     * 
+     * @param v
+     *        the vector to build one perpendicular vector of
+     * @param dest
+     *        will hold the result
+     */
+    public static void perpendicular(Vector2f v, Vector2f dest) {
+        dest.x = v.y;
+        dest.y = v.x * -1;
+    }
+
+    /**
+     * Set this vector to be one of its perpendicular vectors.
+     * 
+     * @return this
+     */
+    public Vector2f perpendicular() {
+        return set(y, x * -1);
+    }
+
+    /**
+     * Subtract <code>b</code> from <code>a</code> and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *        the first operand
+     * @param b
+     *        the second operand
+     * @param dest
+     *        will hold the result of <code>a - b</code>
+     */
+    public static void sub(Vector2f a, Vector2f b, Vector2f dest) {
+        dest.x = a.x - b.x;
+        dest.y = a.y - b.y;
+    }
+
+    /**
+     * Subtract <code>v</code> from this vector.
+     * 
+     * @param v
+     *        the vector to subtract from this
+     * @return this
+     */
+    public Vector2f sub(Vector2f v) {
+        x -= v.x;
+        y -= v.y;
+        return this;
+    }
+
+    /**
+     * Subtract <tt>(x, y)</tt> from this vector.
+     * 
+     * @param x
+     *        the x component to subtract
+     * @param y
+     *        the y component to subtract
+     * @return this
+     */
+    public Vector2f sub(float x, float y) {
+        this.x -= x;
+        this.y -= y;
+        return this;
+    }
+
+    /**
+     * Return the dot product of this vector and <code>v</code>.
+     * 
+     * @param v
+     *        the other vector
+     * @return the dot product
+     */
+    public float dot(Vector2f v) {
+        return x * v.x + y * v.y;
+    }
+
+    /**
+     * Return the angle between this vector and the supplied vector.
+     * 
+     * @param v
+     *        the other vector
+     * @return the angle, in radians
+     */
+    public float angle(Vector2f v) {
+        float dot = x*v.x + y*v.y;
+        float det = x*v.y - y*v.x;
+        return (float) Math.atan2(det, dot);
+    }
+
+    /**
+     * Return the length of this vector.
+     * 
+     * @return the length
+     */
+    public float length() {
+        return (float) Math.sqrt((x * x) + (y * y));
+    }
+
+    /**
+     * Return the length squared of this vector.
+     * 
+     * @return the length squared
+     */
+    public float lengthSquared() {
+        return x * x + y * y;
+    }
+
+    /**
+     * Return the distance between this and <code>v</code>.
+     * 
+     * @param v
+     *        the other vector
+     * @return the distance
+     */
+    public float distance(Vector2f v) {
+        float dx = v.x - x;
+        float dy = v.y - y;
+        return (float) Math.sqrt(dx * dx + dy * dy);
+    }
+
+    /**
+     * Normalize this vector.
+     * 
+     * @return this
+     */
+    public Vector2f normalize() {
+        float invLength = (float) (1.0 / Math.sqrt(x * x + y * y));
+        x *= invLength;
+        y *= invLength;
+        return this;
+    }
+
+    /**
+     * Normalize this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *        will hold the result
+     * @return dest
+     */
+    public Vector2f normalize(Vector2f dest) {
+        float invLength = (float) (1.0 / Math.sqrt(x * x + y * y));
+        dest.x = x * invLength;
+        dest.y = y * invLength;
+        return dest;
+    }
+
+    /**
+     * Add <code>v</code> to this vector.
+     * 
+     * @param v
+     *        the vector to add
+     * @return this
+     */
+    public Vector2f add(Vector2f v) {
+        x += v.x;
+        y += v.y;
+        return this;
+    }
+
+    /**
+     * Add <code>a</code> to <code>b</code> and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *        the first addend
+     * @param b
+     *        the second addend
+     * @param dest
+     *        will hold the result
+     */
+    public static void add(Vector2f a, Vector2f b, Vector2f dest) {
+        dest.x = a.x + b.x;
+        dest.y = a.y + b.y;
+    }
+
+    /**
+     * Set all components to zero.
+     * 
+     * @return this
+     */
+    public Vector2f zero() {
+        this.x = 0.0f;
+        this.y = 0.0f;
+        return this;
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeFloat(x);
+        out.writeFloat(y);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        x = in.readFloat();
+        y = in.readFloat();
+    }
+
+    /**
+     * Negate this vector.
+     * 
+     * @return this
+     */
+    public Vector2f negate() {
+        x = -x;
+        y = -y;
+        return this;
+    }
+
+    /**
+     * Negate this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *        will hold the result
+     * @return dest
+     */
+    public Vector2f negate(Vector2f dest) {
+        dest.x = -x;
+        dest.y = -y;
+        return dest;
+    }
+
+    /**
+     * Multiply the components of this vector by the given scalar.
+     * 
+     * @param scalar
+     *        the value to multiply this vector's components by
+     * @return this
+     */
+    public Vector2f mul(float scalar) {
+        this.x *= scalar;
+        this.y *= scalar;
+        return this;
+    }
+
+    /**
+     * Multiply the components of this vector by the given scalar and store the result in <code>dest</code>.
+     * 
+     * @param scalar
+     *        the value to multiply this vector's components by
+     * @param dest
+     *        will hold the result
+     * @return dest
+     */
+    public Vector2f mul(float scalar, Vector2f dest) {
+        dest.x *= scalar;
+        dest.y *= scalar;
+        return dest;
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>this</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @return this
+     */
+    public Vector2f lerp(Vector2f other, float t) {
+        return lerp(other, t, this);
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2f lerp(Vector2f other, float t, Vector2f dest) {
+        dest.x = x + (other.x - x) * t;
+        dest.y = y + (other.y - y) * t;
+        return dest;
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Float.floatToIntBits(x);
+        result = prime * result + Float.floatToIntBits(y);
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Vector2f other = (Vector2f) obj;
+        if (Float.floatToIntBits(x) != Float.floatToIntBits(other.x))
+            return false;
+        if (Float.floatToIntBits(y) != Float.floatToIntBits(other.y))
+            return false;
+        return true;
+    }
+
+    /**
+     * Return a string representation of this vector.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this vector by formatting the vector components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *        the {@link NumberFormat} used to format the vector components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + " " + formatter.format(y) + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector2f fma(Vector2f a, Vector2f b) {
+        x += a.x * b.x;
+        y += a.y * b.y;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector2f fma(float a, Vector2f b) {
+        x += a * b.x;
+        y += a * b.y;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2f fma(Vector2f a, Vector2f b, Vector2f dest) {
+        dest.x = x + a.x * b.x;
+        dest.y = y + a.y * b.y;
+        return dest;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector2f fma(float a, Vector2f b, Vector2f dest) {
+        dest.x = x + a * b.x;
+        dest.y = y + a * b.y;
+        return dest;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Vector3d.java
+++ b/GVRf/Framework/src/org/joml/Vector3d.java
@@ -1,0 +1,1910 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+
+/**
+ * Contains the definition of a Vector comprising 3 doubles and associated
+ * transformations.
+ *
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Vector3d implements Externalizable {
+
+    private static final long serialVersionUID = 1L;   
+
+    /**
+     * The x component of the vector.
+     */
+    public double x;
+    /**
+     * The y component of the vector.
+     */
+    public double y;
+    /**
+     * The z component of the vector.
+     */
+    public double z;
+
+    /**
+     * Create a new {@link Vector3d} with all components set to zero.
+     */
+    public Vector3d() {
+    }
+
+    /**
+     * Create a new {@link Vector3d} and initialize all three components with the given value.
+     *
+     * @param d
+     *          the value of all three components
+     */
+    public Vector3d(double d) {
+        this(d, d, d);
+    }
+
+    /**
+     * Create a new {@link Vector3d} with the given component values.
+     * 
+     * @param x
+     *          the value of x
+     * @param y
+     *          the value of y
+     * @param z
+     *          the value of z
+     */
+    public Vector3d(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    /**
+     * Create a new {@link Vector3d} whose values will be copied from the given vector.
+     * 
+     * @param v
+     *          provides the initial values for the new vector
+     */
+    public Vector3d(Vector3f v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+    }
+
+    /**
+     * Create a new {@link Vector3d} with the first two components from the
+     * given <code>v</code> and the given <code>z</code>
+     *
+     * @param v
+     *          the {@link Vector2f} to copy the values from
+     * @param z
+     *          the z component
+     */
+    public Vector3d(Vector2f v, double z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+    }
+
+    /**
+     * Create a new {@link Vector3d} whose values will be copied from the given vector.
+     * 
+     * @param v
+     *          provides the initial values for the new vector
+     */
+    public Vector3d(Vector3d v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+    }
+
+    /**
+     * Create a new {@link Vector3d} with the first two components from the
+     * given <code>v</code> and the given <code>z</code>
+     *
+     * @param v
+     *          the {@link Vector2d} to copy the values from
+     * @param z
+     *          the z component
+     */
+    public Vector3d(Vector2d v, double z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+    }
+
+    /**
+     * Create a new {@link Vector3d} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #Vector3d(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @see #Vector3d(int, ByteBuffer)
+     */
+    public Vector3d(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector3d} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     */
+    public Vector3d(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        z = buffer.getDouble(index + 16);
+    }
+
+    /**
+     * Create a new {@link Vector3d} and read this vector from the supplied {@link DoubleBuffer}
+     * at the current buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the vector is read, use {@link #Vector3d(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @see #Vector3d(int, DoubleBuffer)
+     */
+    public Vector3d(DoubleBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector3d} and read this vector from the supplied {@link DoubleBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     */
+    public Vector3d(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+    }
+
+    /**
+     * Set the x, y and z components to match the supplied vector.
+     * 
+     * @param v
+     *          the vector to set this vector's components from
+     * @return this
+     */
+    public Vector3d set(Vector3d v) {
+        x = v.x;
+        y = v.y;
+        z = v.z;
+        return this;
+    }
+
+    /**
+     * Set the first two components from the given <code>v</code>
+     * and the z component from the given <code>z</code>
+     *
+     * @param v
+     *          the {@link Vector2d} to copy the values from
+     * @param z
+     *          the z component
+     * @return this
+     */
+    public Vector3d set(Vector2d v, double z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        return this;
+    }
+
+    /**
+     * Set the x, y and z components to match the supplied vector.
+     * 
+     * @param v
+     *          the vector to set this vector's components from
+     * @return this
+     */
+    public Vector3d set(Vector3f v) {
+        x = v.x;
+        y = v.y;
+        z = v.z;
+        return this;
+    }
+
+    /**
+     * Set the first two components from the given <code>v</code>
+     * and the z component from the given <code>z</code>
+     *
+     * @param v
+     *          the {@link Vector2f} to copy the values from
+     * @param z
+     *          the z component
+     * @return this
+     */
+    public Vector3d set(Vector2f v, double z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        return this;
+    }
+
+    /**
+     * Set the x, y, and z components to the supplied value.
+     *
+     * @param d
+     *          the value of all three components
+     * @return this
+     */
+    public Vector3d set(double d) {
+        return set(d, d, d);
+    }
+
+    /**
+     * Set the x, y and z components to the supplied values.
+     * 
+     * @param x
+     *          the x component
+     * @param y
+     *          the y component
+     * @param z
+     *          the z component
+     * @return this
+     */
+    public Vector3d set(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector3d set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3d set(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        z = buffer.getDouble(index + 16);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the vector is read, use {@link #set(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer 
+     *          values will be read in <tt>x, y, z</tt> order
+     * @return this
+     * @see #set(int, DoubleBuffer)
+     */
+    public Vector3d set(DoubleBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index
+     *          the absolute position into the DoubleBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3d set(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return the passed in buffer
+     * @see #get(int, ByteBuffer)
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putDouble(index,      x);
+        buffer.putDouble(index + 8,  y);
+        buffer.putDouble(index + 16,  z);
+        return buffer;
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the vector is stored, use {@link #get(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return the passed in buffer
+     * @see #get(int, DoubleBuffer)
+     */
+    public DoubleBuffer get(DoubleBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index
+     *          the absolute position into the DoubleBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return the passed in buffer
+     */
+    public DoubleBuffer get(int index, DoubleBuffer buffer) {
+        buffer.put(index,      x);
+        buffer.put(index + 1,  y);
+        buffer.put(index + 2,  z);
+        return buffer;
+    }
+
+    /**
+     * Subtract the supplied vector from this one.
+     * 
+     * @param v
+     *          the vector to subtract from this
+     * @return this
+     */
+    public Vector3d sub(Vector3d v) {
+        x -= v.x;
+        y -= v.y;
+        z -= v.z;
+        return this;
+    }
+
+    /**
+     * Subtract the supplied vector from this one and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to subtract from <code>this</code>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d sub(Vector3d v, Vector3d dest) {
+        dest.x = x - v.x;
+        dest.y = y - v.y;
+        dest.z = z - v.z;
+        return dest;
+    }
+
+    /**
+     * Subtract the supplied vector from this one.
+     * 
+     * @param v
+     *          the vector to subtract from this
+     * @return this
+     */
+    public Vector3d sub(Vector3f v) {
+        x -= v.x;
+        y -= v.y;
+        z -= v.z;
+        return this;
+    }
+
+    /**
+     * Subtract the supplied vector from this one and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to subtract from <code>this</code>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d sub(Vector3f v, Vector3d dest) {
+        dest.x = x - v.x;
+        dest.y = y - v.y;
+        dest.z = z - v.z;
+        return dest;
+    }
+
+    /**
+     * Subtract <tt>(x, y, z)</tt> from this vector.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @return this
+     */
+    public Vector3d sub(double x, double y, double z) {
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        return this;
+    }
+
+    /**
+     * Subtract <tt>(x, y, z)</tt> from this vector and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d sub(double x, double y, double z, Vector3d dest) {
+        dest.x = this.x - x;
+        dest.y = this.y - y;
+        dest.z = this.z - z;
+        return dest;
+    }
+
+    /**
+     * Subtract <code>v2</code> from <code>v1</code> and store the result in <code>dest</code>.
+     * 
+     * @param v1
+     *          the vector to subtract from
+     * @param v2
+     *          the vector to subtract
+     * @param dest
+     *          will hold the result
+     */
+    public static void sub(Vector3f v1, Vector3d v2, Vector3d dest) {
+        dest.x = v1.x - v2.x;
+        dest.y = v1.y - v2.y;
+        dest.z = v1.z - v2.z;
+    }
+
+    /**
+     * Add the supplied vector to this one.
+     * 
+     * @param v
+     *          the vector to add
+     * @return this
+     */
+    public Vector3d add(Vector3d v) {
+        x += v.x;
+        y += v.y;
+        z += v.z;
+        return this;
+    }
+
+    /**
+     * Add the supplied vector to this one and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d add(Vector3d v, Vector3d dest) {
+        dest.x = x + v.x;
+        dest.y = y + v.y;
+        dest.z = z + v.z;
+        return dest;
+    }
+
+    /**
+     * Add the supplied vector to this one.
+     * 
+     * @param v
+     *          the vector to add
+     * @return this
+     */
+    public Vector3d add(Vector3f v) {
+        x += v.x;
+        y += v.y;
+        z += v.z;
+        return this;
+    }
+
+    /**
+     * Add the supplied vector to this one and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d add(Vector3f v, Vector3d dest) {
+        dest.x = x + v.x;
+        dest.y = y + v.y;
+        dest.z = z + v.z;
+        return dest;
+    }
+
+    /**
+     * Increment the components of this vector by the given values.
+     * 
+     * @param x
+     *          the x component to add
+     * @param y
+     *          the y component to add
+     * @param z
+     *          the z component to add
+     * @return this
+     */
+    public Vector3d add(double x, double y, double z) {
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        return this;
+    }
+
+    /**
+     * Increment the components of this vector by the given values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to add
+     * @param y
+     *          the y component to add
+     * @param z
+     *          the z component to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d add(double x, double y, double z, Vector3d dest) {
+        dest.x = this.x + x;
+        dest.y = this.y + y;
+        dest.z = this.z + z;
+        return dest;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector3d fma(Vector3d a, Vector3d b) {
+        x += a.x * b.x;
+        y += a.y * b.y;
+        z += a.z * b.z;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector3d fma(double a, Vector3d b) {
+        x += a * b.x;
+        y += a * b.y;
+        z += a * b.z;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d fma(Vector3d a, Vector3d b, Vector3d dest) {
+        dest.x = x + a.x * b.x;
+        dest.y = y + a.y * b.y;
+        dest.z = z + a.z * b.z;
+        return dest;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d fma(double a, Vector3d b, Vector3d dest) {
+        dest.x = x + a * b.x;
+        dest.y = y + a * b.y;
+        dest.z = z + a * b.z;
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector3d component-wise by another Vector3d.
+     * 
+     * @param v
+     *          the vector to multiply by
+     * @return this
+     */
+    public Vector3d mul(Vector3d v) {
+        x *= v.x;
+        y *= v.y;
+        z *= v.z;
+        return this;
+    }
+
+    /**
+     * Multiply this Vector3d component-wise by another Vector3f.
+     * 
+     * @param v
+     *          the vector to multiply by
+     * @return this
+     */
+    public Vector3d mul(Vector3f v) {
+        x *= v.x;
+        y *= v.y;
+        z *= v.z;
+        return this;
+    }
+
+    /**
+     * Multiply this Vector3d component-wise by another Vector3f and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to multiply by
+     * @param dest
+     * 			will hold the result
+     * @return dest
+     */
+    public Vector3d mul(Vector3f v, Vector3d dest) {
+        dest.x = x * v.x;
+        dest.y = y * v.y;
+        dest.z = z * v.z;
+        return dest;
+    }
+
+    /**
+     * Multiply this by <code>v</code> component-wise and store the result into <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to multiply by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mul(Vector3d v, Vector3d dest) {
+        dest.x = x * v.x;
+        dest.y = y * v.y;
+        dest.z = z * v.z;
+        return dest;
+    }
+
+    /**
+     * Divide this Vector3d component-wise by another Vector3d.
+     * 
+     * @param v
+     *          the vector to divide by
+     * @return this
+     */
+    public Vector3d div(Vector3d v) {
+        x /= v.x;
+        y /= v.y;
+        z /= v.z;
+        return this;
+    }
+
+    /**
+     * Divide this Vector3d component-wise by another Vector3f.
+     * 
+     * @param v
+     *          the vector to divide by
+     * @return this
+     */
+    public Vector3d div(Vector3f v) {
+        x /= v.x;
+        y /= v.y;
+        z /= v.z;
+        return this;
+    }
+
+    /**
+     * Divide this Vector3d component-wise by another Vector3f and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to divide by
+     * @param dest
+     * 			will hold the result
+     * @return dest
+     */
+    public Vector3d div(Vector3f v, Vector3d dest) {
+        dest.x = x / v.x;
+        dest.y = y / v.y;
+        dest.z = z / v.z;
+        return dest;
+    }
+
+    /**
+     * Divide this by <code>v</code> component-wise and store the result into <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to divide by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d div(Vector3d v, Vector3d dest) {
+        dest.x = x / v.x;
+        dest.y = y / v.y;
+        dest.z = z / v.z;
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector3d by the given matrix <code>mat</code>, perform perspective division
+     * and store the result in <code>dest</code>.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mulProject(Matrix4d mat, Vector3d dest) {
+        double invW = 1.0 / (mat.m03 * x + mat.m13 * y + mat.m23 * z + mat.m33);
+        dest.set((mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30) * invW,
+                 (mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31) * invW,
+                 (mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32) * invW);
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector3d by the given matrix <code>mat</code>, perform perspective division.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3d mulProject(Matrix4d mat) {
+        return mulProject(mat, this);
+    }
+
+    /**
+     * Multiply this Vector3d by the given matrix <code>mat</code>, perform perspective division
+     * and store the result in <code>dest</code>.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mulProject(Matrix4f mat, Vector3d dest) {
+        double invW = 1.0 / (mat.m03 * x + mat.m13 * y + mat.m23 * z + mat.m33);
+        dest.set((mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30) * invW,
+                 (mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31) * invW,
+                 (mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32) * invW);
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector3d by the given matrix <code>mat</code>, perform perspective division.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3d mulProject(Matrix4f mat) {
+        return mulProject(mat, this);
+    }
+
+    /**
+     * Multiply this Vector3d by the given matrix <code>mat</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3d mul(Matrix3f mat) {
+        return mul(mat, this);
+    }
+
+    /**
+     * Multiply this Vector3d by the given matrix <code>mat</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3d mul(Matrix3d mat) {
+        return mul(mat, this);
+    }
+
+    /**
+     * Multiply <code>this</code> by the given matrix <code>mat</code> and store the
+     * result in <code>dest</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mul(Matrix3d mat, Vector3d dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z);
+        return dest;
+    }
+
+    /**
+     * Multiply <code>this</code> by the given matrix <code>mat</code> and store the
+     * result in <code>dest</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mul(Matrix3f mat, Vector3d dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z);
+        return dest;
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>1.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3d mulPoint(Matrix4f mat) {
+        return mulPoint(mat, this);
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>1.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3d mulPoint(Matrix4d mat) {
+        return mulPoint(mat, this);
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code> and store the
+     * result in <code>dest</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>1.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mulPoint(Matrix4d mat, Vector3d dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32);
+        return dest;
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code> and store the
+     * result in <code>dest</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>1.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mulPoint(Matrix4f mat, Vector3d dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32);
+        return dest;
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>0.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3d mulDirection(Matrix4f mat) {
+        return mulDirection(mat, this);
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>0.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3d mulDirection(Matrix4d mat) {
+        return mulDirection(mat, this);
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code> and store the
+     * result in <code>dest</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>0.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mulDirection(Matrix4d mat, Vector3d dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z);
+        return dest;
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code> and store the
+     * result in <code>dest</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>0.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mulDirection(Matrix4f mat, Vector3d dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z);
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector3d by the given scalar value.
+     * 
+     * @param scalar
+     *          the scalar to multiply this vector by
+     * @return this
+     */
+    public Vector3d mul(double scalar) {
+        x *= scalar;
+        y *= scalar;
+        z *= scalar;
+        return this;
+    }
+
+    /**
+     * Multiply this Vector3d by the given scalar value and store the result in <code>dest</code>.
+     * 
+     * @param scalar
+     *          the scalar factor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mul(double scalar, Vector3d dest) {
+        dest.x = x * scalar;
+        dest.y = y * scalar;
+        dest.z = z * scalar;
+        return dest;
+    }
+
+    /**
+     * Multiply the components of this Vector3f by the given scalar values and store the result in <code>this</code>.
+     * 
+     * @param x
+     *          the x component to multiply this vector by
+     * @param y
+     *          the y component to multiply this vector by
+     * @param z
+     *          the z component to multiply this vector by
+     * @return this
+     */
+    public Vector3d mul(double x, double y, double z) {
+        this.x *= x;
+        this.y *= y;
+        this.z *= z;
+        return this;
+    }
+
+    /**
+     * Multiply the components of this Vector3f by the given scalar values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to multiply this vector by
+     * @param y
+     *          the y component to multiply this vector by
+     * @param z
+     *          the z component to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d mul(double x, double y, double z, Vector3d dest) {
+        dest.x = this.x * x;
+        dest.y = this.y * y;
+        dest.z = this.z * z;
+        return dest;
+    }
+
+    /**
+     * Rotate this vector by the given quaternion <code>quat</code> and store the result in <code>this</code>.
+     * 
+     * @see Quaterniond#transform(Vector3d)
+     * 
+     * @param quat
+     *          the quaternion to rotate this vector
+     * @return this
+     */
+    public Vector3d rotate(Quaterniond quat) {
+        quat.transform(this, this);
+        return this;
+    }
+
+    /**
+     * Rotate this vector by the given quaternion <code>quat</code> and store the result in <code>dest</code>.
+     * 
+     * @see Quaterniond#transform(Vector3d)
+     * 
+     * @param quat
+     *          the quaternion to rotate this vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d rotate(Quaterniond quat, Vector3d dest) {
+        quat.transform(this, dest);
+        return dest;
+    }
+
+    /**
+     * Divide this Vector3d by the given scalar value.
+     * 
+     * @param scalar
+     *          the scalar to divide this vector by
+     * @return this
+     */
+    public Vector3d div(double scalar) {
+        x /= scalar;
+        y /= scalar;
+        z /= scalar;
+        return this;
+    }
+
+    /**
+     * Divide this Vector3d by the given scalar value and store the result in <code>dest</code>.
+     * 
+     * @param scalar
+     *          the scalar to divide this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d div(double scalar, Vector3d dest) {
+        dest.x = x / scalar;
+        dest.y = y / scalar;
+        dest.z = z / scalar;
+        return dest;
+    }
+
+    /**
+     * Divide the components of this Vector3f by the given scalar values and store the result in <code>this</code>.
+     * 
+     * @param x
+     *          the x component to divide this vector by
+     * @param y
+     *          the y component to divide this vector by
+     * @param z
+     *          the z component to divide this vector by
+     * @return this
+     */
+    public Vector3d div(double x, double y, double z) {
+        this.x /= x;
+        this.y /= y;
+        this.z /= z;
+        return this;
+    }
+
+    /**
+     * Divide the components of this Vector3f by the given scalar values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to divide this vector by
+     * @param y
+     *          the y component to divide this vector by
+     * @param z
+     *          the z component to divide this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d div(double x, double y, double z, Vector3d dest) {
+        dest.x = this.x / x;
+        dest.y = this.y / y;
+        dest.z = this.z / z;
+        return dest;
+    }
+
+    /**
+     * Multiply <code>v</code> by the <code>scalar</code> value and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to multiply
+     * @param scalar
+     *          the scalar to multiply the given vector by
+     * @param dest
+     *          will hold the result
+     */
+    public static void mul(Vector3f v, double scalar, Vector3d dest) {
+        dest.x = v.x * scalar;
+        dest.y = v.y * scalar;
+        dest.z = v.z * scalar;
+    }
+
+    /**
+     * Return the length squared of this vector.
+     * 
+     * @return the length squared
+     */
+    public double lengthSquared() {
+        return x * x + y * y + z * z;
+    }
+
+    /**
+     * Return the length of this vector.
+     * 
+     * @return the length
+     */
+    public double length() {
+        return Math.sqrt(lengthSquared());
+    }
+
+    /**
+     * Normalize this vector.
+     * 
+     * @return this
+     */
+    public Vector3d normalize() {
+        double invLength = 1.0 / length();
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        return this;
+    }
+
+    /**
+     * Normalize this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d normalize(Vector3d dest) {
+        double invLength = 1.0 / length();
+        dest.x = x * invLength;
+        dest.y = y * invLength;
+        dest.z = z * invLength;
+        return dest;
+    }
+
+    /**
+     * Set this vector to be the cross product of this and v2.
+     * 
+     * @param v
+     *          the other vector
+     * @return this
+     */
+    public Vector3d cross(Vector3d v) {
+        set(y * v.z - z * v.y,
+            z * v.x - x * v.z,
+            x * v.y - y * v.x);
+        return this;
+    }
+
+    /**
+     * Set this vector to be the cross product of itself and <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return this
+     */
+    public Vector3d cross(double x, double y, double z) {
+        return set(this.y * z - this.z * y,
+                   this.z * x - this.x * z,
+                   this.x * y - this.y * x);
+    }
+
+    /**
+     * Calculate the cross product of this and v2 and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d cross(Vector3d v, Vector3d dest) {
+        dest.set(y * v.z - z * v.y,
+                 z * v.x - x * v.z,
+                 x * v.y - y * v.x);
+        return dest;
+    }
+
+    /**
+     * Compute the cross product of this vector and <tt>(x, y, z)</tt> and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d cross(double x, double y, double z, Vector3d dest) {
+        return dest.set(this.y * z - this.z * y,
+                        this.z * x - this.x * z,
+                        this.x * y - this.y * x);
+    }
+
+    /**
+     * Return the distance between this vector and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the distance
+     */
+    public double distance(Vector3d v) {
+        double dx = v.x - x;
+        double dy = v.y - y;
+        double dz = v.z - z;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    /**
+     * Return the distance between <code>this</code> vector and <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return the euclidean distance
+     */
+    public double distance(double x, double y, double z) {
+        double dx = this.x - x;
+        double dy = this.y - y;
+        double dz = this.z - z;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    /**
+     * Return the square of the distance between this vector and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the squared of the distance
+     */
+    public double distanceSquared(Vector3d v) {
+        double dx = v.x - x;
+        double dy = v.y - y;
+        double dz = v.z - z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    /**
+     * Return the square of the distance between <code>this</code> vector and <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return the square of the distance
+     */
+    public double distanceSquared(double x, double y, double z) {
+        double dx = this.x - x;
+        double dy = this.y - y;
+        double dz = this.z - z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    /**
+     * Return the dot product of this vector and the supplied vector.
+     * 
+     * @param v
+     *          the other vector
+     * @return the dot product
+     */
+    public double dot(Vector3d v) {
+        return x * v.x + y * v.y + z * v.z;
+    }
+
+    /**
+     * Return the dot product of this vector and the vector <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return the dot product
+     */
+    public double dot(double x, double y, double z) {
+        return this.x * x + this.y * y + this.z * z;
+    }
+
+    /**
+     * Return the cosine of the angle between <code>this</code> vector and
+     * the supplied vector. Use this instead of <tt>Math.cos(angle(v))</tt>.
+     * 
+     * @see #angle(Vector3d)
+     * 
+     * @param v
+     *          the other vector
+     * @return the cosine of the angle
+     */
+    public double angleCos(Vector3d v) {
+        double length1Sqared = x * x + y * y + z * z;
+        double length2Sqared = v.x * v.x + v.y * v.y + v.z * v.z;
+        double dot = x * v.x + y * v.y + z * v.z;
+        return dot / (Math.sqrt(length1Sqared * length2Sqared));
+    }
+
+    /**
+     * Return the angle between this vector and the supplied vector.
+     * 
+     * @see #angleCos(Vector3d)
+     * 
+     * @param v
+     *          the other vector
+     * @return the angle, in radians
+     */
+    public double angle(Vector3d v) {
+        double cos = angleCos(v);
+        // This is because sometimes cos goes above 1 or below -1 because of lost precision
+        cos = Math.min(cos, 1);
+        cos = Math.max(cos, -1);
+        return Math.acos(cos);
+    }
+
+    /**
+     * Set all components to zero.
+     * 
+     * @return this
+     */
+    public Vector3d zero() {
+        x = 0.0;
+        y = 0.0;
+        z = 0.0;
+        return this;
+    }
+
+    /**
+     * Return a string representation of this vector.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this vector by formatting the vector components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the vector components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + " " + formatter.format(y) + " " + formatter.format(z) + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeDouble(x);
+        out.writeDouble(y);
+        out.writeDouble(z);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        x = in.readDouble();
+        y = in.readDouble();
+        z = in.readDouble();
+    }
+
+    /**
+     * Negate this vector.
+     * 
+     * @return this
+     */
+    public Vector3d negate() {
+        x = -x;
+        y = -y;
+        z = -z;
+        return this;
+    }
+
+    /**
+     * Negate this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d negate(Vector3d dest) {
+        dest.x = -x;
+        dest.y = -y;
+        dest.z = -z;
+        return dest;
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(x);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(y);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(z);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Vector3d other = (Vector3d) obj;
+        if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+            return false;
+        if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
+            return false;
+        if (Double.doubleToLongBits(z) != Double.doubleToLongBits(other.z))
+            return false;
+        return true;
+    }
+
+    /**
+     * Reflect this vector about the given normal vector.
+     * 
+     * @param normal
+     *          the vector to reflect about
+     * @return this
+     */
+    public Vector3d reflect(Vector3d normal) {
+        double dot = this.dot(normal);
+        x = x - 2.0 * dot * normal.x;
+        y = y - 2.0 * dot * normal.y;
+        z = z - 2.0 * dot * normal.z;
+        return this;
+    }
+
+    /**
+     * Reflect this vector about the given normal vector.
+     * 
+     * @param x
+     *          the x component of the normal
+     * @param y
+     *          the y component of the normal
+     * @param z
+     *          the z component of the normal
+     * @return this
+     */
+    public Vector3d reflect(double x, double y, double z) {
+        double dot = this.dot(x, y, z);
+        this.x = this.x - 2.0 * dot * x;
+        this.y = this.y - 2.0 * dot * y;
+        this.z = this.z - 2.0 * dot * z;
+        return this;
+    }
+
+    /**
+     * Reflect this vector about the given normal vector and store the result in <code>dest</code>.
+     * 
+     * @param normal
+     *          the vector to reflect about
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d reflect(Vector3d normal, Vector3d dest) {
+        double dot = this.dot(normal);
+        dest.x = x - 2.0 * dot * normal.x;
+        dest.y = y - 2.0 * dot * normal.y;
+        dest.z = z - 2.0 * dot * normal.z;
+        return dest;
+    }
+
+    /**
+     * Reflect this vector about the given normal vector and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component of the normal
+     * @param y
+     *          the y component of the normal
+     * @param z
+     *          the z component of the normal
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d reflect(double x, double y, double z, Vector3d dest) {
+        double dot = this.dot(x, y, z);
+        dest.x = this.x - 2.0 * dot * x;
+        dest.y = this.y - 2.0 * dot * y;
+        dest.z = this.z - 2.0 * dot * z;
+        return dest;
+    }
+
+    /**
+     * Compute the half vector between this and the other vector.
+     * 
+     * @param other
+     *          the other vector
+     * @return this
+     */
+    public Vector3d half(Vector3d other) {
+        return this.add(other).normalize();
+    }
+
+    /**
+     * Compute the half vector between this and the vector <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return this
+     */
+    public Vector3d half(double x, double y, double z) {
+        return this.add(x, y, z).normalize();
+    }
+
+    /**
+     * Compute the half vector between this and the other vector and store the result in <code>dest</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d half(Vector3d other, Vector3d dest) {
+        return dest.set(this).add(other).normalize();
+    }
+
+    /**
+     * Compute the half vector between this and the vector <tt>(x, y, z)</tt> 
+     * and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d half(double x, double y, double z, Vector3d dest) {
+        return dest.set(this).add(x, y, z).normalize();
+    }
+
+    /**
+     * Compute a smooth-step (i.e. hermite with zero tangents) interpolation
+     * between <code>this</code> vector and the given vector <code>v</code> and
+     * store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @param t
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d smoothStep(Vector3d v, double t, Vector3d dest) {
+        double t2 = t * t;
+        double t3 = t2 * t;
+        dest.x = (2.0 * x - 2.0 * v.x) * t3 + (3.0 * v.x - 3.0 * x) * t2 + x * t + x;
+        dest.y = (2.0 * y - 2.0 * v.y) * t3 + (3.0 * v.y - 3.0 * y) * t2 + y * t + y;
+        dest.z = (2.0 * z - 2.0 * v.z) * t3 + (3.0 * v.z - 3.0 * z) * t2 + z * t + z;
+        return dest;
+    }
+
+    /**
+     * Compute a hermite interpolation between <code>this</code> vector and its
+     * associated tangent <code>t0</code> and the given vector <code>v</code>
+     * with its tangent <code>t1</code> and store the result in
+     * <code>dest</code>.
+     * 
+     * @param t0
+     *          the tangent of <code>this</code> vector
+     * @param v1
+     *          the other vector
+     * @param t1
+     *          the tangent of the other vector
+     * @param t
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d hermite(Vector3d t0, Vector3d v1, Vector3d t1, double t, Vector3d dest) {
+        double t2 = t * t;
+        double t3 = t2 * t;
+        dest.x = (2.0 * x - 2.0 * v1.x + t1.x + t0.x) * t3 + (3.0 * v1.x - 3.0 * x - 2.0 * t0.x - t1.x) * t2 + x * t + x;
+        dest.y = (2.0 * y - 2.0 * v1.y + t1.y + t0.y) * t3 + (3.0 * v1.y - 3.0 * y - 2.0 * t0.y - t1.y) * t2 + y * t + y;
+        dest.z = (2.0 * z - 2.0 * v1.z + t1.z + t0.z) * t3 + (3.0 * v1.z - 3.0 * z - 2.0 * t0.z - t1.z) * t2 + z * t + z;
+        return dest;
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>this</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @return this
+     */
+    public Vector3d lerp(Vector3d other, double t) {
+        return lerp(other, t, this);
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3d lerp(Vector3d other, double t, Vector3d dest) {
+        dest.x = x + (other.x - x) * t;
+        dest.y = y + (other.y - y) * t;
+        dest.z = z + (other.z - z) * t;
+        return dest;
+    }
+
+    /**
+     * Get the value of the specified component of this vector.
+     * 
+     * @param component
+     *          the component, within <tt>[0..2]</tt>
+     * @return the value
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..2]</tt>
+     */
+    public double get(int component) throws IllegalArgumentException {
+        switch (component) {
+        case 0:
+            return x;
+        case 1:
+            return y;
+        case 2:
+            return z;
+        default:
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Set the value of the specified component of this vector.
+     * 
+     * @param component
+     *          the component whose value to set, within <tt>[0..2]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..2]</tt>
+     */
+    public Vector3d set(int component, double value) throws IllegalArgumentException {
+        switch (component) {
+        case 0:
+            x = value;
+            break;
+        case 1:
+            y = value;
+            break;
+        case 2:
+            z = value;
+            break;
+        default:
+            throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
+    /**
+     * Determine the component with the biggest absolute value.
+     * 
+     * @return the component index, within <tt>[0..2]</tt>
+     */
+    public double maxComponent() {
+        double absX = Math.abs(x);
+        double absY = Math.abs(y);
+        double absZ = Math.abs(z);
+        boolean xy = absX >= absY;
+        boolean yz = absY >= absZ;
+        if (xy && yz) {
+            return 0;
+        } else if (yz) {
+            return 1;
+        }
+        return 2;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Vector3f.java
+++ b/GVRf/Framework/src/org/joml/Vector3f.java
@@ -1,0 +1,1621 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+
+/**
+ * Contains the definition of a Vector comprising 3 floats and associated
+ * transformations.
+ *
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Vector3f implements Externalizable {
+
+    private static final long serialVersionUID = 1L;    
+
+    /**
+     * The x component of the vector.
+     */
+    public float x;
+    /**
+     * The y component of the vector.
+     */
+    public float y;
+    /**
+     * The z component of the vector.
+     */
+    public float z;
+
+    /**
+     * Create a new {@link Vector3f} of <tt>(0, 0, 0)</tt>.
+     */
+    public Vector3f() {
+    }
+
+    /**
+     * Create a new {@link Vector3f} and initialize all three components with the given value.
+     *
+     * @param d
+     *          the value of all three components
+     */
+    public Vector3f(float d) {
+        this(d, d, d);
+    }
+
+    /**
+     * Create a new {@link Vector4f} with the given component values.
+     * 
+     * @param x
+     *          the value of x
+     * @param y
+     *          the value of y
+     * @param z
+     *          the value of z
+     */
+    public Vector3f(float x, float y, float z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    /**
+     * Create a new {@link Vector3f} with the same values as <code>v</code>.
+     * 
+     * @param v
+     *          the {@link Vector3f} to copy the values from
+     */
+    public Vector3f(Vector3f v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+    }
+
+    /**
+     * Create a new {@link Vector3f} with the first two components from the
+     * given <code>v</code> and the given <code>z</code>
+     * 
+     * @param v
+     *          the {@link Vector2f} to copy the values from
+     * @param z
+     *          the z component
+     */
+    public Vector3f(Vector2f v, float z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+    }
+
+    /**
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #Vector3f(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @see #Vector3f(int, ByteBuffer)
+     */
+    public Vector3f(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     */
+    public Vector3f(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        z = buffer.getFloat(index + 8);
+    }
+
+    /**
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer}
+     * at the current buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the vector is read, use {@link #Vector3f(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @see #Vector3f(int, FloatBuffer)
+     */
+    public Vector3f(FloatBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index  the absolute position into the FloatBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     */
+    public Vector3f(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+    }
+
+    /**
+     * Set the x, y and z components to match the supplied vector.
+     * 
+     * @param v
+     *          contains the values of x, y and z to set
+     * @return this
+     */
+    public Vector3f set(Vector3f v) {
+        x = v.x;
+        y = v.y;
+        z = v.z;
+        return this;
+    }
+
+    /**
+     * Set the x, y and z components to match the supplied vector.
+     * <p>
+     * Note that due to the given vector <code>v</code> storing the components in double-precision,
+     * there is the possibility to lose precision.
+     * 
+     * @param v
+     *          contains the values of x, y and z to set
+     * @return this
+     */
+    public Vector3f set(Vector3d v) {
+        x = (float) v.x;
+        y = (float) v.y;
+        z = (float) v.z;
+        return this;
+    }
+
+    /**
+     * Set the first two components from the given <code>v</code>
+     * and the z component from the given <code>z</code>
+     *
+     * @param v
+     *          the {@link Vector2f} to copy the values from
+     * @param z
+     *          the z component
+     * @return this
+     */
+    public Vector3f set(Vector2f v, float z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        return this;
+    }
+
+    /**
+     * Set the x, y, and z components to the supplied value.
+     *
+     * @param d
+     *          the value of all three components
+     * @return this
+     */
+    public Vector3f set(float d) {
+        return set(d, d, d);
+    }
+
+    /**
+     * Set the x, y and z components to the supplied values.
+     * 
+     * @param x
+     *          the x component
+     * @param y
+     *          the y component 
+     * @param z
+     *          the z component
+     * @return this
+     */
+    public Vector3f set(float x, float y, float z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector3f set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3f set(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        z = buffer.getFloat(index + 8);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the vector is read, use {@link #set(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z</tt> order
+     * @return this
+     * @see #set(int, FloatBuffer)
+     */
+    public Vector3f set(FloatBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index
+     *          the absolute position into the FloatBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3f set(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the vector is stored, use {@link #get(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, FloatBuffer)
+     * 
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return the passed in buffer
+     * @see #get(int, FloatBuffer)
+     */
+    public FloatBuffer get(FloatBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * 
+     * @param index
+     *          the absolute position into the FloatBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(int index, FloatBuffer buffer) {
+        buffer.put(index,    x);
+        buffer.put(index+1,  y);
+        buffer.put(index+2,  z);
+        return buffer;
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @see #get(int, ByteBuffer)
+     * 
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return the passed in buffer
+     * @see #get(int, ByteBuffer)
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * 
+     * @param index
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putFloat(index,    x);
+        buffer.putFloat(index+4,  y);
+        buffer.putFloat(index+8,  z);
+        return buffer;
+    }
+
+    /**
+     * Subtract the supplied vector from this one and store the result in <code>this</code>.
+     * 
+     * @param v
+     *          the vector to subtract
+     * @return this
+     */
+    public Vector3f sub(Vector3f v) {
+        x -= v.x;
+        y -= v.y;
+        z -= v.z;
+        return this;
+    }
+
+    /**
+     * Subtract the supplied vector from this one and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to subtract
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f sub(Vector3f v, Vector3f dest) {
+        dest.x = x - v.x;
+        dest.y = y - v.y;
+        dest.z = z - v.z;
+        return dest;
+    }
+
+    /**
+     * Decrement the components of this vector by the given values.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @return this
+     */
+    public Vector3f sub(float x, float y, float z) {
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        return this;
+    }
+
+    /**
+     * Decrement the components of this vector by the given values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f sub(float x, float y, float z, Vector3f dest) {
+        dest.x = this.x - x;
+        dest.y = this.y - y;
+        dest.z = this.z - z;
+        return dest;
+    }
+
+    /**
+     * Add the supplied vector to this one.
+     * 
+     * @param v
+     *          the vector to add
+     * @return this
+     */
+    public Vector3f add(Vector3f v) {
+        x += v.x;
+        y += v.y;
+        z += v.z;
+        return this;
+    }
+
+    /**
+     * Add the supplied vector to this one and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f add(Vector3f v, Vector3f dest) {
+        dest.x = x + v.x;
+        dest.y = y + v.y;
+        dest.z = z + v.z;
+        return dest;
+    }
+
+    /**
+     * Increment the components of this vector by the given values.
+     * 
+     * @param x
+     *          the x component to add
+     * @param y
+     *          the y component to add
+     * @param z
+     *          the z component to add
+     * @return this
+     */
+    public Vector3f add(float x, float y, float z) {
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        return this;
+    }
+
+    /**
+     * Increment the components of this vector by the given values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to add
+     * @param y
+     *          the y component to add
+     * @param z
+     *          the z component to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f add(float x, float y, float z, Vector3f dest) {
+        dest.x = this.x + x;
+        dest.y = this.y + y;
+        dest.z = this.z + z;
+        return dest;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector3f fma(Vector3f a, Vector3f b) {
+        x += a.x * b.x;
+        y += a.y * b.y;
+        z += a.z * b.z;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector3f fma(float a, Vector3f b) {
+        x += a * b.x;
+        y += a * b.y;
+        z += a * b.z;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f fma(Vector3f a, Vector3f b, Vector3f dest) {
+        dest.x = x + a.x * b.x;
+        dest.y = y + a.y * b.y;
+        dest.z = z + a.z * b.z;
+        return dest;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f fma(float a, Vector3f b, Vector3f dest) {
+        dest.x = x + a * b.x;
+        dest.y = y + a * b.y;
+        dest.z = z + a * b.z;
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector3f component-wise by another Vector3f.
+     * 
+     * @param v
+     *          the vector to multiply by
+     * @return this
+     */
+    public Vector3f mul(Vector3f v) {
+        x *= v.x;
+        y *= v.y;
+        z *= v.z;
+        return this;
+    }
+
+    /**
+     * Multiply this Vector3f component-wise by another Vector3f and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to multiply by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f mul(Vector3f v, Vector3f dest) {
+        dest.x = x * v.x;
+        dest.y = y * v.y;
+        dest.z = z * v.z;
+        return dest;
+    }
+
+    /**
+     * Divide this Vector3f component-wise by another Vector3f.
+     * 
+     * @param v
+     *          the vector to divide by
+     * @return this
+     */
+    public Vector3f div(Vector3f v) {
+        x /= v.x;
+        y /= v.y;
+        z /= v.z;
+        return this;
+    }
+
+    /**
+     * Divide this Vector3f component-wise by another Vector3f and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to divide by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f div(Vector3f v, Vector3f dest) {
+        dest.x = x / v.x;
+        dest.y = y / v.y;
+        dest.z = z / v.z;
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector3f by the given matrix <code>mat</code>, perform perspective division
+     * and store the result in <code>dest</code>.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f mulProject(Matrix4f mat, Vector3f dest) {
+        float invW = 1.0f / (mat.m03 * x + mat.m13 * y + mat.m23 * z + mat.m33);
+        dest.set((mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30) * invW,
+                 (mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31) * invW,
+                 (mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32) * invW);
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector3f by the given matrix <code>mat</code>, perform perspective division.
+     * <p>
+     * This method uses <tt>w=1.0</tt> as the fourth vector component.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3f mulProject(Matrix4f mat) {
+        return mulProject(mat, this);
+    }
+
+    /**
+     * Multiply this Vector3f by the given matrix and store the result in <code>this</code>.
+     * 
+     * @param mat
+     *          the matrix
+     * @return this
+     */
+    public Vector3f mul(Matrix3f mat) {
+        return mul(mat, this);
+    }
+
+    /**
+     * Multiply this Vector3f by the given matrix and store the result in <code>dest</code>.
+     * 
+     * @param mat
+     *          the matrix
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f mul(Matrix3f mat, Vector3f dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z);
+        return dest;
+    }
+
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>1.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3f mulPoint(Matrix4f mat) {
+        return mulPoint(mat, this);
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code> and store the
+     * result in <code>dest</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>1.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f mulPoint(Matrix4f mat, Vector3f dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32);
+        return dest;
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>0.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector3f mulDirection(Matrix4f mat) {
+        return mulDirection(mat, this);
+    }
+
+    /**
+     * Multiply <code>this</code> by the given 4x4 matrix <code>mat</code> and store the
+     * result in <code>dest</code>.
+     * <p>
+     * This method assumes the <tt>w</tt> component of <code>this</code> to be <tt>0.0</tt>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f mulDirection(Matrix4f mat, Vector3f dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z);
+        return dest;
+    }
+
+    /**
+     * Multiply all components of this {@link Vector3f} by the given scalar
+     * value.
+     * 
+     * @param scalar
+     *          the scalar to multiply this vector by
+     * @return this
+     */
+    public Vector3f mul(float scalar) {
+        x *= scalar;
+        y *= scalar;
+        z *= scalar;
+        return this;
+    }
+
+    /**
+     * Multiply all components of this {@link Vector3f} by the given scalar
+     * value and store the result in <code>dest</code>.
+     * 
+     * @param scalar
+     *          the scalar to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f mul(float scalar, Vector3f dest) {
+        dest.x = x * scalar;
+        dest.y = y * scalar;
+        dest.z = z * scalar;
+        return dest;
+    }
+
+    /**
+     * Multiply the components of this Vector3f by the given scalar values and store the result in <code>this</code>.
+     * 
+     * @param x
+     *          the x component to multiply this vector by
+     * @param y
+     *          the y component to multiply this vector by
+     * @param z
+     *          the z component to multiply this vector by
+     * @return this
+     */
+    public Vector3f mul(float x, float y, float z) {
+        this.x *= x;
+        this.y *= y;
+        this.z *= z;
+        return this;
+    }
+
+    /**
+     * Multiply the components of this Vector3f by the given scalar values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to multiply this vector by
+     * @param y
+     *          the y component to multiply this vector by
+     * @param z
+     *          the z component to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f mul(float x, float y, float z, Vector3f dest) {
+        dest.x = this.x * x;
+        dest.y = this.y * y;
+        dest.z = this.z * z;
+        return dest;
+    }
+
+    /**
+     * Divide all components of this {@link Vector3f} by the given scalar
+     * value.
+     * 
+     * @param scalar
+     *          the scalar to divide by
+     * @return this
+     */
+    public Vector3f div(float scalar) {
+        x /= scalar;
+        y /= scalar;
+        z /= scalar;
+        return this;
+    }
+
+    /**
+     * Divide all components of this {@link Vector3f} by the given scalar
+     * value and store the result in <code>dest</code>.
+     * 
+     * @param scalar
+     *          the scalar to divide by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f div(float scalar, Vector3f dest) {
+        dest.x = x / scalar;
+        dest.y = y / scalar;
+        dest.z = z / scalar;
+        return dest;
+    }
+
+    /**
+     * Divide the components of this Vector3f by the given scalar values and store the result in <code>this</code>.
+     * 
+     * @param x
+     *          the x component to divide this vector by
+     * @param y
+     *          the y component to divide this vector by
+     * @param z
+     *          the z component to divide this vector by
+     * @return this
+     */
+    public Vector3f div(float x, float y, float z) {
+        this.x /= x;
+        this.y /= y;
+        this.z /= z;
+        return this;
+    }
+
+    /**
+     * Divide the components of this Vector3f by the given scalar values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to divide this vector by
+     * @param y
+     *          the y component to divide this vector by
+     * @param z
+     *          the z component to divide this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f div(float x, float y, float z, Vector3f dest) {
+        dest.x = this.x / x;
+        dest.y = this.y / y;
+        dest.z = this.z / z;
+        return dest;
+    }
+
+    /**
+     * Rotate this vector by the given quaternion <code>quat</code> and store the result in <code>this</code>.
+     * 
+     * @see Quaternionf#transform(Vector3f)
+     * 
+     * @param quat
+     *          the quaternion to rotate this vector
+     * @return this
+     */
+    public Vector3f rotate(Quaternionf quat) {
+        quat.transform(this, this);
+        return this;
+    }
+
+    /**
+     * Rotate this vector by the given quaternion <code>quat</code> and store the result in <code>dest</code>.
+     * 
+     * @see Quaternionf#transform(Vector3f)
+     * 
+     * @param quat
+     *          the quaternion to rotate this vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f rotate(Quaternionf quat, Vector3f dest) {
+        quat.transform(this, dest);
+        return dest;
+    }
+
+    /**
+     * Return the length squared of this vector.
+     * 
+     * @return the length squared
+     */
+    public float lengthSquared() {
+        return x * x + y * y + z * z;
+    }
+
+    /**
+     * Return the length of this vector.
+     * 
+     * @return the length
+     */
+    public float length() {
+        return (float) Math.sqrt(lengthSquared());
+    }
+
+    /**
+     * Normalize this vector.
+     * 
+     * @return this
+     */
+    public Vector3f normalize() {
+        float invLength = 1.0f / length();
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        return this;
+    }
+
+    /**
+     * Normalize this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f normalize(Vector3f dest) {
+        float invLength = 1.0f / length();
+        dest.x = x * invLength;
+        dest.y = y * invLength;
+        dest.z = z * invLength;
+        return dest;
+    }
+
+    /**
+     * Set this vector to be the cross product of itself and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return this
+     */
+    public Vector3f cross(Vector3f v) {
+        return set(y * v.z - z * v.y,
+                   z * v.x - x * v.z,
+                   x * v.y - y * v.x);
+    }
+
+    /**
+     * Set this vector to be the cross product of itself and <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return this
+     */
+    public Vector3f cross(float x, float y, float z) {
+        return set(this.y * z - this.z * y,
+                   this.z * x - this.x * z,
+                   this.x * y - this.y * x);
+    }
+
+    /**
+     * Compute the cross product of this vector and <code>v</code> and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f cross(Vector3f v, Vector3f dest) {
+        return dest.set(y * v.z - z * v.y,
+                        z * v.x - x * v.z,
+                        x * v.y - y * v.x);
+    }
+
+    /**
+     * Compute the cross product of this vector and <tt>(x, y, z)</tt> and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f cross(float x, float y, float z, Vector3f dest) {
+        return dest.set(this.y * z - this.z * y,
+                        this.z * x - this.x * z,
+                        this.x * y - this.y * x);
+    }
+
+    /**
+     * Return the distance between this Vector and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the distance
+     */
+    public float distance(Vector3f v) {
+        float dx = v.x - x;
+        float dy = v.y - y;
+        float dz = v.z - z;
+        return (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    /**
+     * Return the distance between <code>this</code> vector and <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return the euclidean distance
+     */
+    public float distance(float x, float y, float z) {
+        float dx = this.x - x;
+        float dy = this.y - y;
+        float dz = this.z - z;
+        return (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    /**
+     * Return the square of the distance between this vector and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the squared of the distance
+     */
+    public float distanceSquared(Vector3f v) {
+        float dx = v.x - x;
+        float dy = v.y - y;
+        float dz = v.z - z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    /**
+     * Return the square of the distance between <code>this</code> vector and <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return the square of the distance
+     */
+    public float distanceSquared(float x, float y, float z) {
+        float dx = this.x - x;
+        float dy = this.y - y;
+        float dz = this.z - z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    /**
+     * Return the dot product of this vector and the supplied vector.
+     * 
+     * @param v
+     *          the other vector
+     * @return the dot product
+     */
+    public float dot(Vector3f v) {
+        return x * v.x + y * v.y + z * v.z;
+    }
+
+    /**
+     * Return the dot product of this vector and the vector <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return the dot product
+     */
+    public float dot(float x, float y, float z) {
+        return this.x * x + this.y * y + this.z * z;
+    }
+
+    /**
+     * Return the cosine of the angle between this vector and the supplied vector. Use this instead of Math.cos(this.angle(v)).
+     * 
+     * @see #angle(Vector3f)
+     * 
+     * @param v
+     *          the other vector
+     * @return the cosine of the angle
+     */
+    public float angleCos(Vector3f v) {
+        double length1Sqared = x * x + y * y + z * z;
+        double length2Sqared = v.x * v.x + v.y * v.y + v.z * v.z;
+        double dot = x * v.x + y * v.y + z * v.z;
+        return (float) (dot / (Math.sqrt(length1Sqared * length2Sqared)));
+    }
+
+    /**
+     * Return the angle between this vector and the supplied vector.
+     * 
+     * @see #angleCos(Vector3f)
+     * 
+     * @param v
+     *          the other vector
+     * @return the angle, in radians
+     */
+    public float angle(Vector3f v) {
+        float cos = angleCos(v);
+        // This is because sometimes cos goes above 1 or below -1 because of lost precision
+        cos = Math.min(cos, 1);
+        cos = Math.max(cos, -1);
+        return (float) Math.acos(cos);
+    }
+
+    /**
+     * Set the components of this vector to be the component-wise minimum of this and the other vector.
+     *
+     * @param v
+     *          the other vector
+     * @return this
+     */
+    public Vector3f min(Vector3f v) {
+        this.x = Math.min(x, v.x);
+        this.y = Math.min(y, v.y);
+        this.z = Math.min(z, v.z);
+        return this;
+    }
+
+    /**
+     * Set the components of this vector to be the component-wise maximum of this and the other vector.
+     *
+     * @param v
+     *          the other vector
+     * @return this
+     */
+    public Vector3f max(Vector3f v) {
+        this.x = Math.max(x, v.x);
+        this.y = Math.max(y, v.y);
+        this.z = Math.max(z, v.z);
+        return this;
+    }
+
+    /**
+     * Set all components to zero.
+     * 
+     * @return this
+     */
+    public Vector3f zero() {
+        x = 0.0f;
+        y = 0.0f;
+        z = 0.0f;
+        return this;
+    }
+
+    /**
+     * Return a string representation of this vector.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this vector by formatting the vector components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the vector components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + " " + formatter.format(y) + " " + formatter.format(z) + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeFloat(x);
+        out.writeFloat(y);
+        out.writeFloat(z);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        x = in.readFloat();
+        y = in.readFloat();
+        z = in.readFloat();
+    }
+
+    /**
+     * Negate this vector.
+     * 
+     * @return this
+     */
+    public Vector3f negate() {
+        x = -x;
+        y = -y;
+        z = -z;
+        return this;
+    }
+
+    /**
+     * Negate this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f negate(Vector3f dest) {
+        dest.x = -x;
+        dest.y = -y;
+        dest.z = -z;
+        return dest;
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Float.floatToIntBits(x);
+        result = prime * result + Float.floatToIntBits(y);
+        result = prime * result + Float.floatToIntBits(z);
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Vector3f other = (Vector3f) obj;
+        if (Float.floatToIntBits(x) != Float.floatToIntBits(other.x))
+            return false;
+        if (Float.floatToIntBits(y) != Float.floatToIntBits(other.y))
+            return false;
+        if (Float.floatToIntBits(z) != Float.floatToIntBits(other.z))
+            return false;
+        return true;
+    }
+
+    /**
+     * Reflect this vector about the given <code>normal</code> vector.
+     * 
+     * @param normal
+     *          the vector to reflect about
+     * @return this
+     */
+    public Vector3f reflect(Vector3f normal) {
+        float dot = this.dot(normal);
+        x = x - 2.0f * dot * normal.x;
+        y = y - 2.0f * dot * normal.y;
+        z = z - 2.0f * dot * normal.z;
+        return this;
+    }
+
+    /**
+     * Reflect this vector about the given normal vector.
+     * 
+     * @param x
+     *          the x component of the normal
+     * @param y
+     *          the y component of the normal
+     * @param z
+     *          the z component of the normal
+     * @return this
+     */
+    public Vector3f reflect(float x, float y, float z) {
+        float dot = this.dot(x, y, z);
+        this.x = this.x - 2.0f * dot * x;
+        this.y = this.y - 2.0f * dot * y;
+        this.z = this.z - 2.0f * dot * z;
+        return this;
+    }
+
+    /**
+     * Reflect this vector about the given <code>normal</code> vector and store the result in <code>dest</code>.
+     * 
+     * @param normal
+     *          the vector to reflect about
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f reflect(Vector3f normal, Vector3f dest) {
+        float dot = this.dot(normal);
+        dest.x = x - 2.0f * dot * normal.x;
+        dest.y = y - 2.0f * dot * normal.y;
+        dest.z = z - 2.0f * dot * normal.z;
+        return dest;
+    }
+
+    /**
+     * Reflect this vector about the given normal vector and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component of the normal
+     * @param y
+     *          the y component of the normal
+     * @param z
+     *          the z component of the normal
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f reflect(float x, float y, float z, Vector3f dest) {
+        float dot = this.dot(x, y, z);
+        dest.x = this.x - 2.0f * dot * x;
+        dest.y = this.y - 2.0f * dot * y;
+        dest.z = this.z - 2.0f * dot * z;
+        return dest;
+    }
+
+    /**
+     * Compute the half vector between this and the other vector.
+     * 
+     * @param other
+     *          the other vector
+     * @return this
+     */
+    public Vector3f half(Vector3f other) {
+        return this.add(other).normalize();
+    }
+
+    /**
+     * Compute the half vector between this and the vector <tt>(x, y, z)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @return this
+     */
+    public Vector3f half(float x, float y, float z) {
+        return this.add(x, y, z).normalize();
+    }
+
+    /**
+     * Compute the half vector between this and the other vector and store the result in <code>dest</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f half(Vector3f other, Vector3f dest) {
+        return dest.set(this).add(other).normalize();
+    }
+
+    /**
+     * Compute the half vector between this and the vector <tt>(x, y, z)</tt> 
+     * and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f half(float x, float y, float z, Vector3f dest) {
+        return dest.set(this).add(x, y, z).normalize();
+    }
+
+    /**
+     * Compute a smooth-step (i.e. hermite with zero tangents) interpolation
+     * between <code>this</code> vector and the given vector <code>v</code> and
+     * store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @param t
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f smoothStep(Vector3f v, float t, Vector3f dest) {
+        float t2 = t * t;
+        float t3 = t2 * t;
+        dest.x = (2.0f * x - 2.0f * v.x) * t3 + (3.0f * v.x - 3.0f * x) * t2 + x * t + x;
+        dest.y = (2.0f * y - 2.0f * v.y) * t3 + (3.0f * v.y - 3.0f * y) * t2 + y * t + y;
+        dest.z = (2.0f * z - 2.0f * v.z) * t3 + (3.0f * v.z - 3.0f * z) * t2 + z * t + z;
+        return dest;
+    }
+
+    /**
+     * Compute a hermite interpolation between <code>this</code> vector with its
+     * associated tangent <code>t0</code> and the given vector <code>v</code>
+     * with its tangent <code>t1</code> and store the result in
+     * <code>dest</code>.
+     * 
+     * @param t0
+     *          the tangent of <code>this</code> vector
+     * @param v1
+     *          the other vector
+     * @param t1
+     *          the tangent of the other vector
+     * @param t
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f hermite(Vector3f t0, Vector3f v1, Vector3f t1, float t, Vector3f dest) {
+        float t2 = t * t;
+        float t3 = t2 * t;
+        dest.x = (2.0f * x - 2.0f * v1.x + t1.x + t0.x) * t3 + (3.0f * v1.x - 3.0f * x - 2.0f * t0.x - t1.x) * t2 + x * t + x;
+        dest.y = (2.0f * y - 2.0f * v1.y + t1.y + t0.y) * t3 + (3.0f * v1.y - 3.0f * y - 2.0f * t0.y - t1.y) * t2 + y * t + y;
+        dest.z = (2.0f * z - 2.0f * v1.z + t1.z + t0.z) * t3 + (3.0f * v1.z - 3.0f * z - 2.0f * t0.z - t1.z) * t2 + z * t + z;
+        return dest;
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>this</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @return this
+     */
+    public Vector3f lerp(Vector3f other, float t) {
+        return lerp(other, t, this);
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector3f lerp(Vector3f other, float t, Vector3f dest) {
+        dest.x = x + (other.x - x) * t;
+        dest.y = y + (other.y - y) * t;
+        dest.z = z + (other.z - z) * t;
+        return dest;
+    }
+
+    /**
+     * Get the value of the specified component of this vector.
+     * 
+     * @param component
+     *          the component, within <tt>[0..2]</tt>
+     * @return the value
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..2]</tt>
+     */
+    public float get(int component) throws IllegalArgumentException {
+        switch (component) {
+        case 0:
+            return x;
+        case 1:
+            return y;
+        case 2:
+            return z;
+        default:
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Set the value of the specified component of this vector.
+     * 
+     * @param component
+     *          the component whose value to set, within <tt>[0..2]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..2]</tt>
+     */
+    public Vector3f set(int component, float value) throws IllegalArgumentException {
+        switch (component) {
+        case 0:
+            x = value;
+            break;
+        case 1:
+            y = value;
+            break;
+        case 2:
+            z = value;
+            break;
+        default:
+            throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
+    /**
+     * Determine the component with the biggest absolute value.
+     * 
+     * @return the component index, within <tt>[0..2]</tt>
+     */
+    public float maxComponent() {
+        float absX = Math.abs(x);
+        float absY = Math.abs(y);
+        float absZ = Math.abs(z);
+        boolean xy = absX >= absY;
+        boolean yz = absY >= absZ;
+        if (xy && yz) {
+            return 0;
+        } else if (yz) {
+            return 1;
+        }
+        return 2;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Vector4d.java
+++ b/GVRf/Framework/src/org/joml/Vector4d.java
@@ -1,0 +1,1513 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+
+/**
+ * Contains the definition of a Vector comprising 4 doubles and associated transformations.
+ * 
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Vector4d implements Externalizable {
+
+    private static final long serialVersionUID = 1L;   
+
+    /**
+     * The x component of the vector.
+     */
+    public double x;
+    /**
+     * The y component of the vector.
+     */
+    public double y;
+    /**
+     * The z component of the vector.
+     */
+    public double z;
+    /**
+     * The w component of the vector.
+     */
+    public double w = 1.0;
+
+    /**
+     * Create a new {@link Vector4d} of <code>(0, 0, 0, 1)</code>.
+     */
+    public Vector4d() {
+    }
+
+    /**
+     * Create a new {@link Vector4d} with the same values as <code>v</code>.
+     * 
+     * @param v
+     *          the {@link Vector4d} to copy the values from
+     */
+    public Vector4d(Vector4d v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = v.w;
+    }
+
+    /**
+     * Create a new {@link Vector4d} with the first three components from the
+     * given <code>v</code> and the given <code>w</code>.
+     * 
+     * @param v
+     *          the {@link Vector3d}
+     * @param w
+     *          the w component
+     */
+    public Vector4d(Vector3d v, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Vector4d} with the first two components from the
+     * given <code>v</code> and the given <code>z</code> and <code>w</code>.
+     *
+     * @param v
+     *          the {@link Vector2d}
+     * @param z
+     *          the z component
+     * @param w
+     *          the w component
+     */
+    public Vector4d(Vector2d v, double z, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Vector4d} with the same values as <code>v</code>.
+     * 
+     * @param v
+     *          the {@link Vector4f} to copy the values from
+     */
+    public Vector4d(Vector4f v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = v.w;
+    }
+
+    /**
+     * Create a new {@link Vector4d} with the x, y, and z components from the
+     * given <code>v</code> and the w component from the given <code>w</code>.
+     * 
+     * @param v
+     *          the {@link Vector3f}
+     * @param w
+     *          the w component
+     */
+    public Vector4d(Vector3f v, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Vector4d} with the x and y components from the
+     * given <code>v</code> and the z and w components from the given <code>z</code> and <code>w</code>.
+     *
+     * @param v
+     *          the {@link Vector2f}
+     * @param z
+     *          the z component
+     * @param w
+     *          the w component
+     */
+    public Vector4d(Vector2f v, double z, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Vector4d} and initialize all four components with the given value.
+     *
+     * @param d
+     *          the value of all four components
+     */
+    public Vector4d(double d) {
+        this(d, d, d, d);
+    }
+
+    /**
+     * Create a new {@link Vector4f} with the given component values.
+     * 
+     * @param x    
+     *          the x component
+     * @param y
+     *          the y component
+     * @param z
+     *          the z component
+     * @param w
+     *          the w component
+     */
+    public Vector4d(double x, double y, double z, double w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #Vector4d(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @see #Vector4d(int, ByteBuffer)
+     */
+    public Vector4d(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     */
+    public Vector4d(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        z = buffer.getDouble(index + 16);
+        w = buffer.getDouble(index + 24);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer}
+     * at the current buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the vector is read, use {@link #Vector4d(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @see #Vector4d(int, DoubleBuffer)
+     */
+    public Vector4d(DoubleBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     */
+    public Vector4d(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        w = buffer.get(index + 3);
+    }
+
+    /**
+     * Set this {@link Vector4d} to the values of the given <code>v</code>.
+     * 
+     * @param v
+     *          the vector whose values will be copied into this
+     * @return this
+     */
+    public Vector4d set(Vector4d v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = v.w;
+        return this;
+    }
+
+    /**
+     * Set this {@link Vector4d} to the values of the given <code>v</code>.
+     * 
+     * @param v
+     *          the vector whose values will be copied into this
+     * @return this
+     */
+    public Vector4d set(Vector4f v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = v.w;
+        return this;
+    }
+
+    /**
+     * Set the x, y, and z components of this to the components of
+     * <code>v</code> and the w component to <code>w</code>.
+     * 
+     * @param v
+     *          the {@link Vector3d} to copy
+     * @param w
+     *          the w component
+     * @return this
+     */
+    public Vector4d set(Vector3d v, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Set the x, y, and z components of this to the components of
+     * <code>v</code> and the w component to <code>w</code>.
+     * 
+     * @param v
+     *          the {@link Vector3f} to copy
+     * @param w
+     *          the w component
+     * @return this
+     */
+    public Vector4d set(Vector3f v, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Set the x and y components from the given <code>v</code>
+     * and the z and w components to the given <code>z</code> and <code>w</code>.
+     *
+     * @param v
+     *          the {@link Vector2d}
+     * @param z
+     *          the z component
+     * @param w
+     *          the w component
+     * @return this
+     */
+    public Vector4d set(Vector2d v, double z, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        this.w = w;
+        return this;
+    }
+    
+    /**
+     * Set the x and y components from the given <code>v</code>
+     * and the z and w components to the given <code>z</code> and <code>w</code>.
+     *
+     * @param v
+     *          the {@link Vector2f}
+     * @param z
+     *          the z components
+     * @param w
+     *          the w components
+     * @return this
+     */
+    public Vector4d set(Vector2f v, double z, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Set the x, y, z, and w components to the supplied value.
+     *
+     * @param d
+     *          the value of all four components
+     * @return this
+     */
+    public Vector4d set(double d) {
+        return set(d, d, d, d);
+    }
+
+    /**
+     * Set the x, y, z, and w components to the supplied values.
+     * 
+     * @param x
+     *          the x component
+     * @param y
+     *          the y component
+     * @param z
+     *          the z component
+     * @param w
+     *          the w component
+     * @return this
+     */
+    public Vector4d set(double x, double y, double z, double w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector4d set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4d set(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        z = buffer.getDouble(index + 16);
+        w = buffer.getDouble(index + 24);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the vector is read, use {@link #set(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #set(int, DoubleBuffer)
+     */
+    public Vector4d set(DoubleBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index
+     *          the absolute position into the DoubleBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4d set(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        w = buffer.get(index + 3);
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return the passed in buffer
+     * @see #get(int, ByteBuffer)
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index 
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putDouble(index,      x);
+        buffer.putDouble(index + 8,  y);
+        buffer.putDouble(index + 16,  z);
+        buffer.putDouble(index + 24,  w);
+        return buffer;
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p>
+     * In order to specify the offset into the DoubleBuffer at which
+     * the vector is stored, use {@link #get(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return the passed in buffer
+     * @see #get(int, DoubleBuffer)
+     */
+    public DoubleBuffer get(DoubleBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index
+     *          the absolute position into the DoubleBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return the passed in buffer
+     */
+    public DoubleBuffer get(int index, DoubleBuffer buffer) {
+        buffer.put(index,      x);
+        buffer.put(index + 1,  y);
+        buffer.put(index + 2,  z);
+        buffer.put(index + 3,  w);
+        return buffer;
+    }
+
+    /**
+     * Subtract the supplied vector from this one.
+     * 
+     * @param v
+     *          the vector to subtract
+     * @return this
+     */
+    public Vector4d sub(Vector4d v) {
+        x -= v.x;
+        y -= v.y;
+        z -= v.z;
+        w -= v.w;
+        return this;
+    }
+
+    /**
+     * Subtract the supplied vector from this one.
+     * 
+     * @param v
+     *          the vector to subtract
+     * @return this
+     */
+    public Vector4d sub(Vector4f v) {
+        x -= v.x;
+        y -= v.y;
+        z -= v.z;
+        w -= v.w;
+        return this;
+    }
+
+    /**
+     * Subtract <tt>(x, y, z, w)</tt> from this.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @param w
+     *          the w component to subtract
+     * @return this
+     */
+    public Vector4d sub(double x, double y, double z, double w) {
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        this.w -= w;
+        return this;
+    }
+
+    /**
+     * Subtract <tt>(x, y, z, w)</tt> from this and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @param w
+     *          the w component to subtract
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d sub(double x, double y, double z, double w, Vector4d dest) {
+        dest.x = this.x - x;
+        dest.y = this.y - y;
+        dest.z = this.z - z;
+        dest.w = this.w - w;
+        return dest;
+    }
+
+    /**
+     * Subtract <code>v2</code> from <code>v1</code> and store the result in <code>dest</code>.
+     * 
+     * @param v1
+     *          the left operand
+     * @param v2
+     *          the right operand
+     * @param dest
+     *          will hold the result
+     */
+    public static void sub(Vector4d v1, Vector4d v2, Vector4d dest) {
+        dest.x = v1.x - v2.x;
+        dest.y = v1.y - v2.y;
+        dest.z = v1.z - v2.z;
+        dest.w = v1.w - v2.w;
+    }
+
+    /**
+     * Subtract <code>v2</code> from <code>v1</code> and store the result in <code>dest</code>.
+     * 
+     * @param v1
+     *          the left operand
+     * @param v2
+     *          the right operand
+     * @param dest
+     *          will hold the result
+     */
+    public static void sub(Vector4d v1, Vector4f v2, Vector4d dest) {
+        dest.x = v1.x - v2.x;
+        dest.y = v1.y - v2.y;
+        dest.z = v1.z - v2.z;
+        dest.w = v1.w - v2.w;
+    }
+
+    /**
+     * Subtract <code>v2</code> from <code>v1</code> and store the result in <code>dest</code>.
+     * 
+     * @param v1
+     *          the left operand
+     * @param v2
+     *          the right operand
+     * @param dest
+     *          will hold the result
+     */
+    public static void sub(Vector4f v1, Vector4d v2, Vector4d dest) {
+        dest.x = v1.x - v2.x;
+        dest.y = v1.y - v2.y;
+        dest.z = v1.z - v2.z;
+        dest.w = v1.w - v2.w;
+    }
+
+    /**
+     * Add the supplied vector to this one.
+     * 
+     * @param v
+     *          the vector to add
+     * @return this
+     */
+    public Vector4d add(Vector4d v) {
+        x += v.x;
+        y += v.y;
+        z += v.z;
+        w += v.w;
+        return this;
+    }
+
+    /**
+     * Add <tt>(x, y, z, w)</tt> to this.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @param w
+     *          the w component to subtract
+     * @return this
+     */
+    public Vector4d add(double x, double y, double z, double w) {
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        this.w += w;
+        return this;
+    }
+
+    /**
+     * Add <tt>(x, y, z, w)</tt> to this and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @param w
+     *          the w component to subtract
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d add(double x, double y, double z, double w, Vector4d dest) {
+        dest.x = this.x - x;
+        dest.y = this.y - y;
+        dest.z = this.z - z;
+        dest.w = this.w - w;
+        return dest;
+    }
+
+    /**
+     * Add the supplied vector to this one.
+     * 
+     * @param v
+     *          the vector to add
+     * @return this
+     */
+    public Vector4d add(Vector4f v) {
+        x += v.x;
+        y += v.y;
+        z += v.z;
+        w += v.w;
+        return this;
+    }
+
+    /**
+     * Add <code>v2</code> to <code>v1</code> and store the result in <code>dest</code>.
+     * 
+     * @param v1
+     *          the first addend
+     * @param v2
+     *          the second addend
+     * @param dest
+     *          will hold the result
+     */
+    public static void add(Vector4d v1, Vector4d v2, Vector4d dest) {
+        dest.x = v1.x + v2.x;
+        dest.y = v1.y + v2.y;
+        dest.z = v1.z + v2.z;
+        dest.w = v1.w + v2.w;
+    }
+
+    /**
+     * Add <code>v2</code> to <code>v1</code> and store the result in <code>dest</code>.
+     * 
+     * @param v1
+     *          the first addend
+     * @param v2
+     *          the second addend
+     * @param dest
+     *          will hold the result
+     */
+    public static void add(Vector4d v1, Vector4f v2, Vector4d dest) {
+        dest.x = v1.x + v2.x;
+        dest.y = v1.y + v2.y;
+        dest.z = v1.z + v2.z;
+        dest.w = v1.w + v2.w;
+    }
+
+    /**
+     * Add <code>v2</code> to <code>v1</code> and store the result in <code>dest</code>.
+     * 
+     * @param v1
+     *          the first addend
+     * @param v2
+     *          the second addend
+     * @param dest
+     *          will hold the result
+     */
+    public static void add(Vector4f v1, Vector4d v2, Vector4d dest) {
+        dest.x = v1.x + v2.x;
+        dest.y = v1.y + v2.y;
+        dest.z = v1.z + v2.z;
+        dest.w = v1.w + v2.w;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector4d fma(Vector4d a, Vector4d b) {
+        x += a.x * b.x;
+        y += a.y * b.y;
+        z += a.z * b.z;
+        w += a.w * b.w;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector4d fma(double a, Vector4d b) {
+        x += a * b.x;
+        y += a * b.y;
+        z += a * b.z;
+        w += a * b.w;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d fma(Vector4d a, Vector4d b, Vector4d dest) {
+        dest.x = x + a.x * b.x;
+        dest.y = y + a.y * b.y;
+        dest.z = z + a.z * b.z;
+        dest.w = w + a.w * b.w;
+        return dest;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d fma(double a, Vector4d b, Vector4d dest) {
+        dest.x = x + a * b.x;
+        dest.y = y + a * b.y;
+        dest.z = z + a * b.z;
+        dest.w = w + a * b.w;
+        return dest;
+    }
+
+    /**
+     * Multiply this {@link Vector4d} component-wise by the given {@link Vector4d}.
+     * 
+     * @param v
+     *          the vector to multiply by
+     * @return this
+     */
+    public Vector4d mul(Vector4d v) {
+        x *= v.x;
+        y *= v.y;
+        z *= v.z;
+        z *= v.w;
+        return this;
+    }
+
+    /**
+     * Multiply this {@link Vector4d} component-wise by the given {@link Vector4d} and store the result in <code>dest</code>.
+     * 
+     * @param v
+     * 			the vector to multiply this by
+     * @param dest
+     * 			will hold the result
+     * @return dest
+     */
+    public Vector4d mul(Vector4d v, Vector4d dest) {
+        dest.x = x * v.x;
+        dest.y = y * v.y;
+        dest.z = z * v.z;
+        dest.w = w * v.w;
+        return dest;
+    }
+
+    /**
+     * Divide this {@link Vector4d} component-wise by the given {@link Vector4d}.
+     * 
+     * @param v
+     *          the vector to divide by
+     * @return this
+     */
+    public Vector4d div(Vector4d v) {
+        x /= v.x;
+        y /= v.y;
+        z /= v.z;
+        z /= v.w;
+        return this;
+    }
+
+    /**
+     * Divide this {@link Vector4d} component-wise by the given {@link Vector4d} and store the result in <code>dest</code>.
+     * 
+     * @param v
+     * 			the vector to divide this by
+     * @param dest
+     * 			will hold the result
+     * @return dest
+     */
+    public Vector4d div(Vector4d v, Vector4d dest) {
+        dest.x = x / v.x;
+        dest.y = y / v.y;
+        dest.z = z / v.z;
+        dest.w = w / v.w;
+        return dest;
+    }
+
+    /**
+     * Multiply this {@link Vector4d} component-wise by the given {@link Vector4f}.
+     * 
+     * @param v
+     *          the vector to multiply by
+     * @return this
+     */
+    public Vector4d mul(Vector4f v) {
+        x *= v.x;
+        y *= v.y;
+        z *= v.z;
+        z *= v.w;
+        return this;
+    }
+
+    /**
+     * Multiply this {@link Vector4d} by the given matrix <code>mat</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply by
+     * @return this
+     */
+    public Vector4d mul(Matrix4d mat) {
+        return mul(mat, this);
+    }
+
+    /**
+     * Multiply this {@link Vector4d} by the given matrix mat and store the result in <code>dest</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply <code>this</code> by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d mul(Matrix4d mat, Vector4d dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30 * w,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31 * w,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32 * w, 
+                 mat.m03 * x + mat.m13 * y + mat.m23 * z + mat.m33 * w);
+        return dest;
+    }
+
+    /**
+     * Multiply this {@link Vector4d} by the given matrix <code>mat</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply by
+     * @return this
+     */
+    public Vector4d mul(Matrix4f mat) {
+        return mul(mat, this);
+    }
+
+    /**
+     * Multiply this Vector4d by the given matrix mat and store the result in <code>dest</code>.
+     *
+     * @param mat
+     *          the matrix to multiply <code>this</code> by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d mul(Matrix4f mat, Vector4d dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30 * w,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31 * w,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32 * w, 
+                 mat.m03 * x + mat.m13 * y + mat.m23 * z + mat.m33 * w);
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector4d by the given matrix <code>mat</code>, perform perspective division
+     * and store the result in <code>dest</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d mulProject(Matrix4d mat, Vector4d dest) {
+        double invW = 1.0 / (mat.m03 * x + mat.m13 * y + mat.m23 * z + mat.m33 * w);
+        dest.set((mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30 * w) * invW,
+                 (mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31 * w) * invW,
+                 (mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32 * w) * invW,
+                 1.0);
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector4d by the given matrix <code>mat</code>, perform perspective division.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector4d mulProject(Matrix4d mat) {
+        return mulProject(mat, this);
+    }
+
+    /**
+     * Multiply this Vector4d by the given scalar value.
+     * 
+     * @param scalar
+     *          the scalar to multiply by
+     * @return this
+     */
+    public Vector4d mul(double scalar) {
+        x *= scalar;
+        y *= scalar;
+        z *= scalar;
+        w *= scalar;
+        return this;
+    }
+
+    /**
+     * Multiply this Vector4d by the given scalar value and store the result in <code>dest</code>.
+     * 
+     * @param scalar
+     *          the factor to multiply by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d mul(double scalar, Vector4d dest) {
+        dest.x = x * scalar;
+        dest.y = y * scalar;
+        dest.z = z * scalar;
+        dest.w = w * scalar;
+        return dest;
+    }
+
+    /**
+     * Divide this Vector4d by the given scalar value.
+     * 
+     * @param scalar
+     *          the scalar to divide by
+     * @return this
+     */
+    public Vector4d div(double scalar) {
+        x /= scalar;
+        y /= scalar;
+        z /= scalar;
+        w /= scalar;
+        return this;
+    }
+
+    /**
+     * Divide this Vector4d by the given scalar value and store the result in <code>dest</code>.
+     * 
+     * @param scalar
+     *          the factor to divide by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d div(double scalar, Vector4d dest) {
+        dest.x = x / scalar;
+        dest.y = y / scalar;
+        dest.z = z / scalar;
+        dest.w = w / scalar;
+        return dest;
+    }
+
+    /**
+     * Transform this vector by the given quaternion <code>quat</code> and store the result in <code>this</code>.
+     * 
+     * @see Quaterniond#transform(Vector4d)
+     * 
+     * @param quat
+     *          the quaternion to transform this vector
+     * @return this
+     */
+    public Vector4d rotate(Quaterniond quat) {
+        return rotate(quat, this);
+    }
+
+    /**
+     * Transform this vector by the given quaternion <code>quat</code> and store the result in <code>dest</code>.
+     * 
+     * @see Quaterniond#transform(Vector4d)
+     * 
+     * @param quat
+     *          the quaternion to transform this vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d rotate(Quaterniond quat, Vector4d dest) {
+        quat.transform(this, dest);
+        return dest;
+    }
+
+    /**
+     * Return the length squared of this vector.
+     * 
+     * @return the length squared
+     */
+    public double lengthSquared() {
+        return x * x + y * y + z * z + w * w;
+    }
+
+    /**
+     * Return the length of this vector.
+     * 
+     * @return the length
+     */
+    public double length() {
+        return Math.sqrt(lengthSquared());
+    }
+
+    /**
+     * Normalizes this vector.
+     * 
+     * @return this
+     */
+    public Vector4d normalize() {
+        double invLength = 1.0 / length();
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        w *= invLength;
+        return this;
+    }
+
+    /**
+     * Normalizes this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d normalize(Vector4d dest) {
+        double invLength = 1.0 / length();
+        dest.x = x * invLength;
+        dest.y = y * invLength;
+        dest.z = z * invLength;
+        dest.w = w * invLength;
+        return dest;
+    }
+
+    /**
+     * Normalize this vector by computing only the norm of <tt>(x, y, z)</tt>.
+     * 
+     * @return this
+     */
+    public Vector4d normalize3() {
+        double invLength = 1.0 / Math.sqrt(x * x + y * y + z * z);
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        w *= invLength;
+        return this;
+    }
+
+    /**
+     * Normalize this vector by computing only the norm of <tt>(x, y, z)</tt> and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d normalize3(Vector4d dest) {
+        double invLength = 1.0 / Math.sqrt(x * x + y * y + z * z);
+        dest.x = x * invLength;
+        dest.y = y * invLength;
+        dest.z = z * invLength;
+        dest.w = w * invLength;
+        return dest;
+    }
+
+    /**
+     * Return the distance between <code>this</code> vector and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the euclidean distance
+     */
+    public double distance(Vector4d v) {
+        double dx = v.x - x;
+        double dy = v.y - y;
+        double dz = v.z - z;
+        double dw = v.w - w;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz + dw * dw);
+    }
+
+    /**
+     * Return the distance between <code>this</code> vector and <tt>(x, y, z, w)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @param w
+     *          the w component of the other vector
+     * @return the euclidean distance
+     */
+    public double distance(double x, double y, double z, double w) {
+        double dx = this.x - x;
+        double dy = this.y - y;
+        double dz = this.z - z;
+        double dw = this.w - w;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz + dw * dw);
+    }
+
+    /**
+     * Compute the dot product (inner product) of this vector and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the dot product
+     */
+    public double dot(Vector4d v) {
+        return x * v.x + y * v.y + z * v.z + w * v.w;
+    }
+
+    /**
+     * Compute the dot product (inner product) of this vector and <tt>(x, y, z, w)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @param w
+     *          the w component of the other vector
+     * @return the dot product
+     */
+    public double dot(double x, double y, double z, double w) {
+        return this.x * x + this.y * y + this.z * z + this.w * w;
+    }
+
+    /**
+     * Return the cosine of the angle between this vector and the supplied vector.
+     * <p>
+     * Use this instead of <code>Math.cos(angle(v))</code>.
+     * 
+     * @see #angle(Vector4d)
+     * 
+     * @param v
+     *          the other vector
+     * @return the cosine of the angle
+     */
+    public double angleCos(Vector4d v) {
+        double length1Sqared = x * x + y * y + z * z + w * w;
+        double length2Sqared = v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w;
+        double dot = x * v.x + y * v.y + z * v.z + w * v.w;
+        return dot / (Math.sqrt(length1Sqared * length2Sqared));
+    }
+
+    /**
+     * Return the angle between this vector and the supplied vector.
+     * 
+     * @see #angleCos(Vector4d)
+     * 
+     * @param v
+     *          the other vector
+     * @return the angle, in radians
+     */
+    public double angle(Vector4d v) {
+        double cos = angleCos(v);
+        // This is because sometimes cos goes above 1 or below -1 because of lost precision
+        cos = Math.min(cos, 1);
+        cos = Math.max(cos, -1);
+        return Math.acos(cos);
+    }
+
+    /**
+     * Set all components to zero.
+     * 
+     * @return this
+     */
+    public Vector4d zero() {
+        x = 0.0;
+        y = 0.0;
+        z = 0.0;
+        w = 0.0;
+        return this;
+    }
+
+    /**
+     * Negate this vector.
+     * 
+     * @return this
+     */
+    public Vector4d negate() {
+        x = -x;
+        y = -y;
+        z = -z;
+        w = -w;
+        return this;
+    }
+
+    /**
+     * Negate this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d negate(Vector4d dest) {
+        dest.x = -x;
+        dest.y = -y;
+        dest.z = -z;
+        dest.w = -w;
+        return dest;
+    }
+
+    /**
+     * Return a string representation of this vector.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this vector by formatting the vector components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the vector components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + " " + formatter.format(y) + " " + formatter.format(z) + " " + formatter.format(w) + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeDouble(x);
+        out.writeDouble(y);
+        out.writeDouble(z);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException,
+            ClassNotFoundException {
+        x = in.readDouble();
+        y = in.readDouble();
+        z = in.readDouble();
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(w);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(x);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(y);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(z);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Vector4d other = (Vector4d) obj;
+        if (Double.doubleToLongBits(w) != Double.doubleToLongBits(other.w))
+            return false;
+        if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+            return false;
+        if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
+            return false;
+        if (Double.doubleToLongBits(z) != Double.doubleToLongBits(other.z))
+            return false;
+        return true;
+    }
+
+    /**
+     * Compute a smooth-step (i.e. hermite with zero tangents) interpolation
+     * between <code>this</code> vector and the given vector <code>v</code> and
+     * store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @param t
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d smoothStep(Vector4d v, double t, Vector4d dest) {
+        double t2 = t * t;
+        double t3 = t2 * t;
+        dest.x = (2.0 * x - 2.0 * v.x) * t3 + (3.0 * v.x - 3.0 * x) * t2 + x * t + x;
+        dest.y = (2.0 * y - 2.0 * v.y) * t3 + (3.0 * v.y - 3.0 * y) * t2 + y * t + y;
+        dest.z = (2.0 * z - 2.0 * v.z) * t3 + (3.0 * v.z - 3.0 * z) * t2 + z * t + z;
+        dest.w = (2.0 * w - 2.0 * v.w) * t3 + (3.0 * v.w - 3.0 * w) * t2 + w * t + w;
+        return dest;
+    }
+
+    /**
+     * Compute a hermite interpolation between <code>this</code> vector and its
+     * associated tangent <code>t0</code> and the given vector <code>v</code>
+     * with its tangent <code>t1</code> and store the result in
+     * <code>dest</code>.
+     * 
+     * @param t0
+     *          the tangent of <code>this</code> vector
+     * @param v1
+     *          the other vector
+     * @param t1
+     *          the tangent of the other vector
+     * @param t
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d hermite(Vector4d t0, Vector4d v1, Vector4d t1, double t, Vector4d dest) {
+        double t2 = t * t;
+        double t3 = t2 * t;
+        dest.x = (2.0 * x - 2.0 * v1.x + t1.x + t0.x) * t3 + (3.0 * v1.x - 3.0 * x - 2.0 * t0.x - t1.x) * t2 + x * t + x;
+        dest.y = (2.0 * y - 2.0 * v1.y + t1.y + t0.y) * t3 + (3.0 * v1.y - 3.0 * y - 2.0 * t0.y - t1.y) * t2 + y * t + y;
+        dest.z = (2.0 * z - 2.0 * v1.z + t1.z + t0.z) * t3 + (3.0 * v1.z - 3.0 * z - 2.0 * t0.z - t1.z) * t2 + z * t + z;
+        dest.w = (2.0 * w - 2.0 * v1.w + t1.w + t0.w) * t3 + (3.0 * v1.w - 3.0 * w - 2.0 * t0.w - t1.w) * t2 + w * t + w;
+        return dest;
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>this</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @return this
+     */
+    public Vector4d lerp(Vector4d other, double t) {
+        return lerp(other, t, this);
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4d lerp(Vector4d other, double t, Vector4d dest) {
+        dest.x = x + (other.x - x) * t;
+        dest.y = y + (other.y - y) * t;
+        dest.z = z + (other.z - z) * t;
+        dest.w = w + (other.w - w) * t;
+        return dest;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/Vector4f.java
+++ b/GVRf/Framework/src/org/joml/Vector4f.java
@@ -1,0 +1,1399 @@
+/*
+ * (C) Copyright 2015 Richard Greenlees
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+package org.joml;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Contains the definition of a Vector comprising 4 floats and associated
+ * transformations.
+ * 
+ * @author Richard Greenlees
+ * @author Kai Burjack
+ */
+public class Vector4f implements Externalizable {
+
+    private static final long serialVersionUID = 1L;   
+
+    /**
+     * The x component of the vector.
+     */
+    public float x;
+    /**
+     * The y component of the vector.
+     */
+    public float y;
+    /**
+     * The z component of the vector.
+     */
+    public float z;
+    /**
+     * The w component of the vector.
+     */
+    public float w = 1.0f;
+
+    /**
+     * Create a new {@link Vector4f} of <code>(0, 0, 0, 1)</code>.
+     */
+    public Vector4f() {
+    }
+
+    /**
+     * Create a new {@link Vector4f} with the same values as <code>v</code>.
+     * 
+     * @param v
+     *          the {@link Vector4f} to copy the values from
+     */
+    public Vector4f(Vector4f v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = v.w;
+    }
+
+    /**
+     * Create a new {@link Vector4f} with the first three components from the
+     * given <code>v</code> and the given <code>w</code>.
+     * 
+     * @param v
+     *          the {@link Vector3f}
+     * @param w
+     *          the w component
+     */
+    public Vector4f(Vector3f v, float w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Vector4f} with the first two components from the
+     * given <code>v</code> and the given <code>z</code>, and <code>w</code>.
+     * 
+     * @param v
+     *          the {@link Vector2f}
+     * @param z
+     *          the z component
+     * @param w
+     *          the w component
+     */
+    public Vector4f(Vector2f v, float z, float w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Vector4f} and initialize all four components with the given value.
+     *
+     * @param d
+     *          the value of all four components
+     */
+    public Vector4f(float d) {
+        this(d, d, d, d);
+    }
+    
+    /**
+     * Create a new {@link Vector4f} with the given component values.
+     * 
+     * @param x
+     *          the x component
+     * @param y
+     *          the y component
+     * @param z
+     *          the z component
+     * @param w
+     *          the w component
+     */
+    public Vector4f(float x, float y, float z, float w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #Vector4f(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @see #Vector4f(int, ByteBuffer)
+     */
+    public Vector4f(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index 
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     */
+    public Vector4f(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        z = buffer.getFloat(index + 8);
+        w = buffer.getFloat(index + 12);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer}
+     * at the current buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the vector is read, use {@link #Vector4f(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @see #Vector4f(int, FloatBuffer)
+     */
+    public Vector4f(FloatBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index 
+     *          the absolute position into the FloatBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     */
+    public Vector4f(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        w = buffer.get(index + 3);
+    }
+
+    /**
+     * Set this {@link Vector4f} to the values of the given <code>v</code>.
+     * 
+     * @param v
+     *          the vector whose values will be copied into this
+     * @return this
+     */
+    public Vector4f set(Vector4f v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = v.w;
+        return this;
+    }
+
+    /**
+     * Set this {@link Vector4f} to the values of the given <code>v</code>.
+     * <p>
+     * Note that due to the given vector <code>v</code> storing the components in double-precision,
+     * there is the possibility to lose precision.
+     * 
+     * @param v
+     *          the vector whose values will be copied into this
+     * @return this
+     */
+    public Vector4f set(Vector4d v) {
+        this.x = (float) v.x;
+        this.y = (float) v.y;
+        this.z = (float) v.z;
+        this.w = (float) v.w;
+        return this;
+    }
+
+    /**
+     * Set the first three components of this to the components of
+     * <code>v</code> and the last component to <code>w</code>.
+     * 
+     * @param v
+     *          the {@link Vector3f} to copy
+     * @param w
+     *          the w component
+     * @return this
+     */
+    public Vector4f set(Vector3f v, float w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Sets the first two components of this to the components of given <code>v</code>
+     * and last two components to the given <code>z</code>, and <code>w</code>.
+     *
+     * @param v
+     *          the {@link Vector2f}
+     * @param z
+     *          the z component
+     * @param w
+     *          the w component
+     * @return this
+     */
+    public Vector4f set(Vector2f v, float z, float w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Set the x, y, z, and w components to the supplied value.
+     *
+     * @param d
+     *          the value of all four components
+     * @return this
+     */
+    public Vector4f set(float d) {
+        return set(d, d, d, d);
+    }
+
+    /**
+     * Set the x, y, z, and w components to the supplied values.
+     * 
+     * @param x
+     *          the x component
+     * @param y
+     *          the y component
+     * @param z
+     *          the z component
+     * @param w
+     *          the w component
+     * @return this
+     */
+    public Vector4f set(float x, float y, float z, float w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is read, use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector4f set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4f set(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        z = buffer.getFloat(index + 8);
+        w = buffer.getFloat(index + 12);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the vector is read, use {@link #set(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #set(int, FloatBuffer)
+     */
+    public Vector4f set(FloatBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index 
+     *          the absolute position into the FloatBuffer
+     * @param buffer
+     *          values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4f set(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        w = buffer.get(index + 3);
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p>
+     * In order to specify the offset into the FloatBuffer at which
+     * the vector is stored, use {@link #get(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return the passed in buffer
+     * @see #get(int, FloatBuffer)
+     */
+    public FloatBuffer get(FloatBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given FloatBuffer.
+     * 
+     * @param index
+     *          the absolute position into the FloatBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return the passed in buffer
+     */
+    public FloatBuffer get(int index, FloatBuffer buffer) {
+        buffer.put(index,    x);
+        buffer.put(index+1,  y);
+        buffer.put(index+2,  z);
+        buffer.put(index+3,  w);
+        return buffer;
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p>
+     * In order to specify the offset into the ByteBuffer at which
+     * the vector is stored, use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     * 
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return the passed in buffer
+     * @see #get(int, ByteBuffer)
+     */
+    public ByteBuffer get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p>
+     * This method will not increment the position of the given ByteBuffer.
+     * 
+     * @param index
+     *          the absolute position into the ByteBuffer
+     * @param buffer
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return the passed in buffer
+     */
+    public ByteBuffer get(int index, ByteBuffer buffer) {
+        buffer.putFloat(index,    x);
+        buffer.putFloat(index+4,  y);
+        buffer.putFloat(index+8,  z);
+        buffer.putFloat(index+12, w);
+        return buffer;
+    }
+
+    /**
+     * Subtract the supplied vector from this one.
+     * 
+     * @param v
+     *          the vector to subtract
+     * @return this
+     */
+    public Vector4f sub(Vector4f v) {
+        x -= v.x;
+        y -= v.y;
+        z -= v.z;
+        w -= v.w;
+        return this;
+    }
+
+    /**
+     * Subtract <tt>(x, y, z, w)</tt> from this.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @param w
+     *          the w component to subtract
+     * @return this
+     */
+    public Vector4f sub(float x, float y, float z, float w) {
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        this.w -= w;
+        return this;
+    }
+
+    /**
+     * Subtract the supplied vector from this one and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to subtract from <code>this</code>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f sub(Vector4f v, Vector4f dest) {
+        dest.x = x - v.x;
+        dest.y = y - v.y;
+        dest.z = z - v.z;
+        dest.w = w - v.w;
+        return dest;
+    }
+
+    /**
+     * Subtract <tt>(x, y, z, w)</tt> from this and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to subtract
+     * @param y
+     *          the y component to subtract
+     * @param z
+     *          the z component to subtract
+     * @param w
+     *          the w component to subtract
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f sub(float x, float y, float z, float w, Vector4f dest) {
+        dest.x = this.x - x;
+        dest.y = this.y - y;
+        dest.z = this.z - z;
+        dest.w = this.w - w;
+        return dest;
+    }
+
+    /**
+     * Add the supplied vector to this one.
+     * 
+     * @param v
+     *          the vector to add
+     * @return this
+     */
+    public Vector4f add(Vector4f v) {
+        x += v.x;
+        y += v.y;
+        z += v.z;
+        w += v.w;
+        return this;
+    }
+
+    /**
+     * Add the supplied vector to this one and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f add(Vector4f v, Vector4f dest) {
+        dest.x = x + v.x;
+        dest.y = y + v.y;
+        dest.z = z + v.z;
+        dest.w = w + v.w;
+        return dest;
+    }
+
+    /**
+     * Increment the components of this vector by the given values.
+     * 
+     * @param x
+     *          the x component to add
+     * @param y
+     *          the y component to add
+     * @param z
+     *          the z component to add
+     * @param w
+     *          the w component to add
+     * @return this
+     */
+    public Vector4f add(float x, float y, float z, float w) {
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        this.w += w;
+        return this;
+    }
+
+    /**
+     * Increment the components of this vector by the given values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to add
+     * @param y
+     *          the y component to add
+     * @param z
+     *          the z component to add
+     * @param w
+     *          the w component to add
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f add(float x, float y, float z, float w, Vector4f dest) {
+        dest.x = this.x + x;
+        dest.y = this.y + y;
+        dest.z = this.z + z;
+        dest.w = this.w + w;
+        return dest;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector4f fma(Vector4f a, Vector4f b) {
+        x += a.x * b.x;
+        y += a.y * b.y;
+        z += a.z * b.z;
+        w += a.w * b.w;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @return this
+     */
+    public Vector4f fma(float a, Vector4f b) {
+        x += a * b.x;
+        y += a * b.y;
+        z += a * b.z;
+        w += a * b.w;
+        return this;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f fma(Vector4f a, Vector4f b, Vector4f dest) {
+        dest.x = x + a.x * b.x;
+        dest.y = y + a.y * b.y;
+        dest.z = z + a.z * b.z;
+        dest.w = w + a.w * b.w;
+        return dest;
+    }
+
+    /**
+     * Add the component-wise multiplication of <code>a * b</code> to this vector
+     * and store the result in <code>dest</code>.
+     * 
+     * @param a
+     *          the first multiplicand
+     * @param b
+     *          the second multiplicand
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f fma(float a, Vector4f b, Vector4f dest) {
+        dest.x = x + a * b.x;
+        dest.y = y + a * b.y;
+        dest.z = z + a * b.z;
+        dest.w = w + a * b.w;
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector4f component-wise by another Vector4f.
+     * 
+     * @param v
+     *          the other vector
+     * @return this
+     */
+    public Vector4f mul(Vector4f v) {
+        x *= v.x;
+        y *= v.y;
+        z *= v.z;
+        w *= v.w;
+        return this;
+    }
+
+    /**
+     * Multiply this Vector4f component-wise by another Vector4f and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f mul(Vector4f v, Vector4f dest) {
+        dest.x = x * v.x;
+        dest.y = y * v.y;
+        dest.z = z * v.z;
+        dest.w = w * v.w;
+        return dest;
+    }
+
+    /**
+     * Divide this Vector4f component-wise by another Vector4f.
+     * 
+     * @param v
+     *          the vector to divide by
+     * @return this
+     */
+    public Vector4f div(Vector4f v) {
+        x /= v.x;
+        y /= v.y;
+        z /= v.z;
+        w /= v.w;
+        return this;
+    }
+
+    /**
+     * Divide this Vector4f component-wise by another Vector4f and store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the vector to divide by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f div(Vector4f v, Vector4f dest) {
+        dest.x = x / v.x;
+        dest.y = y / v.y;
+        dest.z = z / v.z;
+        dest.w = w / v.w;
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector4f by the given matrix mat and store the result in
+     * <code>this</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply the vector with
+     * @return this
+     */
+    public Vector4f mul(Matrix4f mat) {
+        return mul(mat, this);
+    }
+
+    /**
+     * Multiply this Vector4f by the given matrix mat and store the result in
+     * <code>dest</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply the vector with
+     * @param dest
+     *          the destination vector to hold the result
+     * @return dest
+     */
+    public Vector4f mul(Matrix4f mat, Vector4f dest) {
+        dest.set(mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30 * w,
+                 mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31 * w,
+                 mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32 * w,
+                 mat.m03 * x + mat.m13 * y + mat.m23 * z + mat.m33 * w);
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector4f by the given matrix <code>mat</code>, perform perspective division
+     * and store the result in <code>dest</code>.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f mulProject(Matrix4f mat, Vector4f dest) {
+        float invW = 1.0f / (mat.m03 * x + mat.m13 * y + mat.m23 * z + mat.m33 * w);
+        dest.set((mat.m00 * x + mat.m10 * y + mat.m20 * z + mat.m30 * w) * invW,
+                 (mat.m01 * x + mat.m11 * y + mat.m21 * z + mat.m31 * w) * invW,
+                 (mat.m02 * x + mat.m12 * y + mat.m22 * z + mat.m32 * w) * invW,
+                 1.0f);
+        return dest;
+    }
+
+    /**
+     * Multiply this Vector3f by the given matrix <code>mat</code>, perform perspective division.
+     * 
+     * @param mat
+     *          the matrix to multiply this vector by
+     * @return this
+     */
+    public Vector4f mulProject(Matrix4f mat) {
+        return mulProject(mat, this);
+    }
+
+    /**
+     * Multiply all components of this {@link Vector4f} by the given scalar
+     * value.
+     * 
+     * @param scalar
+     *          the scalar to multiply by
+     * @return this
+     */
+    public Vector4f mul(float scalar) {
+        x *= scalar;
+        y *= scalar;
+        z *= scalar;
+        w *= scalar;
+        return this;
+    }
+
+    /**
+     * Multiply all components of this {@link Vector4f} by the given scalar
+     * value and store the result in <code>dest</code>.
+     * 
+     * @param scalar
+     *          the scalar to multiply by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f mul(float scalar, Vector4f dest) {
+        dest.x = x * scalar;
+        dest.y = y * scalar;
+        dest.z = z * scalar;
+        dest.w = w * scalar;
+        return dest;
+    }
+
+    /**
+     * Multiply the components of this Vector4f by the given scalar values and store the result in <code>this</code>.
+     * 
+     * @param x
+     *          the x component to multiply by
+     * @param y
+     *          the y component to multiply by
+     * @param z
+     *          the z component to multiply by
+     * @param w
+     *          the w component to multiply by
+     * @return this
+     */
+    public Vector4f mul(float x, float y, float z, float w) {
+        this.x *= x;
+        this.y *= y;
+        this.z *= z;
+        this.w *= w;
+        return this;
+    }
+
+    /**
+     * Multiply the components of this Vector4f by the given scalar values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to multiply by
+     * @param y
+     *          the y component to multiply by
+     * @param z
+     *          the z component to multiply by
+     * @param w
+     *          the w component to multiply by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f mul(float x, float y, float z, float w, Vector4f dest) {
+        dest.x = this.x * x;
+        dest.y = this.y * y;
+        dest.z = this.z * z;
+        dest.w = this.w * w;
+        return dest;
+    }
+
+    /**
+     * Divide all components of this {@link Vector4f} by the given scalar
+     * value.
+     * 
+     * @param scalar
+     *          the scalar to divide by
+     * @return this
+     */
+    public Vector4f div(float scalar) {
+        x /= scalar;
+        y /= scalar;
+        z /= scalar;
+        w /= scalar;
+        return this;
+    }
+
+    /**
+     * Divide all components of this {@link Vector4f} by the given scalar
+     * value and store the result in <code>dest</code>.
+     * 
+     * @param scalar
+     *          the scalar to divide by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f div(float scalar, Vector4f dest) {
+        dest.x = x / scalar;
+        dest.y = y / scalar;
+        dest.z = z / scalar;
+        dest.w = w / scalar;
+        return dest;
+    }
+
+    /**
+     * Divide the components of this Vector4f by the given scalar values and store the result in <code>this</code>.
+     * 
+     * @param x
+     *          the x component to divide by
+     * @param y
+     *          the y component to divide by
+     * @param z
+     *          the z component to divide by
+     * @param w
+     *          the w component to divide by
+     * @return this
+     */
+    public Vector4f div(float x, float y, float z, float w) {
+        this.x /= x;
+        this.y /= y;
+        this.z /= z;
+        this.w /= w;
+        return this;
+    }
+
+    /**
+     * Divide the components of this Vector4f by the given scalar values and store the result in <code>dest</code>.
+     * 
+     * @param x
+     *          the x component to divide by
+     * @param y
+     *          the y component to divide by
+     * @param z
+     *          the z component to divide by
+     * @param w
+     *          the w component to divide by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f div(float x, float y, float z, float w, Vector4f dest) {
+        dest.x = this.x / x;
+        dest.y = this.y / y;
+        dest.z = this.z / z;
+        dest.w = this.w / w;
+        return dest;
+    }
+
+    /**
+     * Rotate this vector by the given quaternion <code>quat</code> and store the result in <code>this</code>.
+     * 
+     * @see Quaternionf#transform(Vector4f)
+     * 
+     * @param quat
+     *          the quaternion to rotate this vector
+     * @return this
+     */
+    public Vector4f rotate(Quaternionf quat) {
+        return rotate(quat, this);
+    }
+
+    /**
+     * Rotate this vector by the given quaternion <code>quat</code> and store the result in <code>dest</code>.
+     * 
+     * @see Quaternionf#transform(Vector4f)
+     * 
+     * @param quat
+     *          the quaternion to rotate this vector
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f rotate(Quaternionf quat, Vector4f dest) {
+        return quat.transform(this, dest);
+    }
+
+    /**
+     * Return the length squared of this vector.
+     * 
+     * @return the length squared
+     */
+    public float lengthSquared() {
+        return x * x + y * y + z * z + w * w;
+    }
+
+    /**
+     * Return the length of this vector.
+     * 
+     * @return the length
+     */
+    public float length() {
+        return (float) Math.sqrt(lengthSquared());
+    }
+
+    /**
+     * Normalizes this vector.
+     * 
+     * @return this
+     */
+    public Vector4f normalize() {
+        float invLength = 1.0f / length();
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        w *= invLength;
+        return this;
+    }
+
+    /**
+     * Normalizes this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f normalize(Vector4f dest) {
+        float invLength = 1.0f / length();
+        dest.x = x * invLength;
+        dest.y = y * invLength;
+        dest.z = z * invLength;
+        dest.w = w * invLength;
+        return dest;
+    }
+
+    /**
+     * Normalize this vector by computing only the norm of <tt>(x, y, z)</tt>.
+     * 
+     * @return this
+     */
+    public Vector4f normalize3() {
+        float invLength = (float) (1.0 / Math.sqrt(x * x + y * y + z * z));
+        x *= invLength;
+        y *= invLength;
+        z *= invLength;
+        w *= invLength;
+        return this;
+    }
+
+    /**
+     * Return the distance between <code>this</code> vector and <code>v</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @return the euclidean distance
+     */
+    public float distance(Vector4f v) {
+        float dx = v.x - x;
+        float dy = v.y - y;
+        float dz = v.z - z;
+        float dw = v.w - w;
+        return (float) Math.sqrt(dx * dx + dy * dy + dz * dz + dw * dw);
+    }
+
+    /**
+     * Return the distance between <code>this</code> vector and <tt>(x, y, z, w)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @param w
+     *          the w component of the other vector
+     * @return the euclidean distance
+     */
+    public float distance(float x, float y, float z, float w) {
+        float dx = this.x - x;
+        float dy = this.y - y;
+        float dz = this.z - z;
+        float dw = this.w - w;
+        return (float) Math.sqrt(dx * dx + dy * dy + dz * dz + dw * dw);
+    }
+
+    /**
+     * Compute the dot product (inner product) of this vector and <code>v</code>
+     * .
+     * 
+     * @param v
+     *          the other vector
+     * @return the dot product
+     */
+    public float dot(Vector4f v) {
+        return x * v.x + y * v.y + z * v.z + w * v.w;
+    }
+
+    /**
+     * Compute the dot product (inner product) of this vector and <tt>(x, y, z, w)</tt>.
+     * 
+     * @param x
+     *          the x component of the other vector
+     * @param y
+     *          the y component of the other vector
+     * @param z
+     *          the z component of the other vector
+     * @param w
+     *          the w component of the other vector
+     * @return the dot product
+     */
+    public float dot(float x, float y, float z, float w) {
+        return this.x * x + this.y * y + this.z * z + this.w * w;
+    }
+
+    /**
+     * Return the cosine of the angle between this vector and the supplied vector. Use this instead of <code>Math.cos(angle(v))</code>.
+     * 
+     * @see #angle(Vector4f)
+     * 
+     * @param v
+     *          the other vector
+     * @return the cosine of the angle
+     */
+    public float angleCos(Vector4f v) {
+        double length1Sqared = x * x + y * y + z * z + w * w;
+        double length2Sqared = v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w;
+        double dot = x * v.x + y * v.y + z * v.z + w * v.w;
+        return (float) (dot / (Math.sqrt(length1Sqared * length2Sqared)));
+    }
+
+    /**
+     * Return the angle between this vector and the supplied vector.
+     * 
+     * @see #angleCos(Vector4f)
+     * 
+     * @param v
+     *          the other vector
+     * @return the angle, in radians
+     */
+    public float angle(Vector4f v) {
+        float cos = angleCos(v);
+        // This is because sometimes cos goes above 1 or below -1 because of lost precision
+        cos = Math.min(cos, 1);
+        cos = Math.max(cos, -1);
+        return (float) Math.acos(cos);
+    }
+
+    /**
+     * Set all components to zero.
+     * 
+     * @return this
+     */
+    public Vector4f zero() {
+        x = 0.0f;
+        y = 0.0f;
+        z = 0.0f;
+        w = 0.0f;
+        return this;
+    }
+
+    /**
+     * Negate this vector.
+     * 
+     * @return this
+     */
+    public Vector4f negate() {
+        x = -x;
+        y = -y;
+        z = -z;
+        w = -w;
+        return this;
+    }
+
+    /**
+     * Negate this vector and store the result in <code>dest</code>.
+     * 
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f negate(Vector4f dest) {
+        dest.x = -x;
+        dest.y = -y;
+        dest.z = -z;
+        dest.w = -w;
+        return dest;
+    }
+
+    /**
+     * Return a string representation of this vector.
+     * <p>
+     * This method creates a new {@link DecimalFormat} on every invocation with the format string "<tt> 0.000E0;-</tt>".
+     * 
+     * @return the string representation
+     */
+    public String toString() {
+        DecimalFormat formatter = new DecimalFormat(" 0.000E0;-"); //$NON-NLS-1$
+        return toString(formatter).replaceAll("E(\\d+)", "E+$1"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Return a string representation of this vector by formatting the vector components with the given {@link NumberFormat}.
+     * 
+     * @param formatter
+     *          the {@link NumberFormat} used to format the vector components with
+     * @return the string representation
+     */
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + " " + formatter.format(y) + " " + formatter.format(z) + " " + formatter.format(w) + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeFloat(x);
+        out.writeFloat(y);
+        out.writeFloat(z);
+        out.writeFloat(w);
+    }
+
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        x = in.readFloat();
+        y = in.readFloat();
+        z = in.readFloat();
+        w = in.readFloat();
+    }
+
+    /**
+     * Set the components of this vector to be the component-wise minimum of
+     * this and the other vector.
+     *
+     * @param v
+     *          the other vector
+     * @return this
+     */
+    public Vector4f min(Vector4f v) {
+        this.x = Math.min(x, v.x);
+        this.y = Math.min(y, v.y);
+        this.z = Math.min(z, v.z);
+        this.w = Math.min(w, v.w);
+        return this;
+    }
+
+    /**
+     * Set the components of this vector to be the component-wise maximum of
+     * this and the other vector.
+     *
+     * @param v
+     *          the other vector
+     * @return this
+     */
+    public Vector4f max(Vector4f v) {
+        this.x = Math.max(x, v.x);
+        this.y = Math.max(y, v.y);
+        this.z = Math.max(z, v.z);
+        this.w = Math.min(w, v.w);
+        return this;
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Float.floatToIntBits(w);
+        result = prime * result + Float.floatToIntBits(x);
+        result = prime * result + Float.floatToIntBits(y);
+        result = prime * result + Float.floatToIntBits(z);
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Vector4f other = (Vector4f) obj;
+        if (Float.floatToIntBits(w) != Float.floatToIntBits(other.w))
+            return false;
+        if (Float.floatToIntBits(x) != Float.floatToIntBits(other.x))
+            return false;
+        if (Float.floatToIntBits(y) != Float.floatToIntBits(other.y))
+            return false;
+        if (Float.floatToIntBits(z) != Float.floatToIntBits(other.z))
+            return false;
+        return true;
+    }
+
+    /**
+     * Compute a smooth-step (i.e. hermite with zero tangents) interpolation
+     * between <code>this</code> vector and the given vector <code>v</code> and
+     * store the result in <code>dest</code>.
+     * 
+     * @param v
+     *          the other vector
+     * @param t
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f smoothStep(Vector4f v, float t, Vector4f dest) {
+        float t2 = t * t;
+        float t3 = t2 * t;
+        dest.x = (2.0f * x - 2.0f * v.x) * t3 + (3.0f * v.x - 3.0f * x) * t2 + x * t + x;
+        dest.y = (2.0f * y - 2.0f * v.y) * t3 + (3.0f * v.y - 3.0f * y) * t2 + y * t + y;
+        dest.z = (2.0f * z - 2.0f * v.z) * t3 + (3.0f * v.z - 3.0f * z) * t2 + z * t + z;
+        dest.w = (2.0f * w - 2.0f * v.w) * t3 + (3.0f * v.w - 3.0f * w) * t2 + w * t + w;
+        return dest;
+    }
+
+    /**
+     * Compute a hermite interpolation between <code>this</code> vector and its
+     * associated tangent <code>t0</code> and the given vector <code>v</code>
+     * with its tangent <code>t1</code> and store the result in
+     * <code>dest</code>.
+     * 
+     * @param t0
+     *          the tangent of <code>this</code> vector
+     * @param v1
+     *          the other vector
+     * @param t1
+     *          the tangent of the other vector
+     * @param t
+     *          the interpolation factor, within <tt>[0..1]</tt>
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f hermite(Vector4f t0, Vector4f v1, Vector4f t1, float t, Vector4f dest) {
+        float t2 = t * t;
+        float t3 = t2 * t;
+        dest.x = (2.0f * x - 2.0f * v1.x + t1.x + t0.x) * t3 + (3.0f * v1.x - 3.0f * x - 2.0f * t0.x - t1.x) * t2 + x * t + x;
+        dest.y = (2.0f * y - 2.0f * v1.y + t1.y + t0.y) * t3 + (3.0f * v1.y - 3.0f * y - 2.0f * t0.y - t1.y) * t2 + y * t + y;
+        dest.z = (2.0f * z - 2.0f * v1.z + t1.z + t0.z) * t3 + (3.0f * v1.z - 3.0f * z - 2.0f * t0.z - t1.z) * t2 + z * t + z;
+        dest.w = (2.0f * w - 2.0f * v1.w + t1.w + t0.w) * t3 + (3.0f * v1.w - 3.0f * w - 2.0f * t0.w - t1.w) * t2 + w * t + w;
+        return dest;
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>this</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @return this
+     */
+    public Vector4f lerp(Vector4f other, float t) {
+        return lerp(other, t, this);
+    }
+
+    /**
+     * Linearly interpolate <code>this</code> and <code>other</code> using the given interpolation factor <code>t</code>
+     * and store the result in <code>dest</code>.
+     * <p>
+     * If <code>t</code> is <tt>0.0</tt> then the result is <code>this</code>. If the interpolation factor is <code>1.0</code>
+     * then the result is <code>other</code>.
+     * 
+     * @param other
+     *          the other vector
+     * @param t
+     *          the interpolation factor between 0.0 and 1.0
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Vector4f lerp(Vector4f other, float t, Vector4f dest) {
+        dest.x = x + (other.x - x) * t;
+        dest.y = y + (other.y - y) * t;
+        dest.z = z + (other.z - z) * t;
+        dest.w = w + (other.w - w) * t;
+        return dest;
+    }
+
+}

--- a/GVRf/Framework/src/org/joml/package.html
+++ b/GVRf/Framework/src/org/joml/package.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+<head>
+</head>
+<body bgcolor="white">
+<p>Contains all classes of JOML.</p>
+<p>If you like to know more about JOML, please visit:</p>
+<ul>
+<li><a href="https://github.com/JOML-CI/JOML">Its GitHub project page</a></li>
+<li><a href="http://joml-ci.github.io/JOML">Its site on GitHub Pages</a></li>
+<li><a href="http://joml-ci.github.io/JOML/apidocs/index.html">The HTML version of this JavaDoc</a></li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
SIDIA contribution for mesh animation
- Mesh animation support in native code
- Mesh animation sample

GVRf skinning infrastrcture
- Add GVRBone and GVRBoneWeight and correpsonding native impl.
- Add GVRSkinningController to construct bone tree from a rigged model
  and control bone transforms during skeletal animation
- Modified assimp shader to animate mesh
- Add pretty print for GVRSceneObject for debugging scene graphs
- Add getLocalModelMatrix to GVRTransform to get local transform
- Modify Jassimp wrapper provider to construct Quaternionf
- Add infrastructure for keyframe animation
  - Add Scale/Pos/Rotation keys
  - Add animation channels
  - Add interpolators to interpolate vectors and quaternions
  - Generate overall transform based on scale/pos/rotation keys
  - Fully integrated with GVRAnimationEngine
- Modified gvrjassimpmodelloader to demo skinning