### PR TITLE
Clear bounding volume before calculating bounds for mesh

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/mesh.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/mesh.cpp
@@ -106,7 +106,7 @@ const BoundingVolume& Mesh::getBoundingVolume() {
     if (have_bounding_volume_) {
         return bounding_volume;
     }
-
+    bounding_volume.reset();
     for (auto it = vertices_.begin(); it != vertices_.end(); ++it) {
         bounding_volume.expand(*it);
     }


### PR DESCRIPTION
Nola's fix; can't cherry-pick it