### PR TITLE
Add life-cycle events for GVRSceneObject and GVRScene

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRScene.java
@@ -21,16 +21,19 @@ import java.util.List;
 
 import org.gearvrf.GVRRenderData.GVRRenderMaskBit;
 import org.gearvrf.debug.GVRConsole;
+import org.gearvrf.script.IScriptable;
 import org.gearvrf.utility.Log;
 
 /** The scene graph */
-public class GVRScene extends GVRHybridObject implements PrettyPrint {
+public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptable, ISceneEvents, IEventReceiver {
     @SuppressWarnings("unused")
     private static final String TAG = Log.tag(GVRScene.class);
 
     private final List<GVRSceneObject> mSceneObjects = new ArrayList<GVRSceneObject>();
     private GVRCameraRig mMainCameraRig;
     private StringBuilder mStatMessage = new StringBuilder();
+
+    private GVREventReceiver mEventReceiver = new GVREventReceiver(this);
 
     /**
      * Constructs a scene with a camera rig holding left & right cameras in it.
@@ -435,6 +438,51 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint {
         StringBuffer sb = new StringBuffer();
         prettyPrint(sb, 0);
         return sb.toString();
+    }
+
+    @Override
+    public GVREventReceiver getEventReceiver() {
+        return mEventReceiver;
+    }
+
+    @Override
+    public void onInit(GVRContext gvrContext, GVRScene scene) {
+        for (GVRSceneObject child : mSceneObjects) {
+            recursivelySendOnInit(child);
+        }
+    }
+
+    private void recursivelySendOnInit(GVRSceneObject sceneObject) {
+        getGVRContext().getEventManager().sendEvent(
+                sceneObject, ISceneObjectEvents.class, "onInit", getGVRContext(), sceneObject);
+
+        for (GVRSceneObject child : sceneObject.rawGetChildren()) {
+            recursivelySendOnInit(child);
+        }
+    }
+
+    @Override
+    public void onAfterInit() {
+        for (GVRSceneObject child : mSceneObjects) {
+            recursivelySendSimpleEvent(child, "onAfterInit");
+        }
+    }
+
+    @Override
+    public void onStep() {
+        // Send "onStep" to all scene objects and their children
+        for (GVRSceneObject child : mSceneObjects) {
+            recursivelySendSimpleEvent(child, "onStep");
+        }
+    }
+
+    private void recursivelySendSimpleEvent(GVRSceneObject sceneObject, String eventName) {
+        getGVRContext().getEventManager().sendEvent(
+                sceneObject, ISceneObjectEvents.class, eventName);
+
+        for (GVRSceneObject child : sceneObject.rawGetChildren()) {
+            recursivelySendSimpleEvent(child, eventName);
+        }
     }
 }
 

--- a/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
@@ -62,13 +62,12 @@ public class GVRSceneObject extends GVRHybridObject implements PrettyPrint, IScr
      *            current {@link GVRContext}
      */
     public GVRSceneObject(GVRContext gvrContext) {
-        super(gvrContext, NativeSceneObject.ctor());
-        attachTransform(new GVRTransform(getGVRContext()));
+        this(gvrContext, null, null, null);
     }
 
     /**
      * Constructs a scene object with an arbitrarily complex mesh.
-     * 
+     *
      * @param gvrContext
      *            current {@link GVRContext}
      * @param mesh
@@ -77,10 +76,7 @@ public class GVRSceneObject extends GVRHybridObject implements PrettyPrint, IScr
      *            {@link GVRContext#createQuad(float, float)}
      */
     public GVRSceneObject(GVRContext gvrContext, GVRMesh mesh) {
-        this(gvrContext);
-        GVRRenderData renderData = new GVRRenderData(gvrContext);
-        attachRenderData(renderData);
-        renderData.setMesh(mesh);
+        this(gvrContext, mesh, null, null);
     }
 
     /**
@@ -118,11 +114,21 @@ public class GVRSceneObject extends GVRHybridObject implements PrettyPrint, IScr
      */
     public GVRSceneObject(GVRContext gvrContext, GVRMesh mesh,
             GVRTexture texture, GVRMaterialShaderId shaderId) {
-        this(gvrContext, mesh);
+        super(gvrContext, NativeSceneObject.ctor());
 
-        GVRMaterial material = new GVRMaterial(gvrContext, shaderId);
-        material.setMainTexture(texture);
-        getRenderData().setMaterial(material);
+        attachTransform(new GVRTransform(getGVRContext()));
+
+        if (mesh != null) {
+            GVRRenderData renderData = new GVRRenderData(gvrContext);
+            attachRenderData(renderData);
+            renderData.setMesh(mesh);
+        }
+
+        if (texture != null) {
+            GVRMaterial material = new GVRMaterial(gvrContext, shaderId);
+            material.setMainTexture(texture);
+            getRenderData().setMaterial(material);
+        }
     }
 
     private static final GVRMaterialShaderId STANDARD_SHADER = GVRShaderType.Texture.ID;
@@ -920,12 +926,6 @@ public class GVRSceneObject extends GVRHybridObject implements PrettyPrint, IScr
         if (childComponent.getOwnerObject() != null) {
             removeChildObject(childComponent.getOwnerObject());
         }
-    }
-
-    /**
-     * Called when the scene object has been loaded from a model.
-     */
-    public void onLoaded() {
     }
 
     /**

--- a/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRSceneObject.java
@@ -40,6 +40,16 @@ import org.gearvrf.utility.Log;
  * {@linkplain GVRSceneObject#attachRenderData(GVRRenderData) attached.} Each
  * {@link GVRRenderData} has a {@link GVRMesh GL mesh} that defines its
  * geometry, and a {@link GVRMaterial} that defines its surface.
+ *
+ * <p>
+ * {@link GVRSceneObject} receives events defined in {@link ISceneObjectEvents}. To add a listener
+ * to these events, use the following code:
+ * <pre>
+ *     ISceneObjectEvents myEventListener = new ISceneObjectEvents() {
+ *         ...
+ *     };
+ *     getEventReceiver().addListener(myEventListener);
+ * </pre>
  */
 public class GVRSceneObject extends GVRHybridObject implements PrettyPrint, IScriptable, IEventReceiver {
 

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -750,6 +750,16 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                                 public void finished(GVRAnimation animation) {
                                     if (mNextMainScene != null) {
                                         setMainScene(mNextMainScene);
+
+                                        // Initialize the main scene
+                                        GVRViewManager.this.getEventManager().sendEvent(
+                                                mMainScene, ISceneEvents.class,
+                                                "onInit", GVRViewManager.this, mMainScene);
+
+                                        // Late-initialize the main scene
+                                        GVRViewManager.this.getEventManager().sendEvent(
+                                                mMainScene, ISceneEvents.class,
+                                                "onAfterInit");
                                     } else {
                                         getMainScene().removeSceneObject(
                                                 splashScreen);
@@ -783,6 +793,10 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
             try {
                 GVRViewManager.this.getEventManager().sendEvent(
                         mScript, IScriptEvents.class, "onStep");
+
+                // Issue "onStep" to the scene
+                GVRViewManager.this.getEventManager().sendEvent(
+                        mMainScene, ISceneEvents.class, "onStep");
             } catch (final Exception exc) {
                 Log.e(TAG, "Exception from onStep: %s", exc.toString());
                 exc.printStackTrace();

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -717,6 +717,9 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                     "onAfterInit");
 
             if (mSplashScreen == null) {
+                // No splash screen, notify main scene now.
+                GVRViewManager.this.notifyMainSceneReady();
+
                 mFrameHandler = normalFrames;
                 firstFrame = splashFrames = null;
             } else {
@@ -750,16 +753,8 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                                 public void finished(GVRAnimation animation) {
                                     if (mNextMainScene != null) {
                                         setMainScene(mNextMainScene);
-
-                                        // Initialize the main scene
-                                        GVRViewManager.this.getEventManager().sendEvent(
-                                                mMainScene, ISceneEvents.class,
-                                                "onInit", GVRViewManager.this, mMainScene);
-
-                                        // Late-initialize the main scene
-                                        GVRViewManager.this.getEventManager().sendEvent(
-                                                mMainScene, ISceneEvents.class,
-                                                "onAfterInit");
+                                        // Splash screen finishes. Notify main scene it is ready.
+                                        GVRViewManager.this.notifyMainSceneReady();
                                     } else {
                                         getMainScene().removeSceneObject(
                                                 splashScreen);
@@ -809,6 +804,21 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
             mMainScene.updateStats();
         }
     };
+
+    // Send onInit and onAfterInit events to main scene when it is ready.
+    // When there is a splash screen, it is called after the splash screen has completed.
+    // If there is no splash screen, it is called after GVRScript.onInit() returns.
+    private void notifyMainSceneReady() {
+        // Initialize the main scene
+        GVRViewManager.this.getEventManager().sendEvent(
+                mMainScene, ISceneEvents.class,
+                "onInit", GVRViewManager.this, mMainScene);
+
+        // Late-initialize the main scene
+        GVRViewManager.this.getEventManager().sendEvent(
+                mMainScene, ISceneEvents.class,
+                "onAfterInit");
+    }
 
     /**
      * This is the code that needs to be executed before either eye is drawn.

--- a/GVRf/Framework/src/org/gearvrf/ILifeCycleEvents.java
+++ b/GVRf/Framework/src/org/gearvrf/ILifeCycleEvents.java
@@ -1,0 +1,20 @@
+package org.gearvrf;
+
+/**
+ * Defines the handler interface for life-cycle events and the onStep event.
+ * Note that the onInit(...) event is intentionally omitted from this interface,
+ * because it has different arguments in different concrete {@link IEvents} interfaces,
+ * such as {@link IScriptEvents}, {@link ISceneObjectEvents}, and so on.
+ */
+public interface ILifeCycleEvents extends IEvents {
+    /**
+     * Called after all handlers of onInit are completed.
+     */
+    void onAfterInit();
+
+    /**
+     * Called before rendering the scene. This is not called if a {@link GVRSceneObject}
+     * is not added to a {@link GVRScene}.
+     */
+    void onStep();
+}

--- a/GVRf/Framework/src/org/gearvrf/ISceneEvents.java
+++ b/GVRf/Framework/src/org/gearvrf/ISceneEvents.java
@@ -1,0 +1,12 @@
+package org.gearvrf;
+
+public interface ISceneEvents extends ILifeCycleEvents {
+    /**
+     * Called when the scene has been initialized.
+     * @param gvrContext
+     *         The GVRContext.
+     * @param scene
+     *         The GVRScene.
+     */
+    void onInit(GVRContext gvrContext, GVRScene scene);
+}

--- a/GVRf/Framework/src/org/gearvrf/ISceneObjectEvents.java
+++ b/GVRf/Framework/src/org/gearvrf/ISceneObjectEvents.java
@@ -1,0 +1,39 @@
+/* Copyright 2016 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf;
+
+/**
+ * This interface defines events for GVRSceneObject. Please note that the GVRSceneObject
+ * class does not implement this interface. To handle events delivered to it, user can
+ * add an object that implements this interface to a GVRSceneObject using
+ * {@link GVREventReceiver#addListener(IEvents)}. The GVREventReceiver can be obtained
+ * using {@link GVRSceneObject#getEventReceiver()}.
+ */
+public interface ISceneObjectEvents extends ILifeCycleEvents {
+    /**
+     * Called when a {@link GVRSceneObject} is constructed.
+     * @param gvrContext
+     *         The GVRContext.
+     * @param sceneObject
+     *         The GVRSceneObject itself.
+     */
+    void onInit(GVRContext gvrContext, GVRSceneObject sceneObject);
+
+    /**
+     * Called after the object has been loaded from a model.
+     */
+    void onLoaded();
+}

--- a/GVRf/Framework/src/org/gearvrf/jassimp2/GVRJassimpSceneObject.java
+++ b/GVRf/Framework/src/org/gearvrf/jassimp2/GVRJassimpSceneObject.java
@@ -14,6 +14,7 @@ import org.gearvrf.GVRMesh;
 import org.gearvrf.GVRRenderData;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRTexture;
+import org.gearvrf.ISceneObjectEvents;
 import org.gearvrf.scene_objects.GVRModelSceneObject;
 import org.gearvrf.utility.Log;
 
@@ -59,7 +60,7 @@ public class GVRJassimpSceneObject extends GVRModelSceneObject {
             }
 
             if (node.getTransform(GVRJassimpAdapter.sWrapperProvider) != null) {
-            	float[] matrix = node.getTransform(GVRJassimpAdapter.sWrapperProvider);
+                float[] matrix = node.getTransform(GVRJassimpAdapter.sWrapperProvider);
                 sceneObject.getTransform().setModelMatrix(matrix);
             }
 
@@ -68,7 +69,10 @@ public class GVRJassimpSceneObject extends GVRModelSceneObject {
             }
 
             // Inform the loaded object after it has been attached to the scene graph
-            sceneObject.onLoaded();
+            getGVRContext().getEventManager().sendEvent(
+                    sceneObject,
+                    ISceneObjectEvents.class,
+                    "onLoaded");
         } catch (Exception e) {
             // Error while recursing the Scene Graph
             e.printStackTrace();


### PR DESCRIPTION
- Create ILifeCycle events which define interface for life-cycle events
  common to all event-receiving classes (GVRScript, GVRScene, GVRSceneObject, etc.)
- Add onStep handler for GVRScene to recursively deliver the event to scene objects.
- Clean up GVRSceneObject constructors: use a general constructor to handle all specific
  constructors, and only call super from one constructor. This ensures there is only one
  exit-point of all constructors, and any common code can be easily added.
- Allow GVRSceneObject to be scriptable and receive ISceneObjectEvents via GVREventReceiver.