### PR TITLE
Fix for "GVRScene.clear() removes the camera rig's scene objects"

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCameraRig.java
@@ -504,6 +504,19 @@ public class GVRCameraRig extends GVRComponent implements PrettyPrint {
     }
 
     /**
+     * Remove all children that have been added to the owner object of this camera rig; except the
+     * camera objects.
+     */
+    public void removeAllChildren() {
+        for (final GVRSceneObject so : headTransformObject.getChildren()) {
+            final boolean notCamera = (so != leftCameraObject && so != rightCameraObject && so != centerCameraObject);
+            if (notCamera) {
+                headTransformObject.removeChildObject(so);
+            }
+        }
+    }
+
+    /**
      * Get the head {@link GVRTransform transform} for setting sensor data. In contrast,
      * use {@link #getTransform()} for additional camera positioning, such as the game
      * character moving and turning.

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -110,8 +110,11 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
      * Remove all scene objects.
      */
     public void removeAllSceneObjects() {
+        getMainCameraRig().removeAllChildren();
         mSceneObjects.clear();
         NativeScene.removeAllSceneObjects(getNative());
+
+        addSceneObject(getMainCameraRig().getOwnerObject());
     }
 
     /**


### PR DESCRIPTION
Should fix https://github.com/Samsung/GearVRf/issues/511; verified using the remote-scripting sample; added a cursor, cleared, added a cursor back.