### PR TITLE
Minor fix for the texture capturer setting

### DIFF
--- a/GVRf/Framework/jni/objects/components/texture_capturer.cpp
+++ b/GVRf/Framework/jni/objects/components/texture_capturer.cpp
@@ -58,7 +58,7 @@ void TextureCapturer::setRenderTexture(RenderTexture *renderTexture) {
 
 void TextureCapturer::setCapture(bool capture, float fps) {
     mPendingCapture = capture;
-    if (fabs(fps) > TOL) {
+    if (capture && fabs(fps) > TOL) {
         mCaptureIntervalNS = (long long)(1000000000.f / fps);
     } else {
         mCaptureIntervalNS = 0;


### PR DESCRIPTION
Allow setCapture(false, 1F) to stop capturing. Previously, it will only stop
it for the first perdiod, after 1F second, it will automatically restart,
which is a bit confusing.