### PR TITLE
Fix native crash in libz with compressed texture loader and some further improvement

### DIFF
--- a/GVRf/Framework/src/org/gearvrf/GVRResourceVolume.java
+++ b/GVRf/Framework/src/org/gearvrf/GVRResourceVolume.java
@@ -109,7 +109,7 @@ public class GVRResourceVolume {
         this.enableUrlLocalCache = cacheEnabled;
     }
 
-    private static ConcurrentHashMap<GVRAndroidResource, GVRAndroidResource> resourceMap = new ConcurrentHashMap<GVRAndroidResource, GVRAndroidResource>();
+    private ConcurrentHashMap<GVRAndroidResource, GVRAndroidResource> resourceMap = new ConcurrentHashMap<GVRAndroidResource, GVRAndroidResource>();
 
     /**
      * Opens a file from the volume. The filePath is relative to the

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncBitmapTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncBitmapTexture.java
@@ -78,24 +78,17 @@ class AsyncBitmapTexture {
                 resource, priority);
     }
 
+    private static final Class<GVRBitmapTexture> TEXTURE_CLASS = GVRBitmapTexture.class;
     /*
      * Singleton
      */
-    private static AsyncBitmapTexture sInstance;
+    private static AsyncBitmapTexture sInstance = new AsyncBitmapTexture();
 
     /**
      * Gets the {@link AsyncBitmapTexture} singleton for loading bitmap textures.
      * @return The {@link AsyncBitmapTexture} singleton.
      */
     public static AsyncBitmapTexture get() {
-        if (sInstance != null) {
-            return sInstance;
-        }
-
-        synchronized (AsyncBitmapTexture.class) {
-            sInstance = new AsyncBitmapTexture();
-        }
-
         return sInstance;
     }
 
@@ -119,7 +112,7 @@ class AsyncBitmapTexture {
 
     private static final String TAG = Log.tag(AsyncBitmapTexture.class);
 
-    private static final Class<GVRBitmapTexture> TEXTURE_CLASS = GVRBitmapTexture.class;
+    
 
     /** Ridiculous amounts of detail about decodeFile() */
     protected static final boolean VERBOSE_DECODE = false;

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCompressedCubemapTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCompressedCubemapTexture.java
@@ -44,7 +44,7 @@ class AsyncCompressedCubemapTexture {
      * The API
      */
 
-    void loadTexture(GVRContext gvrContext,
+    static void loadTexture(GVRContext gvrContext,
             CancelableCallback<GVRCompressedCubemapTexture> callback,
             GVRAndroidResource resource, int priority, Map<String, Integer> map) {
         faceIndexMap = map;
@@ -52,25 +52,20 @@ class AsyncCompressedCubemapTexture {
                 resource, priority);
     }
 
+    private static Map<String, Integer> faceIndexMap;
+    
+    private static final Class<GVRCompressedCubemapTexture> TEXTURE_CLASS = GVRCompressedCubemapTexture.class;
+
     /*
      * Singleton
      */
-
-    private static AsyncCompressedCubemapTexture sInstance;
+    private static AsyncCompressedCubemapTexture sInstance = new AsyncCompressedCubemapTexture();
 
     /**
-     * Gets the {@link AsyncCompressedCubemapTexture} singleton for loading bitmap textures.
+     * Gets the {@link AsyncCompressedCubemapTexture} singleton for loading compressed cubmap textures.
      * @return The {@link AsyncCompressedCubemapTexture} singleton.
      */
     public static AsyncCompressedCubemapTexture get() {
-        if (sInstance != null) {
-            return sInstance;
-        }
-
-        synchronized (AsyncBitmapTexture.class) {
-            sInstance = new AsyncCompressedCubemapTexture();
-        }
-
         return sInstance;
     }
 
@@ -93,10 +88,6 @@ class AsyncCompressedCubemapTexture {
     /*
      * Static constants
      */
-
-    // private static final String TAG = Log.tag(AsyncCubemapTexture.class);
-
-    private static final Class<GVRCompressedCubemapTexture> TEXTURE_CLASS = GVRCompressedCubemapTexture.class;
 
     /*
      * Asynchronous loader for compressed cubemap texture
@@ -161,6 +152,4 @@ class AsyncCompressedCubemapTexture {
         return textureArray;
       }
     }
-
-    private static Map<String, Integer> faceIndexMap;
 }

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCompressedTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCompressedTexture.java
@@ -1,0 +1,118 @@
+/* Copyright 2016 Samsung Electronics Co., LTD
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.gearvrf.asynchronous;
+
+import java.io.IOException;
+
+import org.gearvrf.GVRAndroidResource;
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRAndroidResource.CancelableCallback;
+import org.gearvrf.asynchronous.Throttler.AsyncLoader;
+import org.gearvrf.asynchronous.Throttler.AsyncLoaderFactory;
+import org.gearvrf.asynchronous.Throttler.GlConverter;
+
+import org.gearvrf.utility.Log;
+
+/**
+ * Async resource loading: compressed textures.
+ * 
+ */
+
+class AsyncCompressedTexture {
+
+    /*
+     * The API
+     */
+    static void loadTexture(GVRContext gvrContext,
+            CancelableCallback<GVRCompressedTexture> callback,
+            GVRAndroidResource resource, int priority) {
+        AsyncManager.get().getScheduler().registerCallback(gvrContext,
+                TEXTURE_CLASS, callback, resource, priority);
+    }
+
+    /*
+     * Singleton
+     */
+
+    private static final Class<GVRCompressedTexture> TEXTURE_CLASS = GVRCompressedTexture.class;
+    
+    private static AsyncCompressedTexture sInstance = new AsyncCompressedTexture();
+
+    /**
+     * Gets the {@link AsynCompressedTexture} singleton for loading compressed textures.
+     * 
+     * @return The {@link AsynCompressedTexture} singleton.
+     */
+    public static AsyncCompressedTexture get() {
+        return sInstance;
+    }
+
+    private AsyncCompressedTexture() {
+        AsyncManager.get().registerDatatype(TEXTURE_CLASS,
+                new AsyncLoaderFactory<GVRCompressedTexture, CompressedTexture>() {
+                    @Override
+                    AsyncLoader<GVRCompressedTexture, CompressedTexture> threadProc(
+                            GVRContext gvrContext, GVRAndroidResource request,
+                            CancelableCallback<GVRCompressedTexture> callback,
+                            int priority) {
+                        return new AsyncLoadTextureResource(gvrContext, request,
+                                callback, priority);
+                    }
+                });
+    }
+
+    /*
+     * Asynchronous loader
+     */
+
+    private static class AsyncLoadTextureResource
+            extends AsyncLoader<GVRCompressedTexture, CompressedTexture> {
+
+        private static final GlConverter<GVRCompressedTexture, CompressedTexture> sConverter = new GlConverter<GVRCompressedTexture, CompressedTexture>() {
+
+            @Override
+            public GVRCompressedTexture convert(GVRContext gvrContext,
+                    CompressedTexture compressedTexture) {
+                return compressedTexture == null ? null
+                        : compressedTexture.toTexture(gvrContext,
+                                GVRCompressedTexture.BALANCED);
+            }
+        };
+
+        protected AsyncLoadTextureResource(GVRContext gvrContext,
+                GVRAndroidResource request,
+                CancelableCallback<GVRCompressedTexture> callback,
+                int priority) {
+            super(gvrContext, sConverter, request, callback);
+        }
+
+        @Override
+        protected CompressedTexture loadResource() {
+            GVRCompressedTextureLoader loader = resource.getCompressedLoader();
+            CompressedTexture compressedTexture = null;
+            try {
+                compressedTexture = CompressedTexture
+                        .parse(resource.getStream(), false, loader);
+                Log.d("ASYNC", "parse compressed texture %s", resource);
+            } catch (IOException e) {
+                e.printStackTrace();
+            } finally {
+                resource.closeStream();
+            }
+            return compressedTexture;
+        }
+    }
+}

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCubemapTexture.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncCubemapTexture.java
@@ -46,7 +46,7 @@ class AsyncCubemapTexture {
      * The API
      */
 
-    void loadTexture(GVRContext gvrContext,
+    static void loadTexture(GVRContext gvrContext,
             CancelableCallback<GVRCubemapTexture> callback,
             GVRAndroidResource resource, int priority, Map<String, Integer> map) {
         faceIndexMap = map;
@@ -54,20 +54,20 @@ class AsyncCubemapTexture {
                 resource, priority);
     }
 
+    private static Map<String, Integer> faceIndexMap;
+    
+    private static final Class<GVRCubemapTexture> TEXTURE_CLASS = GVRCubemapTexture.class;
+    
     /*
      * Singleton
      */
-
-    private static AsyncCubemapTexture sInstance;
+    private static AsyncCubemapTexture sInstance = new AsyncCubemapTexture();
 
     /**
      * Gets the {@link AsyncCubemapTexture} singleton for loading bitmap textures.
      * @return The {@link AsyncCubemapTexture} singleton.
      */
-    public static synchronized AsyncCubemapTexture get() {
-        if (sInstance == null) {
-            sInstance = new AsyncCubemapTexture();
-        }
+    public static AsyncCubemapTexture get() {
         return sInstance;
     }
 
@@ -85,14 +85,6 @@ class AsyncCubemapTexture {
                     }
                 });
     }
-
-    /*
-     * Static constants
-     */
-
-    // private static final String TAG = Log.tag(AsyncCubemapTexture.class);
-
-    private static final Class<GVRCubemapTexture> TEXTURE_CLASS = GVRCubemapTexture.class;
 
     /*
      * Asynchronous loader for uncompressed cubemap
@@ -148,6 +140,4 @@ class AsyncCubemapTexture {
             return bitmapArray;
         }
     }
-
-    private static Map<String, Integer> faceIndexMap;
 }

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncManager.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncManager.java
@@ -83,11 +83,5 @@ public class AsyncManager {
 
         // Setup default scheduler to Throttler
         mScheduler = Throttler.get();
-
-        // Poke all loaders to get them registered.
-        AsyncBitmapTexture.get();
-        AsyncCubemapTexture.get();
-        AsyncCompressedCubemapTexture.get();
-        AsyncMesh.get();
     }
 }

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncMesh.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/AsyncMesh.java
@@ -48,22 +48,17 @@ class AsyncMesh {
     /*
      * Singleton
      */
+    
 
-    private static AsyncMesh sInstance;
+    private static final Class<GVRMesh> MESH_CLASS = GVRMesh.class;
+
+    private static AsyncMesh sInstance = new AsyncMesh();
 
     /**
      * Gets the {@link AsyncMesh} singleton for loading bitmap textures.
      * @return The {@link AsyncMesh} singleton.
      */
     public static AsyncMesh get() {
-        if (sInstance != null) {
-            return sInstance;
-        }
-
-        synchronized (AsyncBitmapTexture.class) {
-            sInstance = new AsyncMesh();
-        }
-
         return sInstance;
     }
 
@@ -104,6 +99,4 @@ class AsyncMesh {
             return gvrContext.loadMesh(resource);
         }
     }
-
-    private static final Class<GVRMesh> MESH_CLASS = GVRMesh.class;
 }

--- a/GVRf/Framework/src/org/gearvrf/asynchronous/Throttler.java
+++ b/GVRf/Framework/src/org/gearvrf/asynchronous/Throttler.java
@@ -62,27 +62,6 @@ class Throttler implements Scheduler {
     }
 
     /*
-     * Singleton
-     */
-
-    private static Throttler mInstance;
-
-    public static Throttler get() {
-        if (mInstance != null) {
-            return mInstance;
-        }
-
-        synchronized (Throttler.class) {
-            mInstance = new Throttler();
-        }
-
-        return mInstance;
-    }
-
-    private Throttler() {
-    }
-
-    /*
      * Static constants
      */
 
@@ -107,6 +86,19 @@ class Throttler implements Scheduler {
      * suspended.
      */
     private static final int DECODE_THREAD_LIMIT = Math.max(CORE_COUNT - 1, 1);
+    
+    /*
+     * Singleton
+     */
+
+    private static Throttler mInstance = new Throttler();
+
+    public static Throttler get() {
+        return mInstance;
+    }
+
+    private Throttler() {
+    }
 
     /*
      * Extension points
@@ -196,20 +188,14 @@ class Throttler implements Scheduler {
             } finally {
                 if (async != null) {
                     final INTERMEDIATE loadedResource = async;
-                    gvrContext.runOnGlThread(new Runnable() {
-
-                        @Override
-                        public void run() {
-                            try  {
-                                OUTPUT gvrfResource = converter.convert(gvrContext,
-                                        loadedResource);
-                                callback.loaded(gvrfResource, resource);
-                            } catch (Throwable t) {
-                                // Catch converter errors
-                                callback.failed(t, resource);
-                            }
-                        }
-                    });
+                    try {
+                        OUTPUT gvrfResource = converter.convert(gvrContext,
+                                loadedResource);
+                        callback.loaded(gvrfResource, resource);
+                    } catch (Throwable t) {
+                        // Catch converter errors
+                        callback.failed(t, resource);
+                    }
                 } else {
                     // loadResource() returned null
                     callback.failed(null, resource);


### PR DESCRIPTION
1. Native crash was due to the concurrent unsafety in stream ops in GVRAndroidResource when sniffing compressed texture loader.
2. Simply the compressed texture loading in async resource loading by introducing a new Async Compressed Texture Factory/Loader. Each compressed texture load request that misses in the cache will now go through Throttler rather than directly processed to prevent redundant loading of different requests.
3. Simply and improve the initialization of all async classes.
4. Offload the texture creating convertion from glthread to the current background thread in AsyncLoader's last step in Throttler.