### PR TITLE
Fix final frame in animation

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationController.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRAnimationController.java
@@ -1,0 +1,36 @@
+package org.gearvrf.animation.keyframe;
+
+public abstract class GVRAnimationController {
+    private static final float TOL = 1e-6f;
+    protected final GVRKeyFrameAnimation animation;
+
+    public GVRAnimationController(GVRKeyFrameAnimation animation) {
+        this.animation = animation;
+    }
+
+    /**
+     * Update animation to {@code timeInSeconds}. This function converts
+     * time to ticks and invokes {@link #animateImpl}.
+     */
+    public void animate(float timeInSeconds) {
+        float ticksPerSecond;
+        float timeInTicks;
+
+        if (animation.mTicksPerSecond != 0) {
+            ticksPerSecond = (float) animation.mTicksPerSecond;
+        } else {
+            ticksPerSecond = 25.0f;
+        }
+        timeInTicks = timeInSeconds * ticksPerSecond;
+
+        float animationTick = timeInTicks % (animation.mDurationTicks + TOL); // auto-repeat
+        animateImpl(animationTick);
+    }
+
+    /**
+     * Animate to a tick in the timeline.
+     * @param animationTick
+     *         The tick to animate to.
+     */
+    protected abstract void animateImpl(float animationTick);
+}

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRNodeAnimationController.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRNodeAnimationController.java
@@ -9,11 +9,9 @@ import org.joml.Matrix4f;
 /**
  * Controls node animation.
  */
-public class GVRNodeAnimationController {
+public class GVRNodeAnimationController extends GVRAnimationController {
     private static final String TAG = GVRNodeAnimationController.class.getSimpleName();
-
     protected GVRSceneObject sceneRoot;
-    protected GVRKeyFrameAnimation animation;
 
     protected class AnimationItem {
         GVRSceneObject target;
@@ -35,8 +33,8 @@ public class GVRNodeAnimationController {
      * @param animation The animation object.
      */
     public GVRNodeAnimationController(GVRSceneObject sceneRoot, GVRKeyFrameAnimation animation) {
+        super(animation);
         this.sceneRoot = sceneRoot;
-        this.animation = animation;
 
         animatedNodes = new ArrayList<AnimationItem>();
         if (animation != null) {
@@ -62,22 +60,13 @@ public class GVRNodeAnimationController {
     }
 
     /**
-     * Update node transforms at each animation step.
+     * Update node transforms to a tick.
+     * @param animationTick
+     *         The tick to animate to.
      */
-    public void animate(float timeInSeconds) {
-        float ticksPerSecond;
-        float timeInTicks;
-        Matrix4f[] animationTransform = null;
-
-        if (animation.mTicksPerSecond != 0) {
-            ticksPerSecond = (float) animation.mTicksPerSecond;
-        } else {
-            ticksPerSecond = 25.0f;
-        }
-        timeInTicks = timeInSeconds * ticksPerSecond;
-
-        float animationTime = timeInTicks % animation.mDurationTicks; // auto-repeat
-        animationTransform = animation.getTransforms(animationTime);
+    @Override
+    protected void animateImpl(float animationTick) {
+        Matrix4f[] animationTransform = animation.getTransforms(animationTick);
 
         for (AnimationItem item : animatedNodes) {
             item.target.getTransform().setModelMatrix(animationTransform[item.channelId]);

--- a/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRSkinningController.java
+++ b/GVRf/Framework/src/org/gearvrf/animation/keyframe/GVRSkinningController.java
@@ -12,19 +12,17 @@ import org.gearvrf.GVRBone;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRMesh;
 import org.gearvrf.GVRSceneObject;
-import org.gearvrf.GVRVertexBoneData;
 import org.gearvrf.utility.Log;
 import org.joml.Matrix4f;
 
 /**
  * Controls skeletal animation (skinning). 
  */
-public class GVRSkinningController {
+public class GVRSkinningController extends GVRAnimationController {
     private static final String TAG = GVRSkinningController.class.getSimpleName();
 
     protected GVRContext gvrContext;
     protected GVRSceneObject sceneRoot;
-    protected GVRKeyFrameAnimation animation;
 
     protected SceneAnimNode animRoot;
     protected Map<String, SceneAnimNode> nodeByName;
@@ -56,8 +54,8 @@ public class GVRSkinningController {
      * @param animation The animation object.
      */
     public GVRSkinningController(GVRSceneObject sceneRoot, GVRKeyFrameAnimation animation) {
+        super(animation);
         this.sceneRoot = sceneRoot;
-        this.animation = animation;
 
         nodeByName = new TreeMap<String, SceneAnimNode>();
         boneMap = new HashMap<GVRSceneObject, List<GVRBone>>();
@@ -119,22 +117,11 @@ public class GVRSkinningController {
     }
 
     /**
-     * Update bone transforms at each animation step.
+     * Update bone transforms for the specified tick.
      */
-    public void animate(float timeInSeconds) {
-        float ticksPerSecond;
-        float timeInTicks;
-        Matrix4f[] animationTransform = null;
-
-        if (animation.mTicksPerSecond != 0) {
-            ticksPerSecond = (float) animation.mTicksPerSecond;
-        } else {
-            ticksPerSecond = 25.0f;
-        }
-        timeInTicks = timeInSeconds * ticksPerSecond;
-
-        float animationTime = timeInTicks % animation.mDurationTicks; // auto-repeat
-        animationTransform = animation.getTransforms(animationTime);
+    @Override
+    protected void animateImpl(float animationTick) {
+        Matrix4f[] animationTransform = animation.getTransforms(animationTick);
 
         updateTransforms(animRoot, new Matrix4f(), animationTransform);
 


### PR DESCRIPTION
If an animation stops at the last frame, it might be warpped to the first frame.
This can be fixed by adding a small value to the duration (1e-6).

The common code in GVRSkinningController and GVRNodeAnimationController is pulled
into a base class, and the fixed is applied on that.

Rename some variables to distinguish time vs ticks in the animation controller(s).