### PR TITLE
Support specifying the location of the Oculus SDK through the global gradle.properties file

### DIFF
--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         minSdkVersion 19
@@ -29,6 +29,9 @@ android {
     }
 
     task buildNative(type: Exec) {
+        if (rootProject.hasProperty("OVR_MOBILE_SDK")) {
+            environment 'OVR_MOBILE_SDK', rootProject.property("OVR_MOBILE_SDK")
+        }
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             commandLine 'ndk-build.cmd', '-C', file('src/main').absolutePath, '-j', 16//, 'NDK_DEBUG=1'
         } else {
@@ -37,6 +40,9 @@ android {
     }
 
     task cleanNative(type: Exec) {
+        if (rootProject.hasProperty("OVR_MOBILE_SDK")) {
+            environment 'OVR_MOBILE_SDK', rootProject.property("OVR_MOBILE_SDK")
+        }
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             commandLine 'ndk-build.cmd', '-C', file('src/main').absolutePath, '-j', 16, 'clean'
         } else {


### PR DESCRIPTION
or in Android Studio via File->Settings->Path Variables.

Set OVR_MOBILE_SDK to point to the directory of the Oculus
Mobile SDK. This will make having ovr_sdk_mobile under GearVRf
optional.