### PR TITLE
Small tweak so the framework can be built from the command line

### DIFF
--- a/GVRf/Framework/settings.gradle
+++ b/GVRf/Framework/settings.gradle
@@ -1,3 +1,1 @@
-//include ':vrlibrary'
-
-//project(':vrlibrary').projectDir = new File('../../oculus_vr/VRLib/vRLib')
+include ':framework'


### PR DESCRIPTION
or from AS standalone

To build from the command line:
gradlew framework:clean
gradlew framework:assemble

These will produce the aar bundles:
./framework/build/outputs/aar/framework-debug.aar
./framework/build/outputs/aar/framework-release.aar

Dependent projects can just import the output .aar as a new
module and start using gvrf.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>