### PR TITLE
Fixed problem with LOD culling

### DIFF
--- a/GVRf/Framework/jni/objects/scene_object.cpp
+++ b/GVRf/Framework/jni/objects/scene_object.cpp
@@ -425,7 +425,7 @@ int SceneObject::frustumCull(Camera *camera, const float frustum[6][4],
                     name_.c_str());
         }
 
-        return 3;
+        if (!using_lod_) return 3;
     }
 
     // 2. Skip the empty objects with no render data


### PR DESCRIPTION
Recent changes to frustumCull() broke LOD because culling exited if everything was inside the frustum instead of testing LOD children individually.

GearVRf-DCO-1.0-Signed-off-by Nola Donato nola.donato@samsung.com