### PR TITLE
Improve the fallback to monoscopic

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRActivity.java
@@ -84,7 +84,7 @@ public class GVRActivity extends Activity {
 
         try {
             mActivityHandler = new VrapiActivityHandler(this, mRenderingCallbacks);
-        } catch (final VrapiNotAvailableException ignored) {
+        } catch (final Exception ignored) {
             // will fall back to mono rendering in that case
         }
     }


### PR DESCRIPTION
- vrapi throws a java exception from the native code if systemactivies.apk is missing; that exception sometimes is, sometimes apparently is not propagated up to java

---
This is an attempt to fix this:

02-22 23:09:07.019: W/dalvikvm(27026): dvmFindClassByName rejecting 'com/oculus/vrapi/loader/AppLoader'
02-22 23:09:07.021: W/System.err(27026): java.lang.RuntimeException: Couldn't load host package
02-22 23:09:07.024: W/System.err(27026):                     at com.oculus.vrapi.loader.AppLoader.getHostContext(AppLoader.java:36)
02-22 23:09:07.026: W/System.err(27026):                     at com.oculus.vrapi.loader.AppLoader.load(AppLoader.java:104)
02-22 23:09:07.027: W/System.err(27026):                     at org.gearvrf.VrapiActivityHandler.nativeInitializeVrApi(Native Method)
02-22 23:09:07.028: W/System.err(27026):                     at org.gearvrf.VrapiActivityHandler.nativeInitializeVrApi(Native Method)
02-22 23:09:07.029: W/System.err(27026):                     at org.gearvrf.VrapiActivityHandler.<init>(VrapiActivityHandler.java:67)
02-22 23:09:07.030: W/System.err(27026):                     at org.gearvrf.GVRActivity.onCreate(GVRActivity.java:86)
02-22 23:09:07.031: W/System.err(27026):                     at org.gearvrf.simplesample.SampleActivity.onCreate(SampleActivity.java:26)
02-22 23:09:07.031: W/System.err(27026):                     at android.app.Activity.performCreate(Activity.java:5248)
02-22 23:09:07.032: W/System.err(27026):                     at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1110)
02-22 23:09:07.033: W/System.err(27026):                     at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2162)
02-22 23:09:07.034: W/System.err(27026):                     at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2257)
02-22 23:09:07.035: W/System.err(27026):                     at android.app.ActivityThread.access$800(ActivityThread.java:139)
02-22 23:09:07.037: W/System.err(27026):                     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1210)
02-22 23:09:07.040: W/System.err(27026):                     at android.os.Handler.dispatchMessage(Handler.java:102)
02-22 23:09:07.042: W/System.err(27026):                     at android.os.Looper.loop(Looper.java:136)
02-22 23:09:07.043: W/System.err(27026):                     at android.app.ActivityThread.main(ActivityThread.java:5097)
02-22 23:09:07.044: W/System.err(27026):                     at java.lang.reflect.Method.invokeNative(Native Method)
02-22 23:09:07.045: W/System.err(27026):                     at java.lang.reflect.Method.invoke(Method.java:515)
02-22 23:09:07.046: W/System.err(27026):                     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:785)
02-22 23:09:07.047: W/System.err(27026):                     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:601)
02-22 23:09:07.048: W/System.err(27026):                     at dalvik.system.NativeStart.main(Native Method)
02-22 23:09:07.049: W/System.err(27026): Caused by: android.content.pm.PackageManager$NameNotFoundException: com.oculus.systemactivities
02-22 23:09:07.051: W/System.err(27026):                     at android.app.ApplicationPackageManager.getPackageInfo(ApplicationPackageManager.java:82)
02-22 23:09:07.052: W/System.err(27026):                     at com.oculus.vrapi.loader.AppLoader.getHostContext(AppLoader.java:26)
02-22 23:09:07.053: W/System.err(27026):                     ... 20 more
02-22 23:09:07.053: W/Loader(27026): vrapi_Initialize: Failed to load VrApi driver!