### PR TITLE
Fixing bug for custom shader to avoid generating VBOs for every frame

### DIFF
--- a/GVRf/Framework/jni/objects/mesh.h
+++ b/GVRf/Framework/jni/objects/mesh.h
@@ -50,7 +50,7 @@ public:
                     have_bounding_volume_(false), vao_dirty_(true),
                     vaoID_(GVR_INVALID), triangle_vboID_(GVR_INVALID), vert_vboID_(GVR_INVALID),
                     norm_vboID_(GVR_INVALID), tex_vboID_(GVR_INVALID),
-                    boneVboID_(GVR_INVALID), vertexBoneData_(this), bone_data_dirty_(true)
+                    boneVboID_(GVR_INVALID), vertexBoneData_(this), bone_data_dirty_(true), regenerate_vao_(true)
     {
     }
 
@@ -251,21 +251,25 @@ public:
     void setVertexAttribLocF(GLuint location, std::string key) {
         attribute_float_keys_[location] = key;
         vao_dirty_ = true;
+        regenerate_vao_ = true;
     }
 
     void setVertexAttribLocV2(GLuint location, std::string key) {
         attribute_vec2_keys_[location] = key;
         vao_dirty_ = true;
+        regenerate_vao_ = true;
     }
 
     void setVertexAttribLocV3(GLuint location, std::string key) {
         attribute_vec3_keys_[location] = key;
         vao_dirty_ = true;
+        regenerate_vao_ = true;
     }
 
     void setVertexAttribLocV4(GLuint location, std::string key) {
         attribute_vec4_keys_[location] = key;
         vao_dirty_ = true;
+        regenerate_vao_ = true;
     }
 
     // generate VAO
@@ -297,7 +301,12 @@ public:
     VertexBoneData &getVertexBoneData() {
         return vertexBoneData_;
     }
-
+    bool isVaoDirty() const {
+    	return regenerate_vao_;
+    }
+    void unSetVaoDirty() {
+    	regenerate_vao_ = false;
+    }
     void generateBoneArrayBuffers();
 
     //must be called by the thread on which the mesh cleanup should happen
@@ -339,7 +348,7 @@ private:
     // triangle information
     GLuint numTriangles_;
     bool vao_dirty_;
-
+    bool regenerate_vao_;
     bool have_bounding_volume_;
     BoundingVolume bounding_volume;
 

--- a/GVRf/Framework/jni/shaders/material/custom_shader.cpp
+++ b/GVRf/Framework/jni/shaders/material/custom_shader.cpp
@@ -116,26 +116,28 @@ void CustomShader::render(const glm::mat4& mvp_matrix, RenderData* render_data,
 #if _GVRF_USE_GLES3_
     glUseProgram(program_->id());
 
-    for (auto it = attribute_float_keys_.begin();
-            it != attribute_float_keys_.end(); ++it) {
-        mesh->setVertexAttribLocF(it->first, it->second);
-    }
+    if(mesh->isVaoDirty()) {
+		for (auto it = attribute_float_keys_.begin();
+				it != attribute_float_keys_.end(); ++it) {
+			mesh->setVertexAttribLocF(it->first, it->second);
+		}
 
-    for (auto it = attribute_vec2_keys_.begin();
-            it != attribute_vec2_keys_.end(); ++it) {
-        mesh->setVertexAttribLocV2(it->first, it->second);
-    }
+		for (auto it = attribute_vec2_keys_.begin();
+				it != attribute_vec2_keys_.end(); ++it) {
+			mesh->setVertexAttribLocV2(it->first, it->second);
+		}
 
-    for (auto it = attribute_vec3_keys_.begin();
-            it != attribute_vec3_keys_.end(); ++it) {
-        mesh->setVertexAttribLocV3(it->first, it->second);
-    }
+		for (auto it = attribute_vec3_keys_.begin();
+				it != attribute_vec3_keys_.end(); ++it) {
+			mesh->setVertexAttribLocV3(it->first, it->second);
+		}
 
-    for (auto it = attribute_vec4_keys_.begin();
-            it != attribute_vec4_keys_.end(); ++it) {
-        mesh->setVertexAttribLocV4(it->first, it->second);
+		for (auto it = attribute_vec4_keys_.begin();
+				it != attribute_vec4_keys_.end(); ++it) {
+			mesh->setVertexAttribLocV4(it->first, it->second);
+		}
+		mesh->unSetVaoDirty();
     }
-
     mesh->generateVAO();  // setup VAO
 
     ///////////// uniform /////////


### PR DESCRIPTION
Custom shader was calling setVertexAttribLoc() which makes vao_dirty -> true which causes generate VBOs for every frame. adding a flag to avoid this.