### PR TITLE
Added getView() API to GVRViewSceneObject

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRViewSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRViewSceneObject.java
@@ -39,6 +39,7 @@ public class GVRViewSceneObject extends GVRSceneObject implements
 
     private final Surface mSurface;
     private final SurfaceTexture mSurfaceTexture;
+    private final GVRView mView;
 
     /**
      * Shows any view into the {@linkplain GVRViewSceneObject scene object} with an arbitrarily complex
@@ -70,6 +71,11 @@ public class GVRViewSceneObject extends GVRSceneObject implements
         gvrView.setSceneObject(this);
 
         gvrView.getView().postInvalidate();
+        mView = gvrView;
+    }
+
+    public GVRView getView() {
+        return mView;
     }
 
     /**


### PR DESCRIPTION
If your code entails this sort of pattern:

    MyClass() {
        super(new GVRViewSceneObject(...));
    }

there's no opportunity for MyClass to get access to the GVRView that
must be passed into GVRViewSceneObject's constructor.  Added
getView() to remedy that.