### PR TITLE
Fixed recycling of motion events for cursor controllers

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRCursorController.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRCursorController.java
@@ -395,6 +395,7 @@ public abstract class GVRCursorController {
                 keyEvent = null;
                 if (motionEvent != null) {
                     motionEvent.recycle();
+                    motionEvent = null;
                 }
             }
             invalidate = true;

--- a/GVRf/Framework/src/org/gearvrf/io/GVRMouseDeviceManager.java
+++ b/GVRf/Framework/src/org/gearvrf/io/GVRMouseDeviceManager.java
@@ -156,7 +156,6 @@ class GVRMouseDeviceManager {
                 super.setPosition(this.x, this.y, this.z);
                 return true;
             }
-            event.recycle();
             return false;
         }
 
@@ -236,7 +235,6 @@ class GVRMouseDeviceManager {
         private boolean dispatchMotionEvent(int id, MotionEvent event) {
             InputDevice device = event.getDevice();
             if (id == -1 || device == null) {
-                event.recycle();
                 return false;
             }
 


### PR DESCRIPTION
Calling recycle() multiple times on the same motion event results in
a runtime exception. This patch prevents the exception for certain
code paths.