### PR TITLE
Switch to NDK_TOOLCHAIN_VERSION 4.9

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/Application.mk
+++ b/GVRf/Framework/framework/src/main/jni/Application.mk
@@ -19,7 +19,7 @@ APP_ABI := armeabi-v7a
 APP_PLATFORM := android-19
 #APP_STL := stlport_static
 APP_STL := gnustl_static
-NDK_TOOLCHAIN_VERSION := 4.8
+NDK_TOOLCHAIN_VERSION := 4.9
 ifndef OVR_MOBILE_SDK
 #	OVR_MOBILE_SDK=../../ovr_sdk_mobile
    	OVR_MOBILE_SDK=../../../../../ovr_sdk_mobile


### PR DESCRIPTION
Newer NDKs no longer support 4.8 so it seem it is time to make the change.