### PR TITLE
Defer GL commands in cubemap constructors

### DIFF
--- a/GVRf/Framework/jni/objects/textures/base_texture.h
+++ b/GVRf/Framework/jni/objects/textures/base_texture.h
@@ -92,13 +92,13 @@ public:
                         + ret;
                 throw error;
             }
-            AndroidBitmap_unlockPixels(env_, bitmapRef_);
 
             glBindTexture(GL_TEXTURE_2D, gl_texture_->id());
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, info_.width, info_.height, 0,
                     GL_RGBA, GL_UNSIGNED_BYTE, pixels_);
-            glGenerateMipmap (GL_TEXTURE_2D);
+            glGenerateMipmap(GL_TEXTURE_2D);
 
+            AndroidBitmap_unlockPixels(env_, bitmapRef_);
             env_->DeleteGlobalRef(bitmapRef_);
             break;
         }

--- a/GVRf/Framework/jni/objects/textures/base_texture.h
+++ b/GVRf/Framework/jni/objects/textures/base_texture.h
@@ -66,6 +66,17 @@ public:
             Texture(new GLTexture(TARGET, texture_parameters)), pending_gl_task_(GL_TASK_NONE) {
     }
 
+    virtual ~BaseTexture() {
+        switch (pending_gl_task_) {
+        case GL_TASK_INIT_BITMAP:
+            env_->DeleteGlobalRef(bitmapRef_);
+            break;
+
+        default:
+            break;
+        }
+    }
+
     bool update(int width, int height, void* data) {
         glBindTexture(GL_TEXTURE_2D, gl_texture_->id());
         glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0,

--- a/GVRf/Framework/jni/objects/textures/cubemap_texture.h
+++ b/GVRf/Framework/jni/objects/textures/cubemap_texture.h
@@ -63,6 +63,27 @@ public:
             Texture(new GLTexture(TARGET)) {
     }
 
+    virtual ~CubemapTexture() {
+        // Release global refs. Race condition does not occur because if
+        // the runPendingGL is running, the object won't be destructed.
+        switch (pending_gl_task_) {
+        case GL_TASK_INIT_BITMAP:
+            for (int i = 0; i < 6; i++) {
+                env_->DeleteGlobalRef(bitmapRef_[i]);
+            }
+            break;
+
+        case GL_TASK_INIT_INTERNAL_FORMAT:
+            for (int i = 0; i < 6; i++) {
+                env_->DeleteGlobalRef(textureRef_[i]);
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+
     GLenum getTarget() const {
         return TARGET;
     }

--- a/GVRf/Framework/jni/objects/textures/cubemap_texture.h
+++ b/GVRf/Framework/jni/objects/textures/cubemap_texture.h
@@ -26,6 +26,7 @@
 
 #include "objects/textures/texture.h"
 #include "util/gvr_log.h"
+#include "util/scope_exit.h"
 
 namespace gvr {
 class CubemapTexture: public Texture {
@@ -33,35 +34,11 @@ public:
     explicit CubemapTexture(JNIEnv* env, jobjectArray bitmapArray,
             int* texture_parameters) :
             Texture(new GLTexture(TARGET, texture_parameters)) {
-        glBindTexture(TARGET, gl_texture_->id());
+        pending_gl_task_ = GL_TASK_INIT_BITMAP;
+        env_ = env;
+
         for (int i = 0; i < 6; i++) {
-            jobject bitmap = env->GetObjectArrayElement(bitmapArray, i);
-
-            AndroidBitmapInfo info;
-            void *pixels;
-            int ret;
-
-            if (bitmap == NULL) {
-                std::string error =
-                        "new BaseTexture() failed! Input bitmap is NULL.";
-                throw error;
-            }
-            if ((ret = AndroidBitmap_getInfo(env, bitmap, &info)) < 0) {
-                std::string error = "AndroidBitmap_getInfo () failed! error = "
-                        + ret;
-                throw error;
-            }
-            if ((ret = AndroidBitmap_lockPixels(env, bitmap, &pixels)) < 0) {
-                std::string error =
-                        "AndroidBitmap_lockPixels () failed! error = " + ret;
-                throw error;
-            }
-
-            glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA,
-                    info.width, info.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-                    pixels);
-
-            AndroidBitmap_unlockPixels(env, bitmap);
+            bitmapRef_[i] = env->NewGlobalRef(env->GetObjectArrayElement(bitmapArray, i));
         }
     }
 
@@ -69,23 +46,16 @@ public:
             GLsizei width, GLsizei height, GLsizei imageSize,
             jobjectArray textureArray, int* textureOffset, int* texture_parameters) :
             Texture(new GLTexture(TARGET, texture_parameters)) {
-        glBindTexture(TARGET, gl_texture_->id());
+        pending_gl_task_ = GL_TASK_INIT_INTERNAL_FORMAT;
+        env_ = env;
+        internalFormat_ = internalFormat;
+        width_ = width;
+        height_ = height;
+        imageSize_ = imageSize;
+        memcpy(textureOffset_, textureOffset, 6 * sizeof(textureOffset_[0]));
+
         for (int i = 0; i < 6; i++) {
-            jbyteArray byteArray = static_cast<jbyteArray>(env->GetObjectArrayElement(textureArray, i));
-
-            jbyte *textureData = env->GetByteArrayElements(byteArray, 0);
-            int ret;
-
-            if (byteArray == NULL) {
-                std::string error =
-                        "new CubemapTexture() failed! Input texture is NULL.";
-                throw error;
-            }
-
-            glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0,
-                    internalFormat, width, height, 0, imageSize, textureData + textureOffset[i]);
-
-            env->ReleaseByteArrayElements(byteArray, textureData, 0);
+            textureRef_[i] = env->NewGlobalRef(env->GetObjectArrayElement(textureArray, i));
         }
     }
 
@@ -97,6 +67,94 @@ public:
         return TARGET;
     }
 
+    virtual void runPendingGL() {
+        Texture::runPendingGL();
+
+        switch (pending_gl_task_) {
+        case GL_TASK_NONE:
+            return;
+
+        case GL_TASK_INIT_BITMAP: {
+            // Clean up upon scope exit. The SCOPE_EXIT utility is used
+            // to avoid duplicated code in the throw case and normal
+            // case.
+            SCOPE_EXIT(
+                    pending_gl_task_ = GL_TASK_NONE;
+                    for (int i = 0; i < 6; i++) {
+                        env_->DeleteGlobalRef(bitmapRef_[i]);
+                    }
+            );
+
+            glBindTexture(TARGET, gl_texture_->id());
+
+            for (int i = 0; i < 6; i++) {
+                jobject bitmap = bitmapRef_[i];
+
+                AndroidBitmapInfo info;
+                void *pixels;
+                int ret;
+
+                if (bitmap == NULL) {
+                    std::string error =
+                            "new BaseTexture() failed! Input bitmap is NULL.";
+                    throw error;
+                }
+                if ((ret = AndroidBitmap_getInfo(env_, bitmap, &info)) < 0) {
+                    std::string error = "AndroidBitmap_getInfo () failed! error = "
+                            + ret;
+                    throw error;
+                }
+                if ((ret = AndroidBitmap_lockPixels(env_, bitmap, &pixels)) < 0) {
+                    std::string error =
+                            "AndroidBitmap_lockPixels () failed! error = " + ret;
+                    throw error;
+                }
+
+                glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA,
+                        info.width, info.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                        pixels);
+
+                AndroidBitmap_unlockPixels(env_, bitmap);
+            }
+
+            break;
+        }
+
+        case GL_TASK_INIT_INTERNAL_FORMAT: {
+            // Clean up upon scope exit
+            SCOPE_EXIT(
+                    pending_gl_task_ = GL_TASK_NONE;
+                    for (int i = 0; i < 6; i++) {
+                        env_->DeleteGlobalRef(textureRef_[i]);
+                    }
+            );
+
+            glBindTexture(TARGET, gl_texture_->id());
+
+            for (int i = 0; i < 6; i++) {
+                jbyteArray byteArray = static_cast<jbyteArray>(textureRef_[i]);
+
+                jbyte *textureData = env_->GetByteArrayElements(byteArray, 0);
+                int ret;
+
+                if (byteArray == NULL) {
+                    std::string error =
+                            "new CubemapTexture() failed! Input texture is NULL.";
+                    throw error;
+                }
+
+                glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0,
+                        internalFormat_, width_, height_, 0, imageSize_, textureData + textureOffset_[i]);
+
+                env_->ReleaseByteArrayElements(byteArray, textureData, 0);
+            }
+
+            break;
+        }
+
+        } // switch
+    }
+
 private:
     CubemapTexture(const CubemapTexture& base_texture);
     CubemapTexture(CubemapTexture&& base_texture);
@@ -105,6 +163,28 @@ private:
 
 private:
     static const GLenum TARGET = GL_TEXTURE_CUBE_MAP;
+
+    // Enum for pending GL tasks. Keep a comma with each line
+    // for easier merging.
+    enum {
+        GL_TASK_NONE = 0,
+        GL_TASK_INIT_BITMAP,
+        GL_TASK_INIT_INTERNAL_FORMAT,
+    };
+    int pending_gl_task_;
+
+    JNIEnv* env_;
+
+    // For GL_TASK_INIT_BITMAP
+    jobject bitmapRef_[6];
+
+    // For GL_TASK_INIT_INTERNAL_FORMAT
+    GLenum internalFormat_;
+    GLsizei width_;
+    GLsizei height_;
+    GLsizei imageSize_;
+    jobject textureRef_[6];
+    int textureOffset_[6];
 };
 
 }

--- a/GVRf/Framework/jni/util/scope_exit.h
+++ b/GVRf/Framework/jni/util/scope_exit.h
@@ -1,0 +1,50 @@
+/* Copyright 2016 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UTIL_SCOPE_EXIT_H_
+#define UTIL_SCOPE_EXIT_H_
+
+#include <functional>
+
+/**
+ * This class allows user to specify a block of code to be
+ * executed when it exits the scope. It is similary to Java's
+ * "finally" block but follows C++ RAII (resource allocation
+ * is initialization) principle.
+ */
+class ScopeExit {
+public:
+    ScopeExit (const std::function<void()> &func)
+    : m_func(func)
+    { }
+
+    ~ScopeExit () {
+        m_func();
+    }
+
+private:
+    std::function<void()> m_func;
+};
+
+#define STR_JOIN(arg1, arg2) STR_JOIN_(arg1, arg2)
+#define STR_JOIN_(arg1, arg2) arg1 ## arg2
+
+// Equivalent of a Java "finally" block
+#define SCOPE_EXIT(code) \
+    ScopeExit STR_JOIN(scope_exit_, __LINE__)([=]() { \
+        code; \
+    })
+
+#endif /* UTIL_SCOPE_EXIT_H_ */


### PR DESCRIPTION
Avoid running GL commands in the constructors of cubemap textures.

This allows them to be used from scripts and allow for better performance in GL thread in general.