### PR TITLE
Splitting the renderRenderData function

### DIFF
--- a/GVRf/Framework/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/jni/engine/renderer/renderer.h
@@ -99,6 +99,16 @@ private:
     static void renderRenderData(RenderData* render_data,
             const glm::mat4& view_matrix, const glm::mat4& projection_matrix,
             int render_mask, ShaderManager* shader_manager, int modeShadow);
+
+    static void renderMesh(RenderData* render_data,
+            const glm::mat4& view_matrix, const glm::mat4& projection_matrix,
+            int render_mask, ShaderManager* shader_manager, int modeShadow);
+
+    static void renderMaterialShader(RenderData* render_data,
+            const glm::mat4& view_matrix, const glm::mat4& projection_matrix,
+            int render_mask, ShaderManager* shader_manager, int modeShadow,
+            Material *material);
+
     static void renderPostEffectData(Camera* camera,
             RenderTexture* render_texture, PostEffectData* post_effect_data,
             PostEffectShaderManager* post_effect_shader_manager);


### PR DESCRIPTION
 Hi all,
i would like to do a cleanup at the Renderer class to reduce its complexity and the size of some functions.

The number of shaders is growing up and the renderRenderData(...) function
is growing up also. So I made a initial cleanup on it, still on progress.

In my opinion, we should think how to manage the shaders to avoid a huge "switch case" in renderRenderData(...). Maybe this "switch case" should be replaced by something like:

curr_material->shader()->render(mvp_matrix, render_data, ...);

But, I think that to implement something like this we should have a abstract/base class for the shaders.

Does anybody have any comments about it?

GearVRf-DCO-1.0-Signed-off-by: Ragner Magalhaes <ragner.n@samsung.com>