### PR TITLE
Removed a log call from texture.h

### DIFF
--- a/GVRf/Framework/jni/objects/textures/texture.h
+++ b/GVRf/Framework/jni/objects/textures/texture.h
@@ -85,7 +85,6 @@ public:
     }
 
     void setReady(bool ready) {
-        LOGD("ASYNC: set texture ready");
         this->ready = ready;
     }
 


### PR DESCRIPTION
The log ends up polluting logcat everytime setTexture is called,
which could be a lot during onInit or for animations.