### PR TITLE
Fix texture loading issue when texture contains path like File::///

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRResourceVolume.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRResourceVolume.java
@@ -57,6 +57,13 @@ public class GVRResourceVolume {
      * @throws IOException
      */
     public GVRAndroidResource openResource(String filePath) throws IOException {
+        // Error tolerance: Remove initial '/' introduced by file::///filename
+        // In this case, the path is interpreted as relative to defaultPath, which
+        // is the root of the filesystem.
+        if (filePath.startsWith(File.separator)) {
+            filePath = filePath.substring(File.separator.length());
+        }
+
         switch (volumeType) {
         case ANDROID_ASSETS:
             return new GVRAndroidResource(gvrContext, getFullPath(defaultPath, filePath));


### PR DESCRIPTION
The URL File::/// confuses loader that the file is relative to the
localhost's root. However, it actually means the current directory.
Just ignore the initial '/' introduced by File::/// in texture loading.