### PR TITLE
Adding a log message if we do not have a rotation sensor.

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/RotationSensor.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/RotationSensor.java
@@ -112,6 +112,9 @@ class RotationSensor {
         if (null == mInternalSensorListener) {
             final SensorManager sensorManager = (SensorManager)mApplicationContext.getSystemService(Context.SENSOR_SERVICE);
             final Sensor internalSensor = sensorManager.getDefaultSensor(Sensor.TYPE_GAME_ROTATION_VECTOR);
+            if (internalSensor == null) {
+                Log.e("RotationSensor", "This phone does not have a rotation sensor - it cannot run GearVRF applications");
+            }
             mInternalSensorListener = new GVRInternalSensorListener(this);
             sensorManager.registerListener(mInternalSensorListener, internalSensor, SensorManager.SENSOR_DELAY_FASTEST);
         }


### PR DESCRIPTION
Adding a log message to indicate we do not have a rotation sensor to work.

GearVRf-DCO-1.0-Signed-off-by: Nola Donato
nola.donato@samsung.com