### PR TITLE
Optimization for Hiearchical View Frustum Culling

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/jni/engine/renderer/renderer.h
@@ -97,11 +97,12 @@ private:
             PostEffectShaderManager* post_effect_shader_manager);
 
     static void occlusion_cull(Scene* scene,
-            std::vector<SceneObject*> scene_objects,
+            std::vector<SceneObject*>& scene_objects,
             ShaderManager *shader_manager, glm::mat4 vp_matrix);
     static void build_frustum(float frustum[6][4], const float *vp_matrix);
     static void frustum_cull(Camera *camera, SceneObject *object,
-            float frustum[6][4]);
+            float frustum[6][4], std::vector<SceneObject*>& scene_objects,
+            bool continue_cull, int planeMask);
 
     static void set_face_culling(int cull_face);
 

--- a/GVRf/Framework/jni/objects/bounding_volume.cpp
+++ b/GVRf/Framework/jni/objects/bounding_volume.cpp
@@ -134,13 +134,13 @@ void BoundingVolume::transform(const BoundingVolume &in_volume,
 
     glm::vec4 min_corner(in_volume.min_corner(), 1.0f);
     glm::vec4 max_corner(in_volume.max_corner(), 1.0f);
-    glm::vec4 transformed_minCorner = matrix * min_corner;
-    glm::vec4 transformed_maxCorner = matrix * max_corner;
+    glm::vec4 transformed_min_corner = matrix * min_corner;
+    glm::vec4 transformed_max_corner = matrix * max_corner;
 
-    glm::vec3 transformed_min(transformed_minCorner.x, transformed_minCorner.y,
-            transformed_minCorner.z);
-    glm::vec3 transformed_max(transformed_maxCorner.x, transformed_maxCorner.y,
-            transformed_maxCorner.z);
+    glm::vec3 transformed_min(transformed_min_corner.x, transformed_min_corner.y,
+            transformed_min_corner.z);
+    glm::vec3 transformed_max(transformed_max_corner.x, transformed_max_corner.y,
+            transformed_max_corner.z);
 
     // expand with the new corners
     expand(transformed_min);

--- a/GVRf/Framework/jni/objects/scene_object.h
+++ b/GVRf/Framework/jni/objects/scene_object.h
@@ -150,17 +150,7 @@ public:
     void dirtyHierarchicalBoundingVolume();
     BoundingVolume& getBoundingVolume();
 
-    int frustumCull(Camera *camera, const float frustum[6][4]);
-    bool sphereInFrustum(float frustum[6][4], BoundingVolume &sphere);
-
-private:
-    SceneObject(const SceneObject& scene_object);
-    SceneObject(SceneObject&& scene_object);
-    SceneObject& operator=(const SceneObject& scene_object);
-    SceneObject& operator=(SceneObject&& scene_object);
-
-    bool is_cube_in_frustum(const float frustum[6][4],
-            BoundingVolume &bounding_volume);
+    int frustumCull(Camera *camera, const float frustum[6][4], int& planeMask);
 
 private:
     std::string name_;
@@ -187,6 +177,20 @@ private:
     bool in_frustum_;
     bool query_currently_issued_;
     GLuint *queries_ = nullptr;
+
+    SceneObject(const SceneObject& scene_object);
+    SceneObject(SceneObject&& scene_object);
+    SceneObject& operator=(const SceneObject& scene_object);
+    SceneObject& operator=(SceneObject&& scene_object);
+
+    bool checkSphereVsFrustum(float frustum[6][4], BoundingVolume &sphere);
+
+    int checkAABBVsFrustumOpt(const float frustum[6][4],
+            BoundingVolume &bounding_volume, int& planeMask);
+
+    bool checkAABBVsFrustumBasic(const float frustum[6][4],
+            BoundingVolume &bounding_volume);
+
 };
 
 }


### PR DESCRIPTION
1. Augment the frustum testing function, to be able to tell if the given object's AABB
is completely inside the frustum that can eliminate further tests for all its children;
2. Add plane masking when doing frustum testing to skip testing against masked planes for all
the children when the parent's AABB is completely inside those planes.