### PR TITLE
Expose input key and motion events via Controllers

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRCursorController.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCursorController.java
@@ -21,9 +21,9 @@ import java.util.List;
 import org.gearvrf.io.CursorControllerListener;
 import org.gearvrf.io.GVRCursorType;
 import org.gearvrf.io.GVRInputManager;
+import org.gearvrf.utility.Log;
 import org.joml.Vector3f;
 
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
@@ -48,6 +48,7 @@ import android.view.MotionEvent;
  * 
  */
 public abstract class GVRCursorController {
+    private static final String TAG = GVRCursorController.class.getSimpleName();
     private static int uniqueControllerId = 0;
     private final int controllerId;
     private final GVRCursorType cursorType;
@@ -323,6 +324,7 @@ public abstract class GVRCursorController {
         if (isEnabled() == false) {
             return;
         }
+
         position.set(x, y, z);
         if (sceneObject != null) {
             synchronized (sceneObjectLock) {
@@ -385,9 +387,17 @@ public abstract class GVRCursorController {
             // reset
             position.zero();
             ray.zero();
-            activeState = ActiveState.NONE;
-            active = false;
-            previousActive = false;
+            if (previousActive) {
+                active = false;
+            }
+
+            synchronized (eventLock) {
+                keyEvent = null;
+                if (motionEvent != null) {
+                    motionEvent.recycle();
+                }
+            }
+            invalidate = true;
         }
     }
 
@@ -472,6 +482,7 @@ public abstract class GVRCursorController {
             previousActive = active;
             position.normalize(ray);
             invalidate = false;
+
             for (ControllerEventListener listener : controllerEventListeners) {
                 listener.onEvent(this);
             }

--- a/GVRf/Framework/src/org/gearvrf/GVRInputManagerImpl.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRInputManagerImpl.java
@@ -95,6 +95,9 @@ class GVRInputManagerImpl extends GVRInputManager {
      */
     void setScene(GVRScene scene) {
         this.scene = scene;
+        for (GVRCursorController controller : controllers) {
+            sensorManager.processPick(scene, controller);
+        }
     }
 
     @Override
@@ -108,9 +111,7 @@ class GVRInputManagerImpl extends GVRInputManager {
         @Override
         public void onDrawFrame(float frameTime) {
             for (GVRCursorController controller : controllers) {
-                if (controller.update()) {
-                    sensorManager.processPick(scene, controller);
-                }
+                controller.update(sensorManager, scene);
             }
         }
     };

--- a/GVRf/Framework/src/org/gearvrf/ISensorEvents.java
+++ b/GVRf/Framework/src/org/gearvrf/ISensorEvents.java
@@ -33,5 +33,5 @@ public interface ISensorEvents extends IEvents {
      *            in {@link SensorEvent} to retrieve the information contained
      *            in the event.
      */
-    public void onSensorEvent(SensorEvent event);
+    void onSensorEvent(SensorEvent event);
 }

--- a/GVRf/Framework/src/org/gearvrf/SensorManager.java
+++ b/GVRf/Framework/src/org/gearvrf/SensorManager.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.gearvrf.GVRCursorController.ActiveState;
 import org.gearvrf.utility.Log;
+import org.joml.Vector3f;
 
 /**
  * This class manages {@link GVRBaseSensor}s
@@ -82,13 +83,12 @@ class SensorManager {
              * Compare ray against the hierarchical bounding volume and then add
              * the children accordingly.
              */
+            Vector3f ray = controller.getRay();
             if (object.intersectsBoundingVolume(ORIGIN[0], ORIGIN[1], ORIGIN[2],
-                    controller.getRayX(), controller.getRayY(),
-                    controller.getRayZ())) {
+                    ray.x, ray.y, ray.z)) {
                 float[] hitPoint = GVRPicker.pickSceneObjectAgainstBoundingBox(
-                        object, ORIGIN[0], ORIGIN[1], ORIGIN[2],
-                        controller.getRayX(), controller.getRayY(),
-                        controller.getRayZ());
+                        object, ORIGIN[0], ORIGIN[1], ORIGIN[2], ray.x, ray.y,
+                        ray.z);
 
                 if (hitPoint != null) {
                     objectSensor.addSceneObject(controller, object, hitPoint);

--- a/GVRf/Framework/src/org/gearvrf/io/GVRGamepadDeviceManager.java
+++ b/GVRf/Framework/src/org/gearvrf/io/GVRGamepadDeviceManager.java
@@ -212,7 +212,6 @@ class GVRGamepadDeviceManager {
                                 point[1], point[2]);
                     }
                 }
-
                 super.setPosition(internalObject.getTransform().getPositionX(),
                         internalObject.getTransform().getPositionY(),
                         internalObject.getTransform().getPositionZ());
@@ -306,8 +305,8 @@ class GVRGamepadDeviceManager {
                             keyEvent = holder.keyEvent;
                             id = holder.id;
                         }
-
                         GVRGamepadController controller = controllers.get(id);
+
                         if (event != null) {
                             dispatchMotionEvent(controller, event);
                         }
@@ -341,46 +340,50 @@ class GVRGamepadDeviceManager {
 
             if (ACTIVE_BUTTONS.contains(keyCode)) {
                 controller.setKeyEvent(event);
-                return;
+            } else {
+                switch (keyCode) {
+                case KeyEvent.KEYCODE_DPAD_LEFT:
+                    if (action == KeyEvent.ACTION_DOWN
+                            && dpadState != KeyEvent.KEYCODE_DPAD_LEFT) {
+                        dpadState = KeyEvent.KEYCODE_DPAD_LEFT;
+                        x = -1.0f;
+                    } else if (action == KeyEvent.ACTION_UP) {
+                        dpadState = 0;
+                    }
+                    break;
+                case KeyEvent.KEYCODE_DPAD_RIGHT:
+                    if (action == KeyEvent.ACTION_DOWN
+                            && dpadState != KeyEvent.KEYCODE_DPAD_RIGHT) {
+                        dpadState = KeyEvent.KEYCODE_DPAD_RIGHT;
+                        x = 1.0f;
+                    } else if (action == KeyEvent.ACTION_UP) {
+                        dpadState = 0;
+                    }
+                    break;
+                case KeyEvent.KEYCODE_DPAD_UP:
+                    if (action == KeyEvent.ACTION_DOWN
+                            && dpadState != KeyEvent.KEYCODE_DPAD_UP) {
+                        dpadState = KeyEvent.KEYCODE_DPAD_UP;
+                        y = 1.0f;
+                    } else if (action == KeyEvent.ACTION_UP) {
+                        dpadState = 0;
+                    }
+                    break;
+                case KeyEvent.KEYCODE_DPAD_DOWN:
+                    if (action == KeyEvent.ACTION_DOWN
+                            && dpadState != KeyEvent.KEYCODE_DPAD_DOWN) {
+                        dpadState = KeyEvent.KEYCODE_DPAD_DOWN;
+                        y = -1.0f;
+                    } else if (action == KeyEvent.ACTION_UP) {
+                        dpadState = 0;
+                    }
+                    break;
+                }
             }
 
-            switch (keyCode) {
-            case KeyEvent.KEYCODE_DPAD_LEFT:
-                if (action == KeyEvent.ACTION_DOWN
-                        && dpadState != KeyEvent.KEYCODE_DPAD_LEFT) {
-                    dpadState = KeyEvent.KEYCODE_DPAD_LEFT;
-                    x = -1.0f;
-                } else if (action == KeyEvent.ACTION_UP) {
-                    dpadState = 0;
-                }
-                break;
-            case KeyEvent.KEYCODE_DPAD_RIGHT:
-                if (action == KeyEvent.ACTION_DOWN
-                        && dpadState != KeyEvent.KEYCODE_DPAD_RIGHT) {
-                    dpadState = KeyEvent.KEYCODE_DPAD_RIGHT;
-                    x = 1.0f;
-                } else if (action == KeyEvent.ACTION_UP) {
-                    dpadState = 0;
-                }
-                break;
-            case KeyEvent.KEYCODE_DPAD_UP:
-                if (action == KeyEvent.ACTION_DOWN
-                        && dpadState != KeyEvent.KEYCODE_DPAD_UP) {
-                    dpadState = KeyEvent.KEYCODE_DPAD_UP;
-                    y = 1.0f;
-                } else if (action == KeyEvent.ACTION_UP) {
-                    dpadState = 0;
-                }
-                break;
-            case KeyEvent.KEYCODE_DPAD_DOWN:
-                if (action == KeyEvent.ACTION_DOWN
-                        && dpadState != KeyEvent.KEYCODE_DPAD_DOWN) {
-                    dpadState = KeyEvent.KEYCODE_DPAD_DOWN;
-                    y = -1.0f;
-                } else if (action == KeyEvent.ACTION_UP) {
-                    dpadState = 0;
-                }
-                break;
+            if (holder != null && holder.event == null) {
+                // reset holder when there is no motion event
+                holder = null;
             }
         }
 
@@ -434,6 +437,7 @@ class GVRGamepadDeviceManager {
             if (event.getAction() != MotionEvent.ACTION_MOVE
                     || device == null) {
                 event.recycle();
+                holder = null;
                 return;
             }
 

--- a/GVRf/Framework/src/org/gearvrf/io/GVRGamepadDeviceManager.java
+++ b/GVRf/Framework/src/org/gearvrf/io/GVRGamepadDeviceManager.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.gearvrf.GVRContext;
+import org.gearvrf.GVRCursorController;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
 
@@ -142,24 +143,27 @@ class GVRGamepadDeviceManager {
         }
 
         @Override
+        protected void setKeyEvent(KeyEvent keyEvent) {
+            super.setKeyEvent(keyEvent);
+        }
+
+        @Override
+        protected void setMotionEvent(MotionEvent motionEvent) {
+            super.setMotionEvent(motionEvent);
+        }
+
+        @Override
         public boolean dispatchKeyEvent(KeyEvent event) {
-            if ((thread.isActive == false
-                    && event.getAction() == KeyEvent.ACTION_DOWN)
-                    || (thread.isActive == true
-                            && event.getAction() == KeyEvent.ACTION_UP)) {
-                return thread.submitKeyEvent(getId(), event);
-            }
-            return false;
+            return thread.submitKeyEvent(getId(), event);
+
         }
 
         @Override
         public boolean dispatchMotionEvent(MotionEvent event) {
-            MotionEvent clone = MotionEvent.obtain(event);
-            return thread.submitMotionEvent(getId(), clone);
+            return thread.submitMotionEvent(getId(), event);
         }
 
-        private void processControllerEvent(float x, float y, float z,
-                boolean active) {
+        private void processControllerEvent(float x, float y, float z) {
             GVRScene scene = context.getMainScene();
             if (scene != null) {
                 float[] viewMatrix = scene.getMainCameraRig().getHeadTransform()
@@ -208,7 +212,7 @@ class GVRGamepadDeviceManager {
                                 point[1], point[2]);
                     }
                 }
-                setActive(active);
+
                 super.setPosition(internalObject.getTransform().getPositionX(),
                         internalObject.getTransform().getPositionY(),
                         internalObject.getTransform().getPositionZ());
@@ -242,8 +246,15 @@ class GVRGamepadDeviceManager {
     }
 
     private class EventHandlerThread extends Thread {
+        private final KeyEvent BUTTON_L2_DOWN = new KeyEvent(
+                KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BUTTON_L2);
+        private final KeyEvent BUTTON_L2_UP = new KeyEvent(KeyEvent.ACTION_UP,
+                KeyEvent.KEYCODE_BUTTON_L2);
+        private final KeyEvent BUTTON_R2_DOWN = new KeyEvent(
+                KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BUTTON_R2);
+        private final KeyEvent BUTTON_R2_UP = new KeyEvent(KeyEvent.ACTION_UP,
+                KeyEvent.KEYCODE_BUTTON_R2);
         private int dpadState;
-        private boolean isActive = false;
         private float x, y, ry;
         private Object lock = new Object();
         private boolean pedalDown = false;
@@ -282,7 +293,6 @@ class GVRGamepadDeviceManager {
         public void run() {
             try {
                 while (true) {
-                    boolean running = false;
                     synchronized (lock) {
                         if (holder == null) {
                             lock.wait();
@@ -296,21 +306,18 @@ class GVRGamepadDeviceManager {
                             keyEvent = holder.keyEvent;
                             id = holder.id;
                         }
-                        if (event != null) {
-                            running = dispatchMotionEvent(id, event);
-                            if (running == false) {
-                                event.recycle();
-                                event = null;
-                                holder = null;
-                            }
-                        }
-                        if (keyEvent != null) {
-                            dispatchKeyEvent(id, keyEvent);
-                            keyEvent = null;
-                        }
+
                         GVRGamepadController controller = controllers.get(id);
+                        if (event != null) {
+                            dispatchMotionEvent(controller, event);
+                        }
+
+                        if (keyEvent != null) {
+                            dispatchKeyEvent(controller, keyEvent);
+                        }
+
                         controller.processControllerEvent(this.x, this.y,
-                                this.ry, isActive);
+                                this.ry);
                     }
                     Thread.sleep(DELAY_MILLISECONDS);
                 }
@@ -319,60 +326,61 @@ class GVRGamepadDeviceManager {
             }
         }
 
-        private void dispatchKeyEvent(int id, KeyEvent event) {
+        /**
+         * Process the KeyEvent from the Gamepad.
+         * 
+         * @param event
+         *            the {@link KeyEvent}.
+         * @return <code>true</code> if the key is from an active button,
+         *         <code>false</code> otherwise
+         */
+        private void dispatchKeyEvent(GVRGamepadController controller,
+                KeyEvent event) {
             int keyCode = event.getKeyCode();
             int action = event.getAction();
 
-            if (id != -1) {
-                if (ACTIVE_BUTTONS.contains(keyCode)) {
-                    if (action == KeyEvent.ACTION_DOWN && isActive == false) {
-                        isActive = true;
-                    } else
-                        if (action == KeyEvent.ACTION_UP && isActive == true) {
-                        isActive = false;
-                    }
-                } else {
-                    switch (keyCode) {
-                    case KeyEvent.KEYCODE_DPAD_LEFT:
-                        if (action == KeyEvent.ACTION_DOWN
-                                && dpadState != KeyEvent.KEYCODE_DPAD_LEFT) {
-                            dpadState = KeyEvent.KEYCODE_DPAD_LEFT;
+            if (ACTIVE_BUTTONS.contains(keyCode)) {
+                controller.setKeyEvent(event);
+                return;
+            }
 
-                            x = -1.0f;
-                        } else if (action == KeyEvent.ACTION_UP) {
-                            dpadState = 0;
-                        }
-                        break;
-                    case KeyEvent.KEYCODE_DPAD_RIGHT:
-                        if (action == KeyEvent.ACTION_DOWN
-                                && dpadState != KeyEvent.KEYCODE_DPAD_RIGHT) {
-                            dpadState = KeyEvent.KEYCODE_DPAD_RIGHT;
-                            x = 1.0f;
-                        } else if (action == KeyEvent.ACTION_UP) {
-                            dpadState = 0;
-                        }
-                        break;
-                    case KeyEvent.KEYCODE_DPAD_UP:
-                        if (action == KeyEvent.ACTION_DOWN
-                                && dpadState != KeyEvent.KEYCODE_DPAD_UP) {
-                            dpadState = KeyEvent.KEYCODE_DPAD_UP;
-                            y = 1.0f;
-                        } else if (action == KeyEvent.ACTION_UP) {
-                            dpadState = 0;
-                        }
-                        break;
-                    case KeyEvent.KEYCODE_DPAD_DOWN:
-                        if (action == KeyEvent.ACTION_DOWN
-                                && dpadState != KeyEvent.KEYCODE_DPAD_DOWN) {
-                            dpadState = KeyEvent.KEYCODE_DPAD_DOWN;
-                            y = -1.0f;
-                        } else if (action == KeyEvent.ACTION_UP) {
-                            dpadState = 0;
-                        }
-                        break;
-                    }
-
+            switch (keyCode) {
+            case KeyEvent.KEYCODE_DPAD_LEFT:
+                if (action == KeyEvent.ACTION_DOWN
+                        && dpadState != KeyEvent.KEYCODE_DPAD_LEFT) {
+                    dpadState = KeyEvent.KEYCODE_DPAD_LEFT;
+                    x = -1.0f;
+                } else if (action == KeyEvent.ACTION_UP) {
+                    dpadState = 0;
                 }
+                break;
+            case KeyEvent.KEYCODE_DPAD_RIGHT:
+                if (action == KeyEvent.ACTION_DOWN
+                        && dpadState != KeyEvent.KEYCODE_DPAD_RIGHT) {
+                    dpadState = KeyEvent.KEYCODE_DPAD_RIGHT;
+                    x = 1.0f;
+                } else if (action == KeyEvent.ACTION_UP) {
+                    dpadState = 0;
+                }
+                break;
+            case KeyEvent.KEYCODE_DPAD_UP:
+                if (action == KeyEvent.ACTION_DOWN
+                        && dpadState != KeyEvent.KEYCODE_DPAD_UP) {
+                    dpadState = KeyEvent.KEYCODE_DPAD_UP;
+                    y = 1.0f;
+                } else if (action == KeyEvent.ACTION_UP) {
+                    dpadState = 0;
+                }
+                break;
+            case KeyEvent.KEYCODE_DPAD_DOWN:
+                if (action == KeyEvent.ACTION_DOWN
+                        && dpadState != KeyEvent.KEYCODE_DPAD_DOWN) {
+                    dpadState = KeyEvent.KEYCODE_DPAD_DOWN;
+                    y = -1.0f;
+                } else if (action == KeyEvent.ACTION_UP) {
+                    dpadState = 0;
+                }
+                break;
             }
         }
 
@@ -380,16 +388,14 @@ class GVRGamepadDeviceManager {
             if (threadStarted && event.isFromSource(InputDevice.SOURCE_GAMEPAD)
                     || event.isFromSource(InputDevice.SOURCE_JOYSTICK)) {
                 MotionEvent clone = MotionEvent.obtain(event);
-
                 synchronized (lock) {
-                    // There are cases of null events being passed.
-                    if (event != null) {
-                        event.recycle();
-                    }
-
                     if (holder == null) {
                         this.holder = new EventDataHolder(id, clone, null);
                     } else {
+                        // if there is already an event recycle it
+                        if (holder.event != null) {
+                            holder.event.recycle();
+                        }
                         holder.setId(id);
                         holder.setEvent(clone);
                     }
@@ -422,17 +428,15 @@ class GVRGamepadDeviceManager {
         // The following methods are taken from the controller sample on the
         // Android Developer web site:
         // https://developer.android.com/training/game-controllers/controller-input.html
-        private boolean dispatchMotionEvent(int id, MotionEvent event) {
-            if (event.getAction() == MotionEvent.ACTION_MOVE) {
-                if (id != -1) {
-                    return processJoystickInput(event);
-                }
-            }
-            return false;
-        }
-
-        private boolean processJoystickInput(MotionEvent event) {
+        private void dispatchMotionEvent(GVRGamepadController controller,
+                MotionEvent event) {
             InputDevice device = event.getDevice();
+            if (event.getAction() != MotionEvent.ACTION_MOVE
+                    || device == null) {
+                event.recycle();
+                return;
+            }
+
             float x = getCenteredAxis(event, device, MotionEvent.AXIS_X);
             if (x == 0) {
                 x = getCenteredAxis(event, device, MotionEvent.AXIS_HAT_X);
@@ -458,23 +462,24 @@ class GVRGamepadDeviceManager {
             } else if ((vendorId == GVRDeviceConstants.STEELSERIES_CONTROLLER_VENDOR_ID
                     && productId == GVRDeviceConstants.STEELSERIES_CONTROLLER_PRODUCT_ID)) {
                 ry = getCenteredAxis(event, device, MotionEvent.AXIS_RZ);
-                if ((getCenteredAxis(event, device, MotionEvent.AXIS_BRAKE) != 0
-                        || getCenteredAxis(event, device,
-                                MotionEvent.AXIS_GAS) != 0)
-                        && pedalDown == false) {
+
+                float brakeAxis = getCenteredAxis(event, device,
+                        MotionEvent.AXIS_BRAKE);
+                float gasAxis = getCenteredAxis(event, device,
+                        MotionEvent.AXIS_GAS);
+                if (brakeAxis != 0 && pedalDown == false) {
                     pedalDown = true;
-                    if (isActive == false) {
-                        isActive = true;
-                    }
-                } else if ((getCenteredAxis(event, device,
-                        MotionEvent.AXIS_BRAKE) == 0
-                        && getCenteredAxis(event, device,
-                                MotionEvent.AXIS_GAS) == 0)
-                        && pedalDown == true) {
+                    controller.setKeyEvent(BUTTON_L2_DOWN);
+                } else if (brakeAxis == 0 && pedalDown == true) {
                     pedalDown = false;
-                    if (isActive == true) {
-                        isActive = false;
-                    }
+                    controller.setKeyEvent(BUTTON_L2_UP);
+                }
+                if (gasAxis != 0 && pedalDown == false) {
+                    pedalDown = true;
+                    controller.setKeyEvent(BUTTON_R2_DOWN);
+                } else if (gasAxis == 0 && pedalDown == true) {
+                    pedalDown = false;
+                    controller.setKeyEvent(BUTTON_R2_UP);
                 }
             }
 
@@ -483,9 +488,12 @@ class GVRGamepadDeviceManager {
             this.ry = ry;
 
             if (x == 0 && y == 0 && ry == 0) {
-                return false;
+                event.recycle();
+                holder = null;
             } else {
-                return true;
+                MotionEvent clone = MotionEvent.obtain(event);
+                holder.event = clone;
+                controller.setMotionEvent(event);
             }
         }
 

--- a/GVRf/Framework/src/org/gearvrf/io/GVRGazeCursorController.java
+++ b/GVRf/Framework/src/org/gearvrf/io/GVRGazeCursorController.java
@@ -18,6 +18,8 @@ package org.gearvrf.io;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRDrawFrameListener;
 import org.joml.Vector3f;
+
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
@@ -25,7 +27,11 @@ class GVRGazeCursorController extends GVRBaseController
         implements GVRDrawFrameListener {
     private static final String TAG = GVRGazeCursorController.class
             .getSimpleName();
-    private boolean isActive;
+    private final KeyEvent BUTTON_GAZE_DOWN = new KeyEvent(KeyEvent.ACTION_DOWN,
+            KeyEvent.KEYCODE_BUTTON_1);
+    private final KeyEvent BUTTON_GAZE_UP = new KeyEvent(KeyEvent.ACTION_UP,
+            KeyEvent.KEYCODE_BUTTON_1);
+
     private final GVRContext context;
 
     // Used to calculate the absolute position that the controller reports to
@@ -46,20 +52,21 @@ class GVRGazeCursorController extends GVRBaseController
 
     @Override
     boolean dispatchKeyEvent(KeyEvent event) {
-        // Not used.
-        return false;
+        setKeyEvent(event);
+        return true;
     }
 
     @Override
     boolean dispatchMotionEvent(MotionEvent event) {
-        if (event.getAction() == MotionEvent.ACTION_DOWN && isActive == false) {
-            this.isActive = true;
-            setActive(isActive);
-        } else if (event.getAction() == MotionEvent.ACTION_UP
-                && isActive == true) {
-            this.isActive = false;
-            setActive(isActive);
+        MotionEvent clone = MotionEvent.obtain(event);
+        if (clone.getAction() == MotionEvent.ACTION_DOWN) {
+            // report ACTION_DOWN as a button
+            setKeyEvent(BUTTON_GAZE_DOWN);
+        } else if (clone.getAction() == MotionEvent.ACTION_UP) {
+            // report ACTION_UP as a button
+            setKeyEvent(BUTTON_GAZE_UP);
         }
+        setMotionEvent(clone);
         return true;
     }
 


### PR DESCRIPTION
The patch includes the following changes:
* The app and query the controller for the latest key and
  motion events processed by the GVRCursorController
* Allow the user to enable/disable the GVRCursorController.By
  default all controllers are enabled. Use the setEnable(boolean)
  call to disable them.
* Use and explicit process scene call whenever the scene changes.
  So that the SensorEvents are always latest.
* Add listener to notify application whenever the controller
  data is invalidated.
* Replaced float arrays by JOML Vector3f in GVRCursorController
* General Cleanup of Mouse and Gamepad controllers.