### PR TITLE
Add simulated head position data

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/components/camera_rig.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/camera_rig.cpp
@@ -191,6 +191,11 @@ void CameraRig::setRotation(const glm::quat& transform_rotation) {
     }
 }
 
+void CameraRig::setPosition(const glm::vec3& transform_position) {
+	Transform* transform = getHeadTransform();
+	transform->set_position(transform_position);
+}
+
 Transform* CameraRig::getHeadTransform() const {
 	return owner_object()->getChildByIndex(0)->transform();
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/camera_rig.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/camera_rig.h
@@ -150,6 +150,7 @@ public:
     Transform* getHeadTransform() const; // for rotation/k-sensor
     glm::vec3 getLookAt() const;
     void setRotation(const glm::quat& transform_rotation);
+    void setPosition(const glm::vec3& transform_position);
 
 private:
     CameraRig(const CameraRig& camera_rig);

--- a/GVRf/Framework/framework/src/main/jni/oculus/head_rotation_provider.cpp
+++ b/GVRf/Framework/framework/src/main/jni/oculus/head_rotation_provider.cpp
@@ -30,6 +30,9 @@ void OculusHeadRotation::predict(GVRActivity& gvrActivity, const ovrFrameParms& 
         const ovrQuatf& orientation = tracking.HeadPose.Pose.Orientation;
         glm::quat quat(orientation.w, orientation.x, orientation.y, orientation.z);
         gvrActivity.cameraRig_->setRotation(glm::conjugate(glm::inverse(quat)));
+        const ovrVector3f& position = tracking.HeadPose.Pose.Position;
+        glm::vec3 pos(position.x, position.y, position.z);
+        gvrActivity.cameraRig_->setPosition(pos);
     } else if (nullptr != gvrActivity.cameraRig_) {
         gvrActivity.cameraRig_->predict(time);
     } else {


### PR DESCRIPTION
Noticed it was missing. Using the OVR head model. Matches standard Oculus Unity integration/plugin where enabled by default so think makes sense to do the same.

Test: readily apparent in a sample with near field objects. (Or stop by.)

Minor, but could rename head_rotation_provider.h/cpp to head_pose_provider.h/cpp to be more accurate.

Signed-off-by: m.blix <m.blix@samsung.com>