### PR TITLE
Fix crash in monoscopic view applications. The first problem was a ze…

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/jni/engine/renderer/renderer.cpp
@@ -194,7 +194,7 @@ void Renderer::renderCamera(Scene* scene, Camera* camera, int framebufferId,
 
     bool renderShadow = cameraLight; // TODO reader from scene;
 
-    if ((framebufferId != 0) && !renderShadow) {
+    if (!renderShadow) {
         renderCamera(scene, camera, framebufferId, viewportX, viewportY,
                 viewportWidth, viewportHeight, shader_manager,
                 post_effect_shader_manager, post_effect_render_texture_a,

--- a/GVRf/Framework/jni/objects/bounding_volume.cpp
+++ b/GVRf/Framework/jni/objects/bounding_volume.cpp
@@ -62,7 +62,10 @@ void BoundingVolume::expand(const glm::vec3 point) {
     }
 
     center_ = (min_corner_ + max_corner_) * 0.5f;
-    radius_ = glm::length(max_corner_ - min_corner_) * 0.5f;
+    if (min_corner_ == max_corner_)
+    	radius_ = 0;
+    else
+    	radius_ = glm::length(max_corner_ - min_corner_) * 0.5f;
 }
 
 /*


### PR DESCRIPTION
…ro value being passed to sqrt when computing the bounding volume. The second problem was a check for framebuffer id not zero in renderCamera which causes important code to be skipped in monoscopic view.
GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com