### PR TITLE
Add GVRFrameLayout

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRActivity.java
@@ -380,6 +380,10 @@ public class GVRActivity extends VrActivity {
      * @param view Is a {@link GVRView} that draw itself into some {@link GVRViewSceneObject}.
      */
     public void registerView(View view) {
+        /* The full screen should be updated
+           otherwise just the children's bounds may be refreshed. */
+        mRenderableViewGroup.setClipChildren(false);
+
         mRenderableViewGroup.addView(view);
     }
 

--- a/GVRf/Framework/src/org/gearvrf/scene_objects/view/GVRFrameLayout.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/view/GVRFrameLayout.java
@@ -1,0 +1,56 @@
+package org.gearvrf.scene_objects.view;
+
+import org.gearvrf.GVRActivity;
+import org.gearvrf.scene_objects.GVRViewSceneObject;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.view.View;
+import android.widget.FrameLayout;
+
+/**
+ * This class represents a {@link FrameLayout} that is rendered
+ * into the attached {@link GVRViewSceneObject}.
+ * Every {@link View Android view} added to this layout will be rendered
+ * into attached {@link GVRViewSceneObject}.
+ * See {@link GVRView} and {@link GVRViewSceneObject}
+ */
+public class GVRFrameLayout extends FrameLayout implements GVRView {
+    private GVRViewSceneObject mSceneObject = null;
+
+    public GVRFrameLayout(GVRActivity  context) {
+        super(context);
+
+        /* Setting background color to avoid complex logic,
+         * otherwise android will call just drawChild
+         * for each child. Setting some background color
+         * it calls draw(Canvas) keeping our default logic.
+         */
+        setBackgroundColor(Color.TRANSPARENT);
+
+        context.registerView(this);
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        if (mSceneObject == null)
+            return;
+
+        // Canvas attached to GVRViewSceneObject to draw on
+        Canvas attachedCanvas = mSceneObject.lockCanvas();
+        // draw the view to provided canvas
+        super.draw(attachedCanvas);
+
+        mSceneObject.unlockCanvasAndPost(attachedCanvas);
+    }
+
+    @Override
+    public void setSceneObject(GVRViewSceneObject sceneObject) {
+        mSceneObject = sceneObject;
+    }
+
+    @Override
+    public View getView() {
+        return this;
+    }
+}


### PR DESCRIPTION
GVRFrameLayout is GVRView that extends Android FrameLayout.
It allows you to render all of its child view into attached GVRViewSceneObject.

To render a Android XML layout into attached GVRViewSceneObject
you just need inflate it into GVRFrameLayout instance calling inflate like this:

View.inflate(this, R.layout.activity_main, GVRFrameLayout instance);

GearVRf-DCO-1.0-Signed-off-by: Ragner Magalhaes <ragner.n@samsung.com>