### PR TITLE
Fixed bug with cylinder construction

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
@@ -650,6 +650,8 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
 
             float stackPercentage0 = ((float) (stack) / stackNumber);
             float stackPercentage1 = ((float) (stack + 1) / stackNumber);
+            float radius0 = (bottomRadius - (difference * stackPercentage0));
+            float radius1 = (bottomRadius - (difference * stackPercentage1));
 
             float t0 = 1.0f - stackPercentage0;
             float t1 = 1.0f - stackPercentage1;
@@ -666,17 +668,15 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
                 double cosTheta1 = Math.cos(theta1);
                 double sinTheta1 = Math.sin(theta1);
 
-                float radius = (bottomRadius - (difference * stackPercentage0));
-                float x0 = (float) (radius * cosTheta0);
-                float z0 = (float) (-radius * sinTheta0);
-                float x1 = (float) (radius * cosTheta1);
-                float z1 = (float) (-radius * sinTheta1);
+                float x0 = (float) (radius0 * cosTheta0);
+                float z0 = (float) (-radius0 * sinTheta0);
+                float x1 = (float) (radius0 * cosTheta1);
+                float z1 = (float) (-radius0 * sinTheta1);
 
-                radius = (bottomRadius - (difference * stackPercentage1));
-                float x2 = (float) (radius * cosTheta0);
-                float z2 = (float) (-radius * sinTheta0);
-                float x3 = (float) (radius * cosTheta1);
-                float z3 = (float) (-radius * sinTheta1);
+                float x2 = (float) (radius1 * cosTheta0);
+                float z2 = (float) (-radius1 * sinTheta0);
+                float x3 = (float) (radius1 * cosTheta1);
+                float z3 = (float) (-radius1 * sinTheta1);
 
                 float s0, s1;
                 if (facingOut) {


### PR DESCRIPTION
I believe this to be a Java compiler bug. I fixed it by moving some initialization outside of the inner loop and using two variables instead of one but the code should have worked fine as written. My fix just makes the compiler generate something more correct.
GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com