### PR TITLE
Fix rendering objects for one eye only

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -645,7 +645,7 @@ void Renderer::renderRenderData(RenderData* render_data,
         int render_mask, ShaderManager* shader_manager,
         const std::vector<Light*>& lightList, int modeShadow) {
 
-    if (!render_mask || !render_data->render_mask())
+    if (!(render_mask & render_data->render_mask()))
         return;
 
     if (render_data->offset()) {


### PR DESCRIPTION
Skip execution only if render masks do not match.
This fixes regression introduced by commit 59920e2.