### PR TITLE
Add GVRTextView class

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRTextViewSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRTextViewSceneObject.java
@@ -38,6 +38,7 @@ import android.webkit.WebView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+@Deprecated
 public class GVRTextViewSceneObject extends GVRSceneObject {
     private static final int HIGH_REFRESH_INTERVAL = 10; // frames
     private static final int MEDIUM_REFRESH_INTERVAL = 20;

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/view/GVRTextView.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/view/GVRTextView.java
@@ -1,0 +1,46 @@
+package org.gearvrf.scene_objects.view;
+
+import org.gearvrf.GVRActivity;
+import org.gearvrf.scene_objects.GVRViewSceneObject;
+
+import android.graphics.Canvas;
+import android.view.View;
+import android.widget.TextView;
+
+/**
+ * This class represents a {@link TextView} that is rendered
+ * into the attached {@link GVRViewSceneObject}
+ * See {@link GVRView} and {@link GVRViewSceneObject}
+ */
+public class GVRTextView extends TextView implements GVRView {
+    private GVRViewSceneObject mSceneObject = null;
+    
+    public GVRTextView(GVRActivity context) {
+        super(context);
+
+        context.registerView(this);
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        if (mSceneObject == null)
+            return;
+
+        // Canvas attached to GVRViewSceneObject to draw on
+        Canvas attachedCanvas = mSceneObject.lockCanvas();
+        // draw the view to provided canvas
+        super.draw(attachedCanvas);
+
+        mSceneObject.unlockCanvasAndPost(attachedCanvas);
+    }
+
+    @Override
+    public void setSceneObject(GVRViewSceneObject sceneObject) {
+        mSceneObject = sceneObject;
+    }
+
+    @Override
+    public View getView() {
+        return this;
+    }
+}


### PR DESCRIPTION
My first try to replace GVRTextViewSceneObject by GVRTextView.
This patch fixes #246(missing way to access all TextView's methods) and the issues related to refresh interval of GVRTextViewSceneObject

To test it, please refer to https://github.com/ragner/GearVRf/tree/renderable