### PR TITLE
Adding a default text color to TextViewSceneObject

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRTextViewSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRTextViewSceneObject.java
@@ -128,6 +128,7 @@ public class GVRTextViewSceneObject extends GVRSceneObject {
         final GVRActivity activity = gvrContext.getActivity();
         mTextView = new TextView(activity);
         mTextView.setBackgroundColor(Color.TRANSPARENT);
+        mTextView.setTextColor(Color.WHITE);
         mTextView.setText(text);
         mTextView.setVisibility(View.VISIBLE);
         mTextView.setLayoutParams(new LayoutParams(canvasWidth, canvasHeight));


### PR DESCRIPTION
Adding a default text color to TextViewSceneObject.  That seems to fix
it for the gvr-remote-scripting sample anyway.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com