### PR TITLE
Cubemap texture jni error fixed.

### DIFF
--- a/GVRf/Framework/jni/objects/textures/compressed_texture_jni.cpp
+++ b/GVRf/Framework/jni/objects/textures/compressed_texture_jni.cpp
@@ -32,7 +32,7 @@ JNIEXPORT jlong JNICALL
 Java_org_gearvrf_asynchronous_NativeCompressedTexture_mipmappedConstructor(JNIEnv * env,
         jobject obj, jint target);
 }
-;
+
 
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_asynchronous_NativeCompressedTexture_normalConstructor(JNIEnv * env,

--- a/GVRf/Framework/jni/objects/textures/cubemap_texture_jni.cpp
+++ b/GVRf/Framework/jni/objects/textures/cubemap_texture_jni.cpp
@@ -29,7 +29,7 @@ JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeCubemapTexture_bitmapArrayConstructor(JNIEnv * env,
         jobject obj, jobjectArray bitmapArray, jintArray jtexture_parameters);
 }
-;
+
 
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeCubemapTexture_bitmapArrayConstructor(JNIEnv * env,

--- a/GVRf/Framework/jni/util/jni_utils.h
+++ b/GVRf/Framework/jni/util/jni_utils.h
@@ -53,6 +53,18 @@ static jclass GetGlobalClassReference(JNIEnv& env, const char * className) {
     return gc;
 }
 
+/**
+ * Assuming this is called only by threads that are already attached to jni; it is the
+ * responsibility of the caller to ensure that.
+ */
+static JNIEnv* getCurrentEnv(JavaVM* javaVm) {
+    JNIEnv* result;
+    if (JNI_OK != javaVm->GetEnv(reinterpret_cast<void**>(&result), JNI_VERSION_1_6)) {
+        FAIL("GetEnv failed");
+    }
+    return result;
+}
+
 }
 
 #endif


### PR DESCRIPTION
 The cubemap sample was crashing immediately after the splash screen was dismissed because of it.

+ applied similar change to other affected textures