### PR TITLE
Rethrow the RuntimeException back to the application

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVREventManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVREventManager.java
@@ -149,7 +149,13 @@ public class GVREventManager {
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
         } catch (InvocationTargetException e) {
-            e.printStackTrace();
+            Throwable throwable = e.getCause();
+            // rethrow the RuntimeException back to the application
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                e.printStackTrace();
+            }
         }
     }
 }


### PR DESCRIPTION
Return the RuntimeException received as a result of the
InvocationTargetException caught by the GVREventManager
back to the application.