### PR TITLE
Add a method to invoke the loaded script.

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptFile.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptFile.java
@@ -140,6 +140,17 @@ public abstract class GVRScriptFile {
     }
 
     /**
+     * Invokes the script.
+     *
+     */
+    public void invoke() {
+        // Run script if it is dirty. This makes sure the script is run
+        // on the same thread as the caller (suppose the caller is always
+        // calling from the same thread).
+        checkDirty();
+    }
+
+    /**
      * Invokes a function defined in the script.
      *
      * @param funcName


### PR DESCRIPTION
Add a method to invoke the loaded script.  Previously, there was only a method to invoke a function within the script.  This will execute the whole script.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com