### PR TITLE
Add more android activity events and an early init event

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRActivity.java
@@ -27,6 +27,7 @@ import org.gearvrf.utility.VrAppSettings;
 
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -352,7 +353,53 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         if (handled == false) {
             handled = super.dispatchTouchEvent(event);// VrActivity's
         }
+
+        mViewManager.getEventManager().sendEventWithMask(
+                SEND_EVENT_MASK,
+                this,
+                IActivityEvents.class,
+                "dispatchTouchEvent", event);
+
         return handled;
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        if (mViewManager != null) {
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onConfigurationChanged", newConfig);
+        }
+
+        super.onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (mViewManager != null) {
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onTouchEvent", event);
+        }
+
+        return super.onTouchEvent(event);
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        if (mViewManager != null) {
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onWindowFocusChanged", hasFocus);
+        }
+
+        super.onWindowFocusChanged(hasFocus);
     }
 
     boolean updateSensoredScene() {

--- a/GVRf/Framework/src/org/gearvrf/GVREventListeners.java
+++ b/GVRf/Framework/src/org/gearvrf/GVREventListeners.java
@@ -1,0 +1,108 @@
+package org.gearvrf;
+
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.view.MotionEvent;
+
+/**
+ * This class contains null implementations for the event interfaces
+ * (subclasses of {@link IEvent}, such as {@link IScriptEvents} and {@link IActivityEvents}).
+ * They can be extended to override individual methods, which produces less code than
+ * implementing the complete interfaces, when the latter is unnecessary.
+ *
+ * For example, code to implement complete IScriptEvents includes 4 methods or more.
+ * If only one method needs to be overridden, {@code GVREventListener.ScriptEvents} can be
+ * derived to produce shorter and clearer code:
+ *
+ * <pre>
+ *     IScriptEvents myScriptEventsHandler = new GVREventListener.ScriptEvents {
+ *         public onInit(GVRContext gvrContext) throws Throwable {
+ *         }
+ *     };
+ * </pre>
+ */
+public class GVREventListeners {
+    /**
+     * Null implementation of {@link IScriptEvents}.
+     */
+    public static class ScriptEvents implements IScriptEvents {
+        @Override
+        public void onEarlyInit(GVRContext gvrContext) {
+        }
+
+        @Override
+        public void onInit(GVRContext gvrContext) throws Throwable {
+        }
+
+        @Override
+        public void onAfterInit() {
+        }
+
+        @Override
+        public void onStep() {
+        }
+    }
+
+    /**
+     * Null implementation of {@link IActivityEvents}.
+     */
+    public static class ActivityEvents implements IActivityEvents {
+        @Override
+        public void onPause() {
+        }
+
+        @Override
+        public void onResume() {
+        }
+
+        @Override
+        public void onDestroy() {
+        }
+
+        @Override
+        public void onSetScript(GVRScript script) {
+        }
+
+        @Override
+        public void onWindowFocusChanged(boolean hasFocus) {
+        }
+
+        @Override
+        public void onConfigurationChanged(Configuration config) {
+        }
+
+        @Override
+        public void onActivityResult(int requestCode, int resultCode,
+                Intent data) {
+        }
+
+        @Override
+        public void onTouchEvent(MotionEvent event) {
+        }
+
+        @Override
+        public void dispatchTouchEvent(MotionEvent event) {
+        }
+    }
+
+    /**
+     * Null implementation of {@link ISceneObjectEvents}.
+     */
+    public static class SceneObjectEvents implements ISceneObjectEvents {
+        @Override
+        public void onAfterInit() {
+        }
+
+        @Override
+        public void onStep() {
+        }
+
+        @Override
+        public void onInit(GVRContext gvrContext, GVRSceneObject sceneObject) {
+        }
+
+        @Override
+        public void onLoaded() {
+        }
+    }
+}

--- a/GVRf/Framework/src/org/gearvrf/GVRScript.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRScript.java
@@ -56,6 +56,15 @@ public abstract class GVRScript implements IScriptEvents, IScriptable, IEventRec
      */
 
     /**
+     * Called before {@link #onInit(GVRContext).
+     *
+     * This is used for initializing plug-ins and other early components.
+     */
+    @Override
+    public void onEarlyInit(GVRContext gvrContext) {
+    }
+
+    /**
      * Called when the GL surface is created, when your app is loaded.
      * 
      * This is where you should build your initial scene graph. Any expensive

--- a/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRViewManager.java
@@ -699,6 +699,10 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
             try {
                 GVRViewManager.this.getEventManager().sendEvent(
                         mScript, IScriptEvents.class,
+                        "onEarlyInit", GVRViewManager.this);
+
+                GVRViewManager.this.getEventManager().sendEvent(
+                        mScript, IScriptEvents.class,
                         "onInit", GVRViewManager.this);
             } catch (Throwable t) {
                 t.printStackTrace();

--- a/GVRf/Framework/src/org/gearvrf/IActivityEvents.java
+++ b/GVRf/Framework/src/org/gearvrf/IActivityEvents.java
@@ -15,6 +15,10 @@
 
 package org.gearvrf;
 
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.view.MotionEvent;
+
 /**
  * This interface defines the callback interface of an Android {@code Activity}.
  * User can add a listener to {@code GVRActivity.getEventReceiver()} to handle
@@ -28,4 +32,14 @@ public interface IActivityEvents extends IEvents {
     void onDestroy();
 
     void onSetScript(GVRScript script);
+
+    void onWindowFocusChanged(boolean hasFocus);
+
+    void onConfigurationChanged(Configuration config);
+
+    void onActivityResult(int requestCode, int resultCode, Intent data);
+
+    void onTouchEvent(MotionEvent event);
+
+    void dispatchTouchEvent(MotionEvent event);
 }

--- a/GVRf/Framework/src/org/gearvrf/IScriptEvents.java
+++ b/GVRf/Framework/src/org/gearvrf/IScriptEvents.java
@@ -20,6 +20,8 @@ package org.gearvrf;
  * events that are handled by an application.
  */
 public interface IScriptEvents extends IEvents {
+    void onEarlyInit(GVRContext gvrContext);
+
     void onInit(GVRContext gvrContext) throws Throwable;
 
     void onAfterInit();

--- a/GVRf/Framework/src/org/gearvrf/script/GVRScriptManager.java
+++ b/GVRf/Framework/src/org/gearvrf/script/GVRScriptManager.java
@@ -27,6 +27,7 @@ import javax.script.ScriptEngine;
 
 import org.gearvrf.GVRAndroidResource;
 import org.gearvrf.GVRContext;
+import org.gearvrf.GVREventListeners;
 import org.gearvrf.GVRResourceVolume;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
@@ -257,7 +258,7 @@ public class GVRScriptManager {
         bindHelper(scriptBundle, null, BIND_MASK_GVRSCRIPT | BIND_MASK_GVRACTIVITY);
 
         if (bindToMainScene) {
-            final IScriptEvents bindToSceneListener = new IScriptEvents() {
+            final IScriptEvents bindToSceneListener = new GVREventListeners.ScriptEvents() {
                 GVRScene mainScene = null;
 
                 @Override
@@ -277,10 +278,6 @@ public class GVRScriptManager {
                         // Remove the listener itself
                         gvrScript.getEventReceiver().removeListener(this);
                     }
-                }
-
-                @Override
-                public void onStep() {
                 }
             };
 


### PR DESCRIPTION
- Activity events can be used by framework plugins which need to respond to android activity callbacks without subclassing GVRActivity.

- onEarlyInit event can be used to perform tasks before application onInit. It can be used for initializing plugins.

- Since more events are added to the interfaces, null implementations are also provided as bases for easier extension.