### PR TITLE
Refine and correct futureTexture setting in GVRMaterial

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
@@ -24,6 +24,7 @@ import org.gearvrf.utility.Threads;
 import static org.gearvrf.utility.Assert.*;
 
 import android.graphics.Color;
+import android.util.Log;
 
 /**
  * This is one of the key GVRF classes: it holds shaders with textures.
@@ -478,17 +479,25 @@ public class GVRMaterial extends GVRHybridObject implements
     }
 
     public void setTexture(final String key, final Future<GVRTexture> texture) {
-        Threads.spawn(new Runnable() {
-
-            @Override
-            public void run() {
-                try {
-                    setTexture(key, texture.get());
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+        if (texture.isDone()) {
+            try {
+                setTexture(key, texture.get());
+            } catch (Exception e) {
+                e.printStackTrace();
             }
-        });
+        } else {
+            Threads.spawn(new Runnable() {
+
+                @Override
+                public void run() {
+                    try {
+                        setTexture(key, texture.get());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+        }
     }
 
     public float getFloat(String key) {


### PR DESCRIPTION
GVRMaterial spawns a new thread to set a future texture and the thread is blocked once
the future texture is not finish loading. However, if a texture is already loaded e.g.,
for the preloaded textures, it is not only unnecessary to spawn a new thread, but also
could lead to scheduling issue once the thread pool/system is crowed, such that even a texture
is set to a material, the setting thread is not being executed in the next frame but later.