### PR TITLE
Fix AsyncResource loading from URL

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRContext.java
@@ -638,7 +638,34 @@ public abstract class GVRContext {
      *
      */
     public GVRSceneObject loadModelFromURL(String urlString) throws IOException {
-        return loadModelFromURL(urlString, GVRImportSettings.getRecommendedSettings());
+        return loadModelFromURL(urlString, false);
+    }
+
+    /**
+     * Simple, high-level method to load a scene object {@link GVRModelSceneObject} from
+     * a 3D model from a URL with an option to store it into local file cache for future use.
+     *
+     * @param urlString
+     *            A URL string pointing to where the model file is located.
+     *
+     * @param cacheEnabled
+     *           An option that a developer can choose for the loading process for the trade off 
+     *           between performance and consistency(or security):
+     *           True: Download and store the file locally in this app's cache directory and
+     *                  load from the cache in future uses;
+     *           false: Don't keep local copy and only do online streaming for loading everytime
+     *           
+     * @return A {@link GVRModelSceneObject} that contains the meshes with textures and bones
+     * and animations.
+     *
+     * @throws IOException
+     *             File does not exist or cannot be read
+     *
+     */
+    public GVRSceneObject loadModelFromURL(String urlString, boolean cacheEnabled) throws IOException {
+        return GVRImporter.loadJassimpModel(this, urlString,
+                GVRResourceVolume.VolumeType.NETWORK,
+                GVRImportSettings.getRecommendedSettings(), cacheEnabled);
     }
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/GVRResourceVolume.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRResourceVolume.java
@@ -38,6 +38,7 @@ public class GVRResourceVolume {
     protected GVRContext gvrContext;
     protected VolumeType volumeType;
     protected String defaultPath;
+    protected boolean enableUrlLocalCache = false;
 
     /*package*/ GVRResourceVolume(GVRContext gvrContext, VolumeType volume) {
         this(gvrContext, volume, null);
@@ -49,10 +50,18 @@ public class GVRResourceVolume {
         this.defaultPath = defaultPath;
     }
 
+    /* package */ GVRResourceVolume(GVRContext gvrContext,
+            VolumeType volumeType, String defaultPath, boolean cacheEnabled) {
+        this(gvrContext, volumeType, defaultPath);
+        this.enableUrlLocalCache = cacheEnabled;
+    }
+
     /**
-     * Opens a file from the volume. The filePath is relative to the defaultPath.
+     * Opens a file from the volume. The filePath is relative to the
+     * defaultPath.
      *
-     * @param filePath          File path of the resource to open.
+     * @param filePath
+     *            File path of the resource to open.
      *
      * @throws IOException
      */
@@ -76,7 +85,8 @@ public class GVRResourceVolume {
             return new GVRAndroidResource(getFullPath(linuxPath, defaultPath, filePath));
 
         case NETWORK:
-            return new GVRAndroidResource(getFullURL(defaultPath, filePath));
+            return new GVRAndroidResource(gvrContext,
+                    getFullURL(defaultPath, filePath), enableUrlLocalCache);
 
         default:
             throw new IOException(String.format("Unrecognized volumeType %s", volumeType));


### PR DESCRIPTION
When a resource is coming from URL, the decoding in AsyncBitmapTexture is not stable and sometimes fails due to OOM error
even the inSampleSize is correctly set to downgrade the source file.
The root cause is the original java BufferInputStream used to wrap the url'ss inputStream  doesn't handle reset() properly
(it resets the offet of the internal buffer well) even the buffer provided is big enough to hold the resource we use in the
failed cases (possibly due to the internal buffer is cleared when resetting the offet).
This change provides a URLBufferedInputStream that resets the http connection everytime we do a reset to that inputStream,
preventing the incorrect offset in the http connection.
In addition, this change also provides an option to resouce loading api to choose between
1. only use internet streaming, and
2. download the resource in local cache,
so that the developer has a much more flexibility to control the consistency vs performance when
doing the resource loading.