### PR TITLE
Fix occasional KSensor crash on docking/undocking

### DIFF
--- a/GVRf/Framework/jni/sensor/ksensor/k_sensor.cpp
+++ b/GVRf/Framework/jni/sensor/ksensor/k_sensor.cpp
@@ -95,7 +95,10 @@ KSensor::KSensor() :
 }
 
 KSensor::~KSensor() {
-    stop();
+    try {
+        stop();
+    } catch (const std::exception&) {
+    }
 }
 
 void KSensor::start() {

--- a/GVRf/Framework/jni/sensor/ksensor/k_sensor.cpp
+++ b/GVRf/Framework/jni/sensor/ksensor/k_sensor.cpp
@@ -95,6 +95,7 @@ KSensor::KSensor() :
 }
 
 KSensor::~KSensor() {
+    stop();
 }
 
 void KSensor::start() {


### PR DESCRIPTION
std::thread's dtor terminates if the thread is joinable
thus ensuring it is not

plus some precautions on the java side

Change-Id: Ia7821688ad7bacabb198827fc47d8a6f8bb5fe59

Conflicts:
	GVRf/Framework/src/org/gearvrf/GVRActivity.java