### PR TITLE
Add Layout container to GVRTextView

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/scene_objects/view/GVRTextView.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/view/GVRTextView.java
@@ -4,6 +4,8 @@ import org.gearvrf.GVRActivity;
 import org.gearvrf.scene_objects.GVRViewSceneObject;
 
 import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.PorterDuff.Mode;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
@@ -55,6 +57,9 @@ public class GVRTextView extends TextView implements GVRView {
 
         // Canvas attached to GVRViewSceneObject to draw on
         Canvas attachedCanvas = mSceneObject.lockCanvas();
+        // Clear the canvas to avoid overlapping text when
+        // TextView's background is transparent.
+        attachedCanvas.drawColor(Color.TRANSPARENT, Mode.CLEAR);
         // draw the view to provided canvas
         super.draw(attachedCanvas);
 

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/view/GVRTextView.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/view/GVRTextView.java
@@ -5,20 +5,47 @@ import org.gearvrf.scene_objects.GVRViewSceneObject;
 
 import android.graphics.Canvas;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 /**
  * This class represents a {@link TextView} that is rendered
- * into the attached {@link GVRViewSceneObject}
+ * into the attached {@link GVRViewSceneObject}.
+ * Internally this view is added to a {@link LinearLayout}.
  * See {@link GVRView} and {@link GVRViewSceneObject}
  */
 public class GVRTextView extends TextView implements GVRView {
     private GVRViewSceneObject mSceneObject = null;
-    
+    private ViewGroup mTextViewContainer;
+
     public GVRTextView(GVRActivity context) {
         super(context);
 
-        context.registerView(this);
+        mTextViewContainer = new LinearLayout(context);
+        mTextViewContainer.addView(this);
+
+        mTextViewContainer.setLayoutParams(new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+
+        context.registerView(mTextViewContainer);
+    }
+
+    /**
+     * Creates a new instance and sets its internal {@linkplain LinearLayout Layout container}
+     * with the specified width and height.
+     *
+     * @param viewWidth
+     *            Width of the {@linkplain LinearLayout Layout container}
+     * @param viewHeight
+     *            Height of the {@linkplain LinearLayout Layout container}
+     */
+    public GVRTextView(GVRActivity context, int viewWidth, int viewHeight) {
+        this(context);
+
+        setLayoutParams(new LinearLayout.LayoutParams(viewWidth, viewHeight));
+        mTextViewContainer.measure(viewWidth, viewHeight);
+        mTextViewContainer.layout(0, 0, viewWidth, viewHeight);
     }
 
     @Override


### PR DESCRIPTION
At my implementation to newest GVRTextView I did a mistake removing the LinearLayout that is implemented at GVRTextViewSceneObject.

We are getting some issues because of that. It is really necessary to define  the layout(position and dimensions) of the TextView in its mesh.

GearVRf-DCO-1.0-Signed-off-by: Ragner Magalhaes <ragner.n@samsung.com>