### PR TITLE
Add light map shader

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -569,6 +569,7 @@ bool Renderer::isShader3d(const Material* curr_material) {
     case Material::ShaderType::TEXTURE_SHADER:
     case Material::ShaderType::EXTERNAL_RENDERER_SHADER:
     case Material::ShaderType::ASSIMP_SHADER:
+    case Material::ShaderType::LIGHTMAP_SHADER:
     default:
         shaders3d = true;
         break;
@@ -766,6 +767,10 @@ void Renderer::renderRenderData(RenderData* render_data,
                                         mv_matrix,
                                         glm::inverseTranspose(mv_matrix),
                                         mvp_matrix, render_data, curr_material);
+                                break;
+                            case Material::ShaderType::LIGHTMAP_SHADER:
+                                shader_manager->getLightMapShader()->render(mvp_matrix,
+                                        render_data, curr_material);
                                 break;
                             default:
                                 shader_manager->getCustomShader(

--- a/GVRf/Framework/jni/objects/material.h
+++ b/GVRf/Framework/jni/objects/material.h
@@ -46,6 +46,7 @@ public:
         EXTERNAL_RENDERER_SHADER = 8,
         ASSIMP_SHADER = 9,
         BOUNDING_BOX_SHADER = 10,
+        LIGHTMAP_SHADER = 11,
         DISTORTION_SHADER = 90, // this shader is implemented and loaded in the distorter
         TEXTURE_SHADER_NOLIGHT = 100,
         BUILTIN_SHADER_SIZE = 101

--- a/GVRf/Framework/jni/shaders/material/lightmap_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/lightmap_shader.cpp
@@ -1,0 +1,111 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/***************************************************************************
+ * Renders the textures of light map plus the main texutre.
+ ***************************************************************************/
+
+#include "lightmap_shader.h"
+
+#include "gl/gl_program.h"
+#include "objects/material.h"
+#include "objects/mesh.h"
+#include "objects/components/render_data.h"
+#include "objects/textures/texture.h"
+#include "util/gvr_gl.h"
+
+namespace gvr {
+static const char VERTEX_SHADER[] = "attribute vec4 a_position;\n"
+        "attribute vec3 a_normal;\n"
+        "attribute vec2 a_tex_coord;\n"
+        "uniform mat4 u_mvp;\n"
+        "varying vec2 coord;\n"
+        "void main() {\n"
+        " vec4 pos = u_mvp * a_position;\n"
+        " coord = a_tex_coord;\n"
+        " gl_Position = pos;\n"
+        "}";
+
+static const char FRAGMENT_SHADER[] = "precision mediump float;\n"
+        "varying vec2  coord;\n"
+        "uniform sampler2D u_main_texture;\n"
+        "uniform sampler2D u_lightmap_texture;\n"
+        "uniform vec2  u_lightmap_offset;\n"
+        "uniform vec2  u_lightmap_scale;\n"
+        "void main() {\n"
+        " vec4 color;\n"
+        " vec4 lightmap_color;\n"
+        " vec2 lightmap_coord = (coord * u_lightmap_scale) + u_lightmap_offset;\n"
+        // Beast exports the texture with vertical flip
+        " lightmap_color = texture2D(u_lightmap_texture, vec2(lightmap_coord.x, 1.0 - lightmap_coord.y));\n"
+        " color = texture2D(u_main_texture, coord);\n"
+        " gl_FragColor = color * lightmap_color;\n"
+        "}";
+
+LightMapShader::LightMapShader() :
+        program_(0), u_mvp_(0), u_texture_(0), u_lightmap_texture_(0),
+        u_lightmap_offset_(0), u_lightmap_scale_(0) {
+    program_ = new GLProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+    u_mvp_ = glGetUniformLocation(program_->id(), "u_mvp");
+    u_texture_ = glGetUniformLocation(program_->id(), "u_texture");
+
+    u_lightmap_texture_ = glGetUniformLocation(program_->id(), "u_lightmap_texture");
+    u_lightmap_offset_ = glGetUniformLocation(program_->id(), "u_lightmap_offset");
+    u_lightmap_scale_ = glGetUniformLocation(program_->id(), "u_lightmap_scale");
+}
+
+LightMapShader::~LightMapShader() {
+    delete program_;
+}
+
+void LightMapShader::render(const glm::mat4& mvp_matrix,
+        RenderData* render_data, Material* material) {
+
+#if _GVRF_USE_GLES3_
+
+    Mesh* mesh = render_data->mesh();
+    Texture* texture = material->getTexture("main_texture");
+    Texture* lightmap_texture = material->getTexture("lightmap_texture");
+    glm::vec2 lightmap_offset = material->getVec2("lightmap_offset");
+    glm::vec2 lightmap_scale = material->getVec2("lightmap_scale");
+
+    mesh->generateVAO();
+
+    glUseProgram(program_->id());
+
+    glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(mvp_matrix));
+
+    glActiveTexture (GL_TEXTURE0);
+    glBindTexture(texture->getTarget(), texture->getId());
+    glUniform1i(u_texture_, 0);
+
+    glActiveTexture (GL_TEXTURE1);
+    glBindTexture(lightmap_texture->getTarget(), lightmap_texture->getId());
+    glUniform1i(u_lightmap_texture_, 1);
+
+    glUniform2f(u_lightmap_offset_, lightmap_offset.x, lightmap_offset.y);
+    glUniform2f(u_lightmap_scale_, lightmap_scale.x, lightmap_scale.y);
+
+    glBindVertexArray(mesh->getVAOId(Material::LIGHTMAP_SHADER));
+    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT, 0);
+    glBindVertexArray(0);
+
+    checkGlError("LightMapShader::render");
+
+#endif
+
+}
+
+};

--- a/GVRf/Framework/jni/shaders/material/lightmap_shader.h
+++ b/GVRf/Framework/jni/shaders/material/lightmap_shader.h
@@ -1,0 +1,61 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/***************************************************************************
+ * Renders a cube map texture without light.
+ ***************************************************************************/
+
+#ifndef LIGHTMAP_SHADER_H_
+#define LIGHTMAP_SHADER_H_
+
+#include <memory>
+
+#include "GLES3/gl3.h"
+#include "glm/glm.hpp"
+#include "glm/gtc/type_ptr.hpp"
+
+#include "objects/hybrid_object.h"
+
+namespace gvr {
+class GLProgram;
+class RenderData;
+class Material;
+
+class LightMapShader: public HybridObject {
+public:
+    LightMapShader();
+    virtual ~LightMapShader();
+
+    void render(const glm::mat4& mvp_matrix,
+            RenderData* render_data, Material* material);
+
+private:
+    LightMapShader(const LightMapShader& lightmap_shader);
+    LightMapShader(LightMapShader&& lightmap_shader);
+    LightMapShader& operator=(const LightMapShader& lightmap_shader);
+    LightMapShader& operator=(LightMapShader&& lightmap_shader);
+
+private:
+    GLProgram* program_;
+    GLuint u_mvp_;
+    GLuint u_texture_;
+    GLuint u_lightmap_texture_;
+    GLuint u_lightmap_offset_;
+    GLuint u_lightmap_scale_;
+};
+
+}
+
+#endif

--- a/GVRf/Framework/jni/shaders/shader_manager.h
+++ b/GVRf/Framework/jni/shaders/shader_manager.h
@@ -35,6 +35,7 @@
 #include "shaders/material/external_renderer_shader.h"
 #include "shaders/material/assimp_shader.h"
 #include "shaders/posteffect/shadow_shader.h"
+#include "shaders/material/lightmap_shader.h"
 #include "util/gvr_log.h"
 
 namespace gvr {
@@ -45,7 +46,7 @@ public:
             unlit_horizontal_stereo_shader_(), unlit_vertical_stereo_shader_(),
             oes_shader_(), oes_horizontal_stereo_shader_(), oes_vertical_stereo_shader_(),
             cubemap_shader_(), cubemap_reflection_shader_(), texture_shader_(), assimp_shader_(),
-            shadow_shader_(), external_renderer_shader_(), error_shader_(),
+            shadow_shader_(), lightmap_shader_(), external_renderer_shader_(), error_shader_(),
             latest_custom_shader_id_(INITIAL_CUSTOM_SHADER_INDEX), custom_shaders_() {
     }
     ~ShaderManager() {
@@ -60,6 +61,7 @@ public:
         delete external_renderer_shader_;
         delete assimp_shader_;
         delete shadow_shader_;
+        delete lightmap_shader_;
         delete error_shader_;
         // We don't delete the custom shaders, as their Java owner-objects will do that for us.
     }
@@ -135,6 +137,14 @@ public:
         }
         return shadow_shader_;
     }
+
+    LightMapShader* getLightMapShader() {
+        if (!lightmap_shader_) {
+            lightmap_shader_ = new LightMapShader();
+        }
+        return lightmap_shader_;
+    }
+
     ErrorShader* getErrorShader() {
         if (!error_shader_) {
             error_shader_ = new ErrorShader();
@@ -179,6 +189,7 @@ private:
     ExternalRendererShader* external_renderer_shader_;
     AssimpShader* assimp_shader_;
     ShadowShader* shadow_shader_;
+    LightMapShader* lightmap_shader_;
     ErrorShader* error_shader_;
     int latest_custom_shader_id_;
     std::map<int, CustomShader*> custom_shaders_;

--- a/GVRf/Framework/src/org/gearvrf/GVRAtlasInformation.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRAtlasInformation.java
@@ -1,0 +1,67 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf;
+
+/**
+ * Contains the information, in UV space, of offset and scale
+ * necessary to map a 2D texture of a texture atlas to the GVRSceneObject.
+ */
+public class GVRAtlasInformation {
+    private String mName = null;
+    private float[] mOffset = {0, 0};
+    private float[] mScale = {1, 1};
+
+    /**
+     * Contructs a Altas information in UV space of a atlased object.
+     *
+     * @param name Name of the atlased object.
+     * @param offset UV space of the position of a atlased object into the texture.
+     * @param scale UV space of the scale of a atlased object into the texture.
+     */
+    public GVRAtlasInformation(String name, float[] offset, float[] scale) {
+        mName = name;
+        mOffset = offset;
+        mScale = scale;
+    }
+
+    /**
+     * The name of the atlased object. Use it to
+     * get find the atlased object into the scene.
+     *
+     * @return The name of a atlased object.
+     */
+    public String getName() {
+        return mName;
+    }
+
+    /**
+     * Offset in uv space of a atlased object into the texture.
+     *
+     * @return array with uv coord of a atlased object.
+     */
+    public float[] getOffset() {
+        return mOffset;
+    }
+
+    /**
+     * Scale in uv space of a atlased object into the texture.
+     *
+     * @return array with uv scale of a atlased object.
+     */
+    public float[] getScale() {
+        return mScale;
+    }
+}

--- a/GVRf/Framework/src/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRContext.java
@@ -1924,8 +1924,6 @@ public abstract class GVRContext {
      */
     public List<GVRAtlasInformation> loadTextureAtlasInformation(GVRAndroidResource resource) {
 
-        assertGLThread();
-
         List<GVRAtlasInformation> atlasInformation
                 = GVRAsynchronousResourceLoader.loadAtlasInformation(resource.getStream());
         resource.closeStream();

--- a/GVRf/Framework/src/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRContext.java
@@ -1908,6 +1908,32 @@ public abstract class GVRContext {
     }
 
     /**
+     * Loads atlas information file placed in the assets folder.
+     *
+     * Atlas information file contains in UV space the information of offset and
+     * scale for each mesh mapped in some atlas texture.
+     * The content of the file is at json format like:
+     *
+     * [ {name: SUN, offset.x: 0.9, offset.y: 0.9, scale.x: 0.5, scale.y: 0.5},
+     * {name: EARTH, offset.x: 0.5, offset.y: 0.9, scale.x: 0.5, scale.y: 0.5} ]
+     *
+     * @param resource
+     *            A stream containing a text file on JSON format.
+     *
+     * @return List of atlas information load.
+     */
+    public List<GVRAtlasInformation> loadTextureAtlasInformation(GVRAndroidResource resource) {
+
+        assertGLThread();
+
+        List<GVRAtlasInformation> atlasInformation
+                = GVRAsynchronousResourceLoader.loadAtlasInformation(resource.getStream());
+        resource.closeStream();
+
+        return atlasInformation;
+    }
+
+    /**
      * Get the current {@link GVRScene}, which contains the scene graph (a
      * hierarchy of {@linkplain GVRSceneObject scene objects}) and the
      * {@linkplain GVRCameraRig camera rig}

--- a/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
@@ -21,10 +21,9 @@ import java.util.concurrent.Future;
 
 import org.gearvrf.utility.Colors;
 import org.gearvrf.utility.Threads;
-import static org.gearvrf.utility.Assert.*;
 
+import static org.gearvrf.utility.Assert.*;
 import android.graphics.Color;
-import android.util.Log;
 
 /**
  * This is one of the key GVRF classes: it holds shaders with textures.
@@ -154,6 +153,11 @@ public class GVRMaterial extends GVRHybridObject implements
                 return (number &= ~(1 << index));
             }
         }
+
+        public abstract static class LightMap {
+            public static final GVRMaterialShaderId ID = new GVRStockMaterialShaderId(
+                    11);
+        }
     };
 
     /**
@@ -219,6 +223,72 @@ public class GVRMaterial extends GVRHybridObject implements
 
     public void setMainTexture(Future<GVRTexture> texture) {
         setTexture(MAIN_TEXTURE, texture);
+    }
+
+    /**
+     * Set the baked light map texture
+     *
+     * @param texture
+     *            Texture with baked light map
+     */
+    public void setLightMapTexture(GVRTexture texture) {
+        setTexture("lightmap_texture", texture);
+    }
+
+    /**
+     * Set the baked light map texture
+     *
+     * @param texture
+     *            Texture with baked light map
+     */
+    public void setLightMapTexture(Future<GVRTexture> texture) {
+        setTexture("lightmap_texture", texture);
+    }
+
+    /**
+     * Set the light map information(offset and scale) at UV space to
+     * map the light map texture to the mesh.
+     *
+     * @param lightMapInformation
+     *            Atlas information object with the offset and scale
+     * at UV space necessary to map the light map texture to the mesh.
+     */
+    public void setLightMapInfo(GVRAtlasInformation lightMapInformation) {
+        setTextureAtlasInfo("lightmap", lightMapInformation);
+    }
+
+    /**
+     * Set the light map information(offset and scale) at UV space to
+     * map the light map texture to the mesh.
+     *
+     * @param key
+     *            Prefix name of the uniform at light map shader:
+     *            ([key]_texture, [key]_offset and [key]_scale.
+     * @param lightMapInformation
+     *            Atlas information object with the offset and scale
+     * at UV space necessary to map the light map texture to the mesh.
+     */
+    public void setTextureAtlasInfo(String key, GVRAtlasInformation atlasInformation) {
+        setTextureAtlasInfo(key, atlasInformation.getOffset(), atlasInformation.getScale());
+    }
+
+    /**
+     * Set the light map information(offset and scale) at UV space to
+     * map the light map texture to the mesh.
+     *
+     * @param key
+     *            Prefix name of the uniform at light map shader:
+     *            ([key]_texture, [key]_offset and [key]_scale.
+     * @param offset
+     *            Array with x and y offset values at UV space
+     *            to map the 2D texture to the mesh.
+     * @param scale
+     *            Array with x and y scale values at UV space
+     *            to map the 2D texture to the mesh.
+     */
+    public void setTextureAtlasInfo(String key, float[] offset, float[] scale) {
+        setVec2(key + "_offset", offset[0], offset[1]);
+        setVec2(key + "_scale", scale[0], scale[1]);
     }
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncAtlasInfo.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncAtlasInfo.java
@@ -1,0 +1,79 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf.asynchronous;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gearvrf.GVRAtlasInformation;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Async resource loading: Atlas texture information.
+ *
+ * Parse the JSON file containing the atlas information for
+ * each mesh mapped at the atlas texture.
+ */
+abstract class AsyncAtlasInfo {
+
+    /**
+     * This method is a sync parse to the JSON stream of atlas information.
+     *
+     * @return List of atlas information.
+     */
+    public static List<GVRAtlasInformation> loadAtlasInformation(InputStream ins) {
+        try {
+            int size = ins.available();
+            byte[] buffer = new byte[size];
+
+            ins.read(buffer);
+
+            return loadAtlasInformation(new JSONArray(new String(buffer, "UTF-8")));
+        } catch (JSONException je) {
+            je.printStackTrace();
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+
+        return null;
+    }
+
+    private static List<GVRAtlasInformation> loadAtlasInformation(JSONArray jsonInfo) throws JSONException {
+        List<GVRAtlasInformation> list = new ArrayList<GVRAtlasInformation>();
+        int length = jsonInfo.length();
+
+        for (int i = 0; i < length; i++) {
+            if (jsonInfo.isNull(i))
+                continue;
+            list.add(parseAtlasInformation(jsonInfo.getJSONObject(i)));
+        }
+
+        return list;
+    }
+
+    private static GVRAtlasInformation parseAtlasInformation(JSONObject jsonObj) throws JSONException {
+        String name = jsonObj.getString("name");
+        float[] offset = {(float) jsonObj.getDouble("offset.x"), (float) jsonObj.getDouble("offset.y")};
+        float[] scale = {(float) jsonObj.getDouble("scale.x"), (float) jsonObj.getDouble("scale.y")};
+
+        return new GVRAtlasInformation(name, offset, scale);
+    }
+
+}

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/GVRAsynchronousResourceLoader.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/GVRAsynchronousResourceLoader.java
@@ -18,6 +18,7 @@ package org.gearvrf.asynchronous;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -30,6 +31,7 @@ import org.gearvrf.GVRAndroidResource;
 import org.gearvrf.GVRAndroidResource.BitmapTextureCallback;
 import org.gearvrf.GVRAndroidResource.CancelableCallback;
 import org.gearvrf.GVRAndroidResource.CompressedTextureCallback;
+import org.gearvrf.GVRAtlasInformation;
 import org.gearvrf.GVRBitmapTexture;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRCubemapTexture;
@@ -662,5 +664,15 @@ public class GVRAsynchronousResourceLoader {
         return AsyncBitmapTexture.decodeStream(stream,
                 AsyncBitmapTexture.glMaxTextureSize,
                 AsyncBitmapTexture.glMaxTextureSize, true, null, closeStream);
+    }
+
+    /**
+     * Load a atlas map information asynchronously.
+     *
+     * @param ins
+     *            JSON text stream
+     */
+    public static List<GVRAtlasInformation> loadAtlasInformation(InputStream ins) {
+        return AsyncAtlasInfo.loadAtlasInformation(ins);
     }
 }


### PR DESCRIPTION
Add a implementation of light map shader to render baked light map from Beast SDK.

I have tried to simplify this API to not add complexity to GearVRf. But further more
we could add support to apply different types of atlas texture to the scene, not just light map.
Because of this  I placed some methods with the prefix "[set,get]TextureAtlas" at Material class.
You may use latest updated branch  https://github.com/gearvrf/GearVRf-Demos/pull/15
to test it.

GearVRf-DCO-1.0-Signed-off-by: Ragner Magalhaes <ragner.n@samsung.com>