### PR TITLE
Method to apply the light map to the scene

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRMaterial.java
@@ -287,7 +287,45 @@ public class GVRMaterial extends GVRHybridObject implements
      *            to map the 2D texture to the mesh.
      */
     public void setTextureAtlasInfo(String key, float[] offset, float[] scale) {
+        setTextureOffset(key, offset);
+        setTextureScale(key, scale);
+    }
+
+    /**
+     * Returns the placement offset of texture {@code key}}
+     * @param key Texture name. A common name is "main",
+     *            "lightmap", etc.
+     * @return    The vector of x and y at uv space.
+     */
+    public float[] getTextureOffset(String key) {
+        return getVec2(key + "_offset");
+    }
+
+    /**
+     * Set the placement offset of texture {@code key}}
+     * @param key Texture name. A common name is "main",
+     *            "lightmap", etc.
+     */
+    public void setTextureOffset(String key, float[] offset) {
         setVec2(key + "_offset", offset[0], offset[1]);
+    }
+
+    /**
+     * Returns the placement scale of texture {@code key}}
+     * @param key Texture name. A common name is "main",
+     *            "lightmap", etc.
+     * @return    The vector of x and y at uv space.
+     */
+    public float[] getTextureScale(String key) {
+        return getVec2(key + "_scale");
+    }
+
+    /**
+     * Set the placement scale of texture {@code key}}
+     * @param key Texture name. A common name is "main",
+     *            "lightmap", etc.
+     */
+    public void setTextureScale(String key, float[] scale) {
         setVec2(key + "_scale", scale[0], scale[1]);
     }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRTexture.java
@@ -15,8 +15,12 @@
 
 package org.gearvrf;
 
+import java.util.List;
+
 /** Wrapper for a GL texture. */
 public class GVRTexture extends GVRHybridObject {
+	private List<GVRAtlasInformation> mAtlasInformation = null;
+
     protected GVRTexture(GVRContext gvrContext, long ptr) {
         super(gvrContext, ptr);
     }
@@ -37,6 +41,40 @@ public class GVRTexture extends GVRHybridObject {
     public void updateTextureParameters(GVRTextureParameters textureParameters) {
         NativeTexture.updateTextureParameters(getNative(),
                 textureParameters.getCurrentValuesArray());
+    }
+
+    /**
+     * Returns the list of atlas information necessary to map
+     * the texture atlas to each scene object.
+     *
+     * @return List of atlas information.
+     */
+    public List<GVRAtlasInformation> getAtlasInformation() {
+        return mAtlasInformation;
+    }
+
+    /**
+     * Set the list of {@link GVRAtlasInformation} to map the texture atlas
+     * to each object of the scene.
+     *
+     * @param atlasInformation Atlas information to map the texture atlas to each
+     *        scene object.
+     */
+    public void setAtlasInformation(List<GVRAtlasInformation> atlasInformation) {
+        mAtlasInformation = atlasInformation;
+    }
+
+    /**
+     * Inform if the texture is a large image containing "atlas" of sub-images
+     * with a list of {@link GVRAtlasInformation} necessary to map it to the
+     * scene objects.
+     *
+     * @return True if the texture is a large image containing "atlas",
+     *         otherwise it returns false.
+     */
+    public boolean isAtlasedTexture() {
+        return mAtlasInformation != null
+            && !mAtlasInformation.isEmpty();
     }
 
 }


### PR DESCRIPTION
Add logic to apply the light map and other texture atlas to the whole scene objects.
GVRTexture may be a texture atlas.

This pull request is result of this following comment:
https://github.com/gearvrf/GearVRf-Demos/pull/15#discussion_r54613966

To test it, I have updated the solar system at:
https://github.com/gearvrf/GearVRf-Demos/pull/15

GearVRf-DCO-1.0-Signed-off-by: Ragner Magalhaes <ragner.n@samsung.com>