### PR TITLE
Fixed mesh check on scene objects for IO

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/SensorManager.java
+++ b/GVRf/Framework/src/org/gearvrf/SensorManager.java
@@ -75,15 +75,19 @@ class SensorManager {
         }
 
         // Well at least we are not comparing against all scene objects.
-        if (objectSensor != null && objectSensor.isEnabled() && object.hasMesh()) {
+        if (objectSensor != null && objectSensor.isEnabled()) {
 
             /**
              * Compare ray against the hierarchical bounding volume and then add
              * the children accordingly.
              */
             Vector3f ray = controller.getRay();
-            if (object.intersectsBoundingVolume(ORIGIN[0], ORIGIN[1], ORIGIN[2],
-                    ray.x, ray.y, ray.z)) {
+            if (false == object.intersectsBoundingVolume(ORIGIN[0], ORIGIN[1],
+                    ORIGIN[2], ray.x, ray.y, ray.z)) {                
+                return;
+            }
+
+            if (object.hasMesh()) {
                 float[] hitPoint = GVRPicker.pickSceneObjectAgainstBoundingBox(
                         object, ORIGIN[0], ORIGIN[1], ORIGIN[2], ray.x, ray.y,
                         ray.z);
@@ -96,13 +100,14 @@ class SensorManager {
                         objectSensor.setActive(controller, true);
                     }
                 }
+            }
 
-                for (GVRSceneObject child : object.getChildren()) {
-                    recurseSceneObject(controller, child, objectSensor,
-                            markActiveNodes);
-                }
+            for (GVRSceneObject child : object.getChildren()) {
+                recurseSceneObject(controller, child, objectSensor,
+                        markActiveNodes);
             }
         }
+
     }
 
     void addSensor(GVRBaseSensor sensor) {


### PR DESCRIPTION
Currently if an object does not have a mesh. All of its children
are ignored.

This fix now checks the bounding volume and then proceeds to
the children even if the parent object does not have a mesh.