### PR TITLE
Save and restore texture states during rendered texture capture to avoid flickering

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/components/texture_capturer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/texture_capturer.cpp
@@ -85,6 +85,8 @@ void TextureCapturer::beginCapture() {
     glGetIntegerv(GL_VIEWPORT, mSavedViewport);
     glGetIntegerv(GL_SCISSOR_BOX, mSavedScissor);
     mIsCullFace = glIsEnabled(GL_CULL_FACE);
+    mIsBlend = glIsEnabled(GL_BLEND);
+    mIsPolygonOffsetFill = glIsEnabled(GL_POLYGON_OFFSET_FILL);
 
     // Setup FBO
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mRenderTexture->getFrameBufferId());
@@ -119,6 +121,16 @@ void TextureCapturer::endCapture() {
         glEnable(GL_CULL_FACE);
     else
         glDisable(GL_CULL_FACE);
+
+    if (mIsBlend)
+        glEnable(GL_BLEND);
+    else
+        glDisable(GL_BLEND);
+
+    if (mIsPolygonOffsetFill)
+        glEnable(GL_POLYGON_OFFSET_FILL);
+    else
+        glDisable(GL_POLYGON_OFFSET_FILL);
 }
 
 void TextureCapturer::render(

--- a/GVRf/Framework/framework/src/main/jni/objects/components/texture_capturer.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/texture_capturer.h
@@ -62,6 +62,8 @@ private:
     GLint mSavedViewport[4];
     GLint mSavedScissor[4];
     bool  mIsCullFace;
+    bool  mIsBlend;
+    bool  mIsPolygonOffsetFill;
 
     // Data for callback
     JNIEnv  *mJNIEnv;


### PR DESCRIPTION
GearVRf-DCO-1.0-Signed-off-by: Srinivasa Algubelli s.algubelli@samsung.com