### PR TITLE
Refactor Throttler for dependency injection, type checking and readability

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncBitmapTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncBitmapTexture.java
@@ -15,8 +15,11 @@
 
 package org.gearvrf.asynchronous;
 
-import static android.opengl.GLES20.*;
-import static org.gearvrf.utility.Threads.*;
+import static android.opengl.GLES20.GL_MAX_TEXTURE_SIZE;
+import static android.opengl.GLES20.GL_NO_ERROR;
+import static android.opengl.GLES20.glGetError;
+import static android.opengl.GLES20.glGetIntegerv;
+import static org.gearvrf.utility.Threads.threadId;
 
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
@@ -24,12 +27,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.gearvrf.GVRAndroidResource;
-import org.gearvrf.GVRAndroidResource.BitmapTextureCallback;
 import org.gearvrf.GVRAndroidResource.CancelableCallback;
 import org.gearvrf.GVRBitmapTexture;
 import org.gearvrf.GVRContext;
-import org.gearvrf.GVRHybridObject;
-import org.gearvrf.GVRTexture;
 import org.gearvrf.asynchronous.Throttler.AsyncLoader;
 import org.gearvrf.asynchronous.Throttler.AsyncLoaderFactory;
 import org.gearvrf.asynchronous.Throttler.GlConverter;
@@ -41,9 +41,16 @@ import org.gearvrf.utility.Threads;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.Context;
-import android.graphics.*;
+import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
+import android.graphics.BitmapFactory;
 import android.graphics.BitmapFactory.Options;
+import android.graphics.BitmapRegionDecoder;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Point;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.view.Display;
 import android.view.WindowManager;
 
@@ -58,24 +65,52 @@ import android.view.WindowManager;
  * 
  * @since 1.6.1
  */
-abstract class AsyncBitmapTexture {
+class AsyncBitmapTexture {
 
     /*
      * The API
      */
 
     static void loadTexture(GVRContext gvrContext,
-            BitmapTextureCallback callback, GVRAndroidResource resource,
-            int priority) {
-        Throttler.registerCallback(gvrContext, TEXTURE_CLASS, callback,
+            CancelableCallback<GVRBitmapTexture> callback,
+            GVRAndroidResource resource, int priority) {
+        AsyncManager.get().getScheduler().registerCallback(gvrContext, TEXTURE_CLASS, callback,
                 resource, priority);
     }
 
-    static void loadTexture(GVRContext gvrContext,
-            CancelableCallback<GVRTexture> callback,
-            GVRAndroidResource resource, int priority) {
-        Throttler.registerCallback(gvrContext, TEXTURE_CLASS, callback,
-                resource, priority);
+    /*
+     * Singleton
+     */
+    private static AsyncBitmapTexture sInstance;
+
+    /**
+     * Gets the {@link AsyncBitmapTexture} singleton for loading bitmap textures.
+     * @return The {@link AsyncBitmapTexture} singleton.
+     */
+    public static AsyncBitmapTexture get() {
+        if (sInstance != null) {
+            return sInstance;
+        }
+
+        synchronized (AsyncBitmapTexture.class) {
+            sInstance = new AsyncBitmapTexture();
+        }
+
+        return sInstance;
+    }
+
+    private AsyncBitmapTexture() {
+        AsyncManager.get().registerDatatype(TEXTURE_CLASS,
+                new AsyncLoaderFactory<GVRBitmapTexture, Bitmap>() {
+            @Override
+            AsyncLoader<GVRBitmapTexture, Bitmap> threadProc(GVRContext gvrContext,
+                    GVRAndroidResource request,
+                    CancelableCallback<GVRBitmapTexture> callback,
+                    int priority) {
+                return new AsyncLoadTextureResource(gvrContext,
+                        request, callback, priority);
+            }
+        });
     }
 
     /*
@@ -84,7 +119,7 @@ abstract class AsyncBitmapTexture {
 
     private static final String TAG = Log.tag(AsyncBitmapTexture.class);
 
-    private static final Class<? extends GVRHybridObject> TEXTURE_CLASS = GVRTexture.class;
+    private static final Class<GVRBitmapTexture> TEXTURE_CLASS = GVRBitmapTexture.class;
 
     /** Ridiculous amounts of detail about decodeFile() */
     protected static final boolean VERBOSE_DECODE = false;
@@ -291,19 +326,19 @@ abstract class AsyncBitmapTexture {
      */
 
     private static class AsyncLoadTextureResource extends
-            AsyncLoader<GVRTexture, Bitmap> {
+            AsyncLoader<GVRBitmapTexture, Bitmap> {
 
-        private static final GlConverter<GVRTexture, Bitmap> sConverter = new GlConverter<GVRTexture, Bitmap>() {
+        private static final GlConverter<GVRBitmapTexture, Bitmap> sConverter = new GlConverter<GVRBitmapTexture, Bitmap>() {
 
             @Override
-            public GVRTexture convert(GVRContext gvrContext, Bitmap bitmap) {
+            public GVRBitmapTexture convert(GVRContext gvrContext, Bitmap bitmap) {
                 return new GVRBitmapTexture(gvrContext, bitmap);
             }
         };
 
         protected AsyncLoadTextureResource(GVRContext gvrContext,
                 GVRAndroidResource request,
-                CancelableCallback<GVRHybridObject> callback, int priority) {
+                CancelableCallback<GVRBitmapTexture> callback, int priority) {
             super(gvrContext, sConverter, request, callback);
         }
 
@@ -314,21 +349,6 @@ abstract class AsyncBitmapTexture {
             resource.closeStream();
             return bitmap;
         }
-    }
-
-    static {
-        Throttler.registerDatatype(TEXTURE_CLASS,
-                new AsyncLoaderFactory<GVRTexture, Bitmap>() {
-
-                    @Override
-                    AsyncLoadTextureResource threadProc(GVRContext gvrContext,
-                            GVRAndroidResource request,
-                            CancelableCallback<GVRHybridObject> callback,
-                            int priority) {
-                        return new AsyncLoadTextureResource(gvrContext,
-                                request, callback, priority);
-                    }
-                });
     }
 
     /*

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCompressedCubemapTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCompressedCubemapTexture.java
@@ -24,7 +24,6 @@ import org.gearvrf.GVRAndroidResource;
 import org.gearvrf.GVRAndroidResource.CancelableCallback;
 import org.gearvrf.GVRCompressedCubemapTexture;
 import org.gearvrf.GVRContext;
-import org.gearvrf.GVRHybridObject;
 import org.gearvrf.GVRTexture;
 import org.gearvrf.asynchronous.Throttler.AsyncLoader;
 import org.gearvrf.asynchronous.Throttler.AsyncLoaderFactory;
@@ -39,18 +38,56 @@ import org.gearvrf.utility.FileNameUtils;
  *
  * @since 1.6.9
  */
-abstract class AsyncCompressedCubemapTexture {
+class AsyncCompressedCubemapTexture {
 
     /*
      * The API
      */
 
-    static void loadTexture(GVRContext gvrContext,
-            CancelableCallback<GVRTexture> callback,
+    void loadTexture(GVRContext gvrContext,
+            CancelableCallback<GVRCompressedCubemapTexture> callback,
             GVRAndroidResource resource, int priority, Map<String, Integer> map) {
         faceIndexMap = map;
-        Throttler.registerCallback(gvrContext, TEXTURE_CLASS, callback,
+        AsyncManager.get().getScheduler().registerCallback(gvrContext, TEXTURE_CLASS, callback,
                 resource, priority);
+    }
+
+    /*
+     * Singleton
+     */
+
+    private static AsyncCompressedCubemapTexture sInstance;
+
+    /**
+     * Gets the {@link AsyncCompressedCubemapTexture} singleton for loading bitmap textures.
+     * @return The {@link AsyncCompressedCubemapTexture} singleton.
+     */
+    public static AsyncCompressedCubemapTexture get() {
+        if (sInstance != null) {
+            return sInstance;
+        }
+
+        synchronized (AsyncBitmapTexture.class) {
+            sInstance = new AsyncCompressedCubemapTexture();
+        }
+
+        return sInstance;
+    }
+
+    private AsyncCompressedCubemapTexture() {
+        AsyncManager.get().registerDatatype(TEXTURE_CLASS,
+                new AsyncLoaderFactory<GVRCompressedCubemapTexture, CompressedTexture[]>() {
+
+                    @Override
+                    AsyncLoader<GVRCompressedCubemapTexture, CompressedTexture[]> threadProc(
+                            GVRContext gvrContext,
+                            GVRAndroidResource request,
+                            CancelableCallback<GVRCompressedCubemapTexture> cancelableCallback,
+                            int priority) {
+                        return new AsyncLoadCompressedCubemapTextureResource(gvrContext,
+                                request, cancelableCallback, priority);
+                    }
+                });
     }
 
     /*
@@ -59,7 +96,7 @@ abstract class AsyncCompressedCubemapTexture {
 
     // private static final String TAG = Log.tag(AsyncCubemapTexture.class);
 
-    private static final Class<? extends GVRHybridObject> TEXTURE_CLASS = GVRCompressedCubemapTexture.class;
+    private static final Class<GVRCompressedCubemapTexture> TEXTURE_CLASS = GVRCompressedCubemapTexture.class;
 
     /*
      * Asynchronous loader for compressed cubemap texture
@@ -89,7 +126,7 @@ abstract class AsyncCompressedCubemapTexture {
 
       protected AsyncLoadCompressedCubemapTextureResource(GVRContext gvrContext,
           GVRAndroidResource request,
-          CancelableCallback<GVRHybridObject> callback, int priority) {
+          CancelableCallback<GVRCompressedCubemapTexture> callback, int priority) {
         super(gvrContext, sConverter, request, callback);
       }
 
@@ -123,20 +160,6 @@ abstract class AsyncCompressedCubemapTexture {
         resource.closeStream();
         return textureArray;
       }
-    }
-
-    static {
-        Throttler.registerDatatype(TEXTURE_CLASS,
-                new AsyncLoaderFactory<GVRCompressedCubemapTexture, CompressedTexture[]>() {
-                  @Override
-                  AsyncLoadCompressedCubemapTextureResource threadProc(
-                      GVRContext gvrContext, GVRAndroidResource request,
-                      CancelableCallback<GVRHybridObject> callback,
-                      int priority) {
-                    return new AsyncLoadCompressedCubemapTextureResource(gvrContext,
-                            request, callback, priority);
-                 }
-               });
     }
 
     private static Map<String, Integer> faceIndexMap;

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCubemapTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCubemapTexture.java
@@ -24,8 +24,6 @@ import org.gearvrf.GVRAndroidResource;
 import org.gearvrf.GVRAndroidResource.CancelableCallback;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRCubemapTexture;
-import org.gearvrf.GVRHybridObject;
-import org.gearvrf.GVRTexture;
 import org.gearvrf.asynchronous.Throttler.AsyncLoader;
 import org.gearvrf.asynchronous.Throttler.AsyncLoaderFactory;
 import org.gearvrf.asynchronous.Throttler.GlConverter;
@@ -42,18 +40,50 @@ import android.graphics.BitmapFactory;
  * 
  * @since 1.6.9
  */
-abstract class AsyncCubemapTexture {
+class AsyncCubemapTexture {
 
     /*
      * The API
      */
 
-    static void loadTexture(GVRContext gvrContext,
-            CancelableCallback<GVRTexture> callback,
+    void loadTexture(GVRContext gvrContext,
+            CancelableCallback<GVRCubemapTexture> callback,
             GVRAndroidResource resource, int priority, Map<String, Integer> map) {
         faceIndexMap = map;
-        Throttler.registerCallback(gvrContext, TEXTURE_CLASS, callback,
+        AsyncManager.get().getScheduler().registerCallback(gvrContext, TEXTURE_CLASS, callback,
                 resource, priority);
+    }
+
+    /*
+     * Singleton
+     */
+
+    private static AsyncCubemapTexture sInstance;
+
+    /**
+     * Gets the {@link AsyncCubemapTexture} singleton for loading bitmap textures.
+     * @return The {@link AsyncCubemapTexture} singleton.
+     */
+    public static synchronized AsyncCubemapTexture get() {
+        if (sInstance == null) {
+            sInstance = new AsyncCubemapTexture();
+        }
+        return sInstance;
+    }
+
+    private AsyncCubemapTexture() {
+        AsyncManager.get().registerDatatype(TEXTURE_CLASS,
+                new AsyncLoaderFactory<GVRCubemapTexture, Bitmap[]>() {
+                    @Override
+                    AsyncLoader<GVRCubemapTexture, Bitmap[]> threadProc(
+                            GVRContext gvrContext,
+                            GVRAndroidResource request,
+                            CancelableCallback<GVRCubemapTexture> cancelableCallback,
+                            int priority) {
+                        return new AsyncLoadCubemapTextureResource(gvrContext,
+                                request, cancelableCallback, priority);
+                    }
+                });
     }
 
     /*
@@ -62,7 +92,7 @@ abstract class AsyncCubemapTexture {
 
     // private static final String TAG = Log.tag(AsyncCubemapTexture.class);
 
-    private static final Class<? extends GVRHybridObject> TEXTURE_CLASS = GVRCubemapTexture.class;
+    private static final Class<GVRCubemapTexture> TEXTURE_CLASS = GVRCubemapTexture.class;
 
     /*
      * Asynchronous loader for uncompressed cubemap
@@ -82,7 +112,7 @@ abstract class AsyncCubemapTexture {
 
         protected AsyncLoadCubemapTextureResource(GVRContext gvrContext,
                 GVRAndroidResource request,
-                CancelableCallback<GVRHybridObject> callback, int priority) {
+                CancelableCallback<GVRCubemapTexture> callback, int priority) {
             super(gvrContext, sConverter, request, callback);
         }
 
@@ -117,21 +147,6 @@ abstract class AsyncCubemapTexture {
             resource.closeStream();
             return bitmapArray;
         }
-    }
-
-    static {
-        Throttler.registerDatatype(TEXTURE_CLASS,
-                new AsyncLoaderFactory<GVRCubemapTexture, Bitmap[]>() {
-
-                    @Override
-                    AsyncLoadCubemapTextureResource threadProc(
-                            GVRContext gvrContext, GVRAndroidResource request,
-                            CancelableCallback<GVRHybridObject> callback,
-                            int priority) {
-                        return new AsyncLoadCubemapTextureResource(gvrContext,
-                                request, callback, priority);
-                    }
-                });
     }
 
     private static Map<String, Integer> faceIndexMap;

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncManager.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncManager.java
@@ -1,0 +1,93 @@
+/* Copyright 2016 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf.asynchronous;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.gearvrf.GVRHybridObject;
+import org.gearvrf.asynchronous.Throttler.AsyncLoaderFactory;
+
+public class AsyncManager {
+    private static AsyncManager sInstance = new AsyncManager();
+
+    /**
+     * Gets the asynchronous manager.
+     * @return The asynchronous manager.
+     */
+    public static AsyncManager get() {
+        return sInstance;
+    }
+
+    /**
+     * Gets the current scheduler;
+     * @return The current scheduler object.
+     */
+    public Scheduler getScheduler() {
+        return mScheduler;
+    }
+
+    /**
+     * Sets the resource loading scheduler.
+     *
+     * @param scheduler
+     *         The scheduler object.
+     */
+    public void setScheduler(Scheduler scheduler) {
+        mScheduler = scheduler;
+    }
+
+    /**
+     * Loaders call this method to register themselves. This method can be called by
+     * loaders provided by the application.
+     *
+     * @param textureClass
+     *         The class the loader is responsible for loading.
+     *
+     * @param asyncLoaderFactory
+     *         The factory object.
+     */
+    public void registerDatatype(Class<? extends GVRHybridObject> textureClass,
+            AsyncLoaderFactory<? extends GVRHybridObject, ?> asyncLoaderFactory) {
+        mFactories.put(textureClass, asyncLoaderFactory);
+    }
+
+    Map<Class<? extends GVRHybridObject>, AsyncLoaderFactory<? extends GVRHybridObject, ?>> getFactories() {
+        return mFactories;
+    }
+
+    // The resource loading scheduler
+    private Scheduler mScheduler;
+
+    // Factories
+    private Map<Class<? extends GVRHybridObject>, AsyncLoaderFactory<? extends GVRHybridObject, ?>> mFactories;
+
+    private AsyncManager() {
+        // Make the static field available before this constructor returns
+        sInstance = this;
+
+        mFactories = new HashMap<Class<? extends GVRHybridObject>, AsyncLoaderFactory<? extends GVRHybridObject, ?>>(); 
+
+        // Setup default scheduler to Throttler
+        mScheduler = Throttler.get();
+
+        // Poke all loaders to get them registered.
+        AsyncBitmapTexture.get();
+        AsyncCubemapTexture.get();
+        AsyncCompressedCubemapTexture.get();
+        AsyncMesh.get();
+    }
+}

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncMesh.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncMesh.java
@@ -18,7 +18,6 @@ package org.gearvrf.asynchronous;
 import org.gearvrf.GVRAndroidResource;
 import org.gearvrf.GVRAndroidResource.CancelableCallback;
 import org.gearvrf.GVRContext;
-import org.gearvrf.GVRHybridObject;
 import org.gearvrf.GVRMesh;
 import org.gearvrf.asynchronous.Throttler.AsyncLoader;
 import org.gearvrf.asynchronous.Throttler.AsyncLoaderFactory;
@@ -30,7 +29,7 @@ import org.gearvrf.utility.Log;
  * 
  * @since 1.6.2
  */
-abstract class AsyncMesh {
+class AsyncMesh {
 
     @SuppressWarnings("unused")
     private static final String TAG = Log.tag(AsyncMesh.class);
@@ -39,11 +38,47 @@ abstract class AsyncMesh {
      * The API
      */
 
-    static void loadMesh(GVRContext gvrContext,
+    void loadMesh(GVRContext gvrContext,
             CancelableCallback<GVRMesh> callback, GVRAndroidResource resource,
             int priority) {
-        Throttler.registerCallback(gvrContext, MESH_CLASS, callback, resource,
+        AsyncManager.get().getScheduler().registerCallback(gvrContext, MESH_CLASS, callback, resource,
                 priority);
+    }
+
+    /*
+     * Singleton
+     */
+
+    private static AsyncMesh sInstance;
+
+    /**
+     * Gets the {@link AsyncMesh} singleton for loading bitmap textures.
+     * @return The {@link AsyncMesh} singleton.
+     */
+    public static AsyncMesh get() {
+        if (sInstance != null) {
+            return sInstance;
+        }
+
+        synchronized (AsyncBitmapTexture.class) {
+            sInstance = new AsyncMesh();
+        }
+
+        return sInstance;
+    }
+
+    private AsyncMesh() {
+        AsyncManager.get().registerDatatype(MESH_CLASS,
+                new AsyncLoaderFactory<GVRMesh, GVRMesh>() {
+                    @Override
+                    AsyncLoader<GVRMesh, GVRMesh> threadProc(
+                            GVRContext gvrContext,
+                            GVRAndroidResource request,
+                            CancelableCallback<GVRMesh> callback,
+                            int priority) {
+                        return new AsyncLoadMesh(gvrContext, request, callback, priority);
+                    }
+                });
     }
 
     /*
@@ -60,7 +95,7 @@ abstract class AsyncMesh {
         };
 
         AsyncLoadMesh(GVRContext gvrContext, GVRAndroidResource request,
-                CancelableCallback<GVRHybridObject> callback, int priority) {
+                CancelableCallback<GVRMesh> callback, int priority) {
             super(gvrContext, sConverter, request, callback);
         }
 
@@ -70,21 +105,5 @@ abstract class AsyncMesh {
         }
     }
 
-    private static final Class<? extends GVRHybridObject> MESH_CLASS = GVRMesh.class;
-
-    static {
-        Throttler.registerDatatype(MESH_CLASS,
-                new AsyncLoaderFactory<GVRMesh, GVRMesh>() {
-
-                    @Override
-                    AsyncLoader<GVRMesh, GVRMesh> threadProc(
-                            GVRContext gvrContext, GVRAndroidResource request,
-                            CancelableCallback<GVRHybridObject> callback,
-                            int priority) {
-                        return new AsyncLoadMesh(gvrContext, request, callback,
-                                priority);
-                    }
-                });
-    }
-
+    private static final Class<GVRMesh> MESH_CLASS = GVRMesh.class;
 }

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/GVRAsynchronousResourceLoader.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/GVRAsynchronousResourceLoader.java
@@ -620,7 +620,7 @@ public class GVRAsynchronousResourceLoader {
      * This is a wrapper to convert {@code CancelableCallback<S>} to {@code CancelableCallback<T>}
      * where T extends S.
      */
-    static class CancelableCallbackWrapper<T extends S, S extends GVRHybridObject>
+    static class CancelableCallbackWrapper<S extends GVRHybridObject, T extends S>
     implements CancelableCallback<T> {
         private CancelableCallback<S> wrapped_;
 
@@ -643,10 +643,10 @@ public class GVRAsynchronousResourceLoader {
             return wrapped_.stillWanted(androidResource);
         }
 
-        public static <T extends S, S extends GVRHybridObject> CancelableCallbackWrapper<T, S> wrap(
+        public static <S extends GVRHybridObject, T extends S> CancelableCallbackWrapper<S, T> wrap(
                 Class<T> targetClass,
                 CancelableCallback<S> wrapped) {
-            return new CancelableCallbackWrapper<T, S>(wrapped);
+            return new CancelableCallbackWrapper<S, T>(wrapped);
         }
     }
 

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/GVRAsynchronousResourceLoader.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/GVRAsynchronousResourceLoader.java
@@ -31,6 +31,7 @@ import org.gearvrf.GVRAndroidResource.BitmapTextureCallback;
 import org.gearvrf.GVRAndroidResource.CancelableCallback;
 import org.gearvrf.GVRAndroidResource.CompressedTextureCallback;
 import org.gearvrf.GVRBitmapTexture;
+import org.gearvrf.GVRCompressedCubemapTexture;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRCubemapTexture;
 import org.gearvrf.GVRHybridObject;
@@ -206,8 +207,9 @@ public class GVRAsynchronousResourceLoader {
         validatePriorityCallbackParameters(gvrContext, callback, resource,
                 priority);
 
-        final GVRTexture cached = textureCache == null ? null : textureCache
-                .get(resource);
+        final GVRBitmapTexture cached = textureCache == null
+                ? null
+                : (GVRBitmapTexture) textureCache.get(resource);
         if (cached != null) {
             gvrContext.runOnGlThread(new Runnable() {
 
@@ -219,7 +221,8 @@ public class GVRAsynchronousResourceLoader {
         } else {
             BitmapTextureCallback actualCallback = textureCache == null ? callback
                     : ResourceCache.wrapCallback(textureCache, callback);
-            AsyncBitmapTexture.loadTexture(gvrContext, actualCallback,
+            AsyncBitmapTexture.loadTexture(gvrContext,
+                    CancelableCallbackWrapper.wrap(GVRBitmapTexture.class, actualCallback),
                     resource, priority);
         }
     }
@@ -305,10 +308,12 @@ public class GVRAsynchronousResourceLoader {
                         } else {
                             // We don't have a compressed texture: pass to
                             // AsyncBitmapTexture code
-                            CancelableCallback<GVRTexture> actualCallback = textureCache == null ? callback
+                            CancelableCallback<GVRTexture> actualCallback = textureCache == null
+                                    ? callback
                                     : textureCache.wrapCallback(callback);
                             AsyncBitmapTexture.loadTexture(gvrContext,
-                                    actualCallback, resource, priority);
+                                    CancelableCallbackWrapper.wrap(GVRBitmapTexture.class, actualCallback),
+                                    resource, priority);
                         }
                     } catch (Exception e) {
                         callback.failed(e, resource);
@@ -408,7 +413,8 @@ public class GVRAsynchronousResourceLoader {
         } else {
             FutureResource<GVRTexture> result = new FutureResource<GVRTexture>();
 
-            AsyncCubemapTexture.loadTexture(gvrContext, result.callback,
+            AsyncCubemapTexture.get().loadTexture(gvrContext,
+                    CancelableCallbackWrapper.wrap(GVRCubemapTexture.class, result.callback),
                     resource, priority, faceIndexMap);
 
             return result;
@@ -450,7 +456,8 @@ public class GVRAsynchronousResourceLoader {
         } else {
             FutureResource<GVRTexture> result = new FutureResource<GVRTexture>();
 
-            AsyncCompressedCubemapTexture.loadTexture(gvrContext, result.callback,
+            AsyncCompressedCubemapTexture.get().loadTexture(gvrContext,
+                    CancelableCallbackWrapper.wrap(GVRCompressedCubemapTexture.class, result.callback),
                     resource, priority, faceIndexMap);
 
             return result;
@@ -491,7 +498,7 @@ public class GVRAsynchronousResourceLoader {
         validatePriorityCallbackParameters(gvrContext, callback, resource,
                 priority);
 
-        AsyncMesh.loadMesh(gvrContext, callback, resource, priority);
+        AsyncMesh.get().loadMesh(gvrContext, callback, resource, priority);
     }
 
     /**
@@ -607,6 +614,40 @@ public class GVRAsynchronousResourceLoader {
             return pending == false;
         }
 
+    }
+
+    /*
+     * This is a wrapper to convert {@code CancelableCallback<S>} to {@code CancelableCallback<T>}
+     * where T extends S.
+     */
+    static class CancelableCallbackWrapper<T extends S, S extends GVRHybridObject>
+    implements CancelableCallback<T> {
+        private CancelableCallback<S> wrapped_;
+
+        private CancelableCallbackWrapper(CancelableCallback<S> wrapped) {
+            wrapped_ = wrapped;
+        }
+
+        @Override
+        public void loaded(T resource, GVRAndroidResource androidResource) {
+            wrapped_.loaded(resource, androidResource);
+        }
+
+        @Override
+        public void failed(Throwable t, GVRAndroidResource androidResource) {
+            wrapped_.failed(t, androidResource);
+        }
+
+        @Override
+        public boolean stillWanted(GVRAndroidResource androidResource) {
+            return wrapped_.stillWanted(androidResource);
+        }
+
+        public static <T extends S, S extends GVRHybridObject> CancelableCallbackWrapper<T, S> wrap(
+                Class<T> targetClass,
+                CancelableCallback<S> wrapped) {
+            return new CancelableCallbackWrapper<T, S>(wrapped);
+        }
     }
 
     private static <T extends GVRHybridObject> void validateCallbackParameters(

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/Scheduler.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/Scheduler.java
@@ -1,0 +1,32 @@
+package org.gearvrf.asynchronous;
+
+import org.gearvrf.GVRAndroidResource;
+import org.gearvrf.GVRAndroidResource.CancelableCallback;
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRHybridObject;
+import org.gearvrf.asynchronous.Throttler.AsyncLoaderFactory;
+
+/**
+ * This is the interface for a scheduler which executes tasks for loading GVRf resources.
+ */
+public interface Scheduler {
+    /**
+     * Schedule a load request with a callback.
+     *
+     * @param gvrContext
+     *         The GVRf Context object.
+     * @param outClass
+     *         The class object of a resource to be loaded.
+     * @param callback
+     *         A callback object to be notified when loading is done or failed.
+     * @param request
+     *         A {@link GVRAndroidResource} object pointing to the resource to be loaded.
+     * @param priority
+     *         The priority of the task.
+     */
+    <OUTPUT extends GVRHybridObject, INTER>
+    void registerCallback(GVRContext gvrContext,
+            Class<OUTPUT> outClass,
+            CancelableCallback<OUTPUT> callback,
+            GVRAndroidResource request, int priority);
+}

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/SyncScheduler.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/SyncScheduler.java
@@ -1,0 +1,69 @@
+package org.gearvrf.asynchronous;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.gearvrf.GVRAndroidResource;
+import org.gearvrf.GVRAndroidResource.CancelableCallback;
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRHybridObject;
+import org.gearvrf.asynchronous.Throttler.AsyncLoader;
+import org.gearvrf.asynchronous.Throttler.AsyncLoaderFactory;
+import org.gearvrf.utility.Log;
+
+/**
+ * This is an implementation of the resource loading scheduler, which
+ * blocks until each resource is loaded. It is mainly used as an example
+ * of implementing a scheduler and for debugging purposes.
+ */
+public class SyncScheduler implements Scheduler {
+    private static final String TAG = Log.tag(SyncScheduler.class);
+
+    /*
+     * Singleton
+     */
+
+    private static SyncScheduler mInstance;
+
+    public static SyncScheduler get() {
+        if (mInstance != null) {
+            return mInstance;
+        }
+
+        synchronized (SyncScheduler.class) {
+            mInstance = new SyncScheduler();
+        }
+
+        return mInstance;
+    }
+
+    private SyncScheduler() {
+    }
+
+    /*
+     * Scheduler
+     */
+
+    @Override
+    public <OUTPUT extends GVRHybridObject, INTER> void registerCallback(GVRContext gvrContext,
+            Class<OUTPUT> outClass,
+            CancelableCallback<OUTPUT> callback, GVRAndroidResource request,
+            int priority) {
+        @SuppressWarnings("unchecked")
+        AsyncLoaderFactory<OUTPUT, INTER> factory = (AsyncLoaderFactory<OUTPUT, INTER>) getFactories().get(outClass);
+        if (factory == null) {
+            callback.failed(new IOException("Cannot find loader factory"), request);
+            return;
+        }
+
+        AsyncLoader<OUTPUT, INTER> loader =
+                factory.threadProc(gvrContext, request, callback, priority);
+
+        // Run the loader synchronously
+        loader.run();
+    }
+
+    private Map<Class<? extends GVRHybridObject>, AsyncLoaderFactory<? extends GVRHybridObject, ?>> getFactories() {
+        return AsyncManager.get().getFactories();
+    }
+}

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/Throttler.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/Throttler.java
@@ -15,21 +15,21 @@
 
 package org.gearvrf.asynchronous;
 
-import static org.gearvrf.utility.Threads.*;
+import static org.gearvrf.utility.Threads.VERBOSE_SCHEDULING;
+import static org.gearvrf.utility.Threads.threadId;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.gearvrf.GVRAndroidResource;
+import org.gearvrf.GVRAndroidResource.Callback;
+import org.gearvrf.GVRAndroidResource.CancelableCallback;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRHybridObject;
 import org.gearvrf.GVRMesh;
-import org.gearvrf.GVRAndroidResource.Callback;
-import org.gearvrf.GVRAndroidResource.CancelableCallback;
 import org.gearvrf.utility.Exceptions;
 import org.gearvrf.utility.Log;
 import org.gearvrf.utility.RuntimeAssertion;
@@ -47,23 +47,39 @@ import android.util.SparseArray;
  * 
  * @since 1.6.2
  */
-abstract class Throttler {
-
+class Throttler implements Scheduler {
     /*
      * The API
      */
 
-    static void registerDatatype(Class<? extends GVRHybridObject> targetClass,
-            AsyncLoaderFactory<? extends GVRHybridObject, ?> factory) {
-        requests.registerDatatype(targetClass, factory);
-    }
-
-    static void registerCallback(GVRContext gvrContext,
-            Class<? extends GVRHybridObject> outClass,
-            CancelableCallback<? extends GVRHybridObject> callback,
-            GVRAndroidResource request, int priority) {
+    @Override
+    public <OUTPUT extends GVRHybridObject, INTER> void registerCallback(
+            GVRContext gvrContext, Class<OUTPUT> outClass,
+            CancelableCallback<OUTPUT> callback, GVRAndroidResource request,
+            int priority) {
         requests.registerCallback(gvrContext, outClass, callback, request,
                 priority);
+    }
+
+    /*
+     * Singleton
+     */
+
+    private static Throttler mInstance;
+
+    public static Throttler get() {
+        if (mInstance != null) {
+            return mInstance;
+        }
+
+        synchronized (Throttler.class) {
+            mInstance = new Throttler();
+        }
+
+        return mInstance;
+    }
+
+    private Throttler() {
     }
 
     /*
@@ -156,12 +172,12 @@ abstract class Throttler {
         protected final GVRContext gvrContext;
         protected final GVRAndroidResource resource;
         protected final GlConverter<OUTPUT, INTERMEDIATE> converter;
-        protected final CancelableCallback<GVRHybridObject> callback;
+        protected final CancelableCallback<OUTPUT> callback;
 
         protected AsyncLoader(GVRContext gvrContext,
                 GlConverter<OUTPUT, INTERMEDIATE> converter,
                 GVRAndroidResource request,
-                CancelableCallback<GVRHybridObject> callback) {
+                CancelableCallback<OUTPUT> callback) {
             this.gvrContext = gvrContext;
             this.converter = converter;
             this.resource = request;
@@ -239,7 +255,7 @@ abstract class Throttler {
         /** Create an AsyncLoader of the right type */
         abstract AsyncLoader<OUTPUT, INTERMEDIATE> threadProc(
                 GVRContext gvrContext, GVRAndroidResource request,
-                CancelableCallback<GVRHybridObject> callback, int priority);
+                CancelableCallback<OUTPUT> cancelableCallback, int priority);
     }
 
     /*
@@ -248,7 +264,7 @@ abstract class Throttler {
 
     // TODO I don't THINK we need to reset PendingRequests on restart, but I may
     // be wrong ....
-    private static final PendingRequests requests = new PendingRequests();
+    private final PendingRequests requests = new PendingRequests();
 
     /**
      * This is the 'heart' of the throttler.
@@ -265,19 +281,12 @@ abstract class Throttler {
 
         private static final String TAG = Log.tag(PendingRequests.class);
 
-        private final Map<GVRAndroidResource, PendingRequest> pendingRequests = new ConcurrentHashMap<GVRAndroidResource, PendingRequest>();
+        private final Map<GVRAndroidResource, PendingRequest<? extends GVRHybridObject, ?>> pendingRequests =
+                new ConcurrentHashMap<GVRAndroidResource, PendingRequest<? extends GVRHybridObject, ?>>();
 
-        private final Map< //
-
-        Class<? extends GVRHybridObject>, //
-        AsyncLoaderFactory<? extends GVRHybridObject, ?>
-
-        > threadFactories = new HashMap< //
-
-        Class<? extends GVRHybridObject>, //
-        AsyncLoaderFactory<? extends GVRHybridObject, ?> //
-
-        >();
+        private Map<Class<? extends GVRHybridObject>, AsyncLoaderFactory<? extends GVRHybridObject, ?>> getFactories() {
+            return AsyncManager.get().getFactories();
+        }
 
         private final ThreadLimiter<PriorityCancelable> deviceThreadLimiter = new ThreadLimiter<PriorityCancelable>(
                 DECODE_THREAD_LIMIT,
@@ -285,14 +294,9 @@ abstract class Throttler {
                 /* Don't exceed DECODE_THREAD_LIMIT when a download gets wedged */
                 Integer.MAX_VALUE);
 
-        void registerDatatype(Class<? extends GVRHybridObject> targetClass,
-                AsyncLoaderFactory<? extends GVRHybridObject, ?> factory) {
-            threadFactories.put(targetClass, factory);
-        }
-
-        void registerCallback(GVRContext gvrContext,
-                Class<? extends GVRHybridObject> outClass,
-                CancelableCallback<? extends GVRHybridObject> callback,
+        <OUTPUT extends GVRHybridObject, INTER> void registerCallback(GVRContext gvrContext,
+                Class<OUTPUT> outClass,
+                CancelableCallback<OUTPUT> callback,
                 GVRAndroidResource request, int priority) {
             if (VERBOSE_SCHEDULING) {
                 Log.d(TAG, "registerCallback(%s, %s)", request, callback);
@@ -311,7 +315,9 @@ abstract class Throttler {
             ThreadLimiter<PriorityCancelable> threadLimiter = deviceThreadLimiter;
 
             synchronized (pendingRequests) {
-                PendingRequest pending = pendingRequests.get(request);
+                @SuppressWarnings("unchecked")
+                PendingRequest<OUTPUT, INTER> pending =
+                        (PendingRequest<OUTPUT, INTER>) pendingRequests.get(request);
 
                 if (pending != null) {
                     if (request == pending.request) {
@@ -335,7 +341,7 @@ abstract class Throttler {
                     // There is no current request for this resource. Create a
                     // new PendingRequest, using a threadFactory to create the
                     // appropriate AsyncLoader.
-                    pending = new PendingRequest(gvrContext, request, callback,
+                    pending = new PendingRequest<OUTPUT,INTER>(gvrContext, request, callback,
                             priority, outClass);
 
                     pendingRequests.put(request, pending);
@@ -349,34 +355,37 @@ abstract class Throttler {
             }
         }
 
-        private class PendingRequest implements
-                CancelableCallback<GVRHybridObject>, PriorityCancelable {
+        private class PendingRequest<OUTPUT extends GVRHybridObject, INTER> implements
+                CancelableCallback<OUTPUT>, PriorityCancelable {
 
             private final String TAG = Log.tag(PendingRequest.class);
 
             private final int EMPTY_LIST = GVRContext.LOWEST_PRIORITY - 1;
 
             private final GVRAndroidResource request;
-            private final List<CancelableCallback<? extends GVRHybridObject>> callbacks = new ArrayList<CancelableCallback<? extends GVRHybridObject>>(
-                    1);
+            private final List<CancelableCallback<OUTPUT>> callbacks = new ArrayList<CancelableCallback<OUTPUT>>(1);
             private final Cancelable cancelable;
             private int priority = EMPTY_LIST;
             private int highestPriority = priority;
 
             public PendingRequest(GVRContext gvrContext,
                     GVRAndroidResource request,
-                    CancelableCallback<? extends GVRHybridObject> callback,
-                    int priority, Class<? extends GVRHybridObject> outClass) {
+                    CancelableCallback<OUTPUT> callback,
+                    int priority, Class<OUTPUT> outClass) {
                 this.request = request;
                 addCallback(callback, priority);
                 updatePriority();
 
-                cancelable = threadFactories.get(outClass).threadProc(
-                        gvrContext, request, this, priority);
+                @SuppressWarnings("unchecked")
+                AsyncLoaderFactory<OUTPUT, INTER> factory =
+                        (AsyncLoaderFactory<OUTPUT, INTER>) getFactories().get(outClass);
+
+                cancelable = factory.threadProc(
+                        gvrContext, request, PendingRequest.this, priority);
             }
 
             public void addCallback(
-                    CancelableCallback<? extends GVRHybridObject> callback,
+                    CancelableCallback<OUTPUT> callback,
                     int priority) {
                 synchronized (callbacks) {
                     callbacks.add(callback);
@@ -386,9 +395,8 @@ abstract class Throttler {
                 }
             }
 
-            @SuppressWarnings("unchecked" /* shameful ... */)
             @Override
-            public void loaded(GVRHybridObject gvrResource,
+            public void loaded(OUTPUT gvrResource,
                     GVRAndroidResource androidResource) {
                 if (VERBOSE_SCHEDULING) {
                     Log.d(TAG, "%s loaded(%s, %s), thread %d: request %s",
@@ -399,7 +407,7 @@ abstract class Throttler {
                 // gvrResource may be null, if we caught an exception in
                 // AsyncLoadImage.run)
                 if (gvrResource != null) {
-                    List<CancelableCallback<? extends GVRHybridObject>> listeners = new ArrayList<CancelableCallback<? extends GVRHybridObject>>();
+                    List<CancelableCallback<OUTPUT>> listeners = new ArrayList<CancelableCallback<OUTPUT>>();
                     do {
                         /*
                          * Copy the list of listeners then clear it, so any
@@ -422,7 +430,7 @@ abstract class Throttler {
                             callbacks.clear();
                         }
 
-                        for (CancelableCallback<? extends GVRHybridObject> callback : listeners) {
+                        for (CancelableCallback<OUTPUT> callback : listeners) {
                             /*
                              * Each callback in its own exception frame,
                              * 
@@ -445,8 +453,7 @@ abstract class Throttler {
                                  * app's callback; there does not *seem* to be
                                  * any way to avoid this.
                                  */
-                                ((CancelableCallback<GVRHybridObject>) callback)
-                                        .loaded(gvrResource, androidResource);
+                                callback.loaded(gvrResource, androidResource);
                             } catch (Exception e) {
                                 e.printStackTrace();
                             }
@@ -461,7 +468,11 @@ abstract class Throttler {
                             "ready(), thread %d: clearing pending request for request %s",
                             threadId(), request);
                 }
-                PendingRequest removed = pendingRequests.remove(request);
+
+                @SuppressWarnings("unchecked")
+                PendingRequest<OUTPUT, INTER> removed =
+                        (PendingRequest<OUTPUT, INTER>) pendingRequests.remove(request);
+
                 if (RUNTIME_ASSERTIONS) {
                     if (removed != this) {
                         throw new RuntimeAssertion(
@@ -479,7 +490,7 @@ abstract class Throttler {
 
             @Override
             public boolean stillWanted(GVRAndroidResource request) {
-                for (CancelableCallback<? extends GVRHybridObject> callback : callbacks) {
+                for (CancelableCallback<OUTPUT> callback : callbacks) {
                     if (callback.stillWanted(request)) {
                         return true;
                     }
@@ -499,9 +510,9 @@ abstract class Throttler {
             @Override
             public boolean stillWanted() {
                 synchronized (callbacks) {
-                    List<CancelableCallback<? extends GVRHybridObject>> canceled = new ArrayList<CancelableCallback<? extends GVRHybridObject>>(
+                    List<CancelableCallback<OUTPUT>> canceled = new ArrayList<CancelableCallback<OUTPUT>>(
                             callbacks.size());
-                    for (CancelableCallback<? extends GVRHybridObject> callback : callbacks) {
+                    for (CancelableCallback<OUTPUT> callback : callbacks) {
                         if (callback.stillWanted(request) != true) {
                             canceled.add(callback);
                         }
@@ -515,8 +526,9 @@ abstract class Throttler {
                             Log.d(TAG, "Canceling %s, request %s", this,
                                     request);
                         }
-                        PendingRequest removed = pendingRequests
-                                .remove(request);
+                        @SuppressWarnings("unchecked")
+                        PendingRequest<OUTPUT, INTER> removed =
+                                (PendingRequest<OUTPUT, INTER>) pendingRequests.remove(request);
                         if (removed != this) {
                             throw new RuntimeAssertion(
                                     "removed = %s, this = %s", removed, this);

--- a/GVRf/Framework/src/org/gearvrf/utility/Threads.java
+++ b/GVRf/Framework/src/org/gearvrf/utility/Threads.java
@@ -462,6 +462,7 @@ public abstract class Threads {
                                 threadId(), threadManager, threadProc);
                     }
                 } else {
+                    // precondition: size == 0 || policyOp != PUT
                     // Update policy within synchronized block
                     switch (policyOp) {
                     case PUT:


### PR DESCRIPTION
Type inference is used in Throttler to avoid lots of type wildcards (e.g.,
? extends T). This allows static type checking, and avoids raw types and
unchecked casts. This refactoring makes the code more robust and more
readable.

Configurability is also improved. Currently, Throttler is hardcoded for loading
all resources. Though it is not a problem by itself, there are cases
where developers would like to use a different scheduling policy, or simply
load textures synchronously for development. In this patch, the API of the
Throttler is extracted as interface Scheduler, and the Scheduler is run-time
configurable. A sample scheduler SyncScheduler is provided, which loads
resources synchronously and can be used for debugging purposes.

Some static members and fields in the Throttler and Async* classes are
changed to non-static, and the classes are converted into Singletons. Therefore,
their initialization sequence can be better controlled. Now, they do not register
themselves until they are called by AsyncManager.