### PR TITLE
Fixed problem with GVRSceneViewObject invalidation

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -26,8 +26,10 @@ import org.gearvrf.utility.GrowBeforeQueueThreadPoolExecutor;
 import org.gearvrf.utility.Log;
 import org.gearvrf.utility.Threads;
 import org.gearvrf.utility.VrAppSettings;
+import org.joml.Vector2f;
 
 import android.app.Activity;
+import android.transition.Scene;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.os.Bundle;
@@ -64,6 +66,7 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
     private GVRViewManager mViewManager;
     private GVRScript mGVRScript;
     private VrAppSettings mAppSettings;
+    private static View mFullScreenView = null;
 
     // Group of views that are going to be drawn
     // by some GVRViewSceneObject to the scene.
@@ -255,6 +258,20 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         }
     }
 
+    public View getFullScreenView() {
+        if (mFullScreenView != null)
+            return mFullScreenView;
+        VrapiActivityHandler handler = (VrapiActivityHandler) mActivityHandler;
+        if (handler != null) {
+            Vector2f dim = handler.getScreenDimensions();
+            ViewGroup.LayoutParams layout = new ViewGroup.LayoutParams((int) dim.x, (int) dim.y);
+            mFullScreenView = new View(this);
+            mFullScreenView.setLayoutParams(layout);
+            mRenderableViewGroup.addView(mFullScreenView);
+        }
+        return mFullScreenView;
+    }
+
     /**
      * Gets the {@linkplain GVRScript a script} linked to the activity.
      * @return the {@link GVRScript}.
@@ -430,7 +447,7 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
                 otherwise just the children's bounds may be refreshed. */
                 mRenderableViewGroup.setClipChildren(false);
 
-                mRenderableViewGroup.addView(view);;
+                mRenderableViewGroup.addView(view);
             }
         });
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/VrapiActivityHandler.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/VrapiActivityHandler.java
@@ -27,6 +27,7 @@ import javax.microedition.khronos.opengles.GL10;
 
 import org.gearvrf.utility.Log;
 import org.gearvrf.utility.VrAppSettings;
+import org.joml.Vector2f;
 
 import android.graphics.PixelFormat;
 import android.opengl.EGL14;
@@ -53,6 +54,7 @@ class VrapiActivityHandler implements ActivityHandler {
     private EGLSurface mPixelBuffer;
     private EGLSurface mMainSurface;
     boolean mVrApiInitialized;
+    private Vector2f mScreenDimensions = null;
 
     VrapiActivityHandler(final GVRActivity activity,
             final ActivityHandlerRenderingCallbacks callbacks) throws VrapiNotAvailableException {
@@ -150,17 +152,25 @@ class VrapiActivityHandler implements ActivityHandler {
         holder.setFormat(PixelFormat.TRANSLUCENT);
 
         final VrAppSettings appSettings = mActivity.getAppSettings();
-        final int framebufferHeight = appSettings.getFramebufferPixelsHigh();
-        final int framebufferWidth = appSettings.getFramebufferPixelsWide();
-        if (-1 != framebufferHeight && -1 != framebufferWidth && screenWidthPixels != framebufferWidth
-                && screenHeightPixels != framebufferHeight) {
-            Log.v(TAG, "--- window configuration ---");
-            Log.v(TAG, "--- width: %d", framebufferWidth);
-            Log.v(TAG, "--- height: %d", framebufferHeight);
-            //a different resolution of the native window requested 
-            holder.setFixedSize(framebufferWidth, framebufferHeight);
-            Log.v(TAG, "----------------------------");
+        mScreenDimensions = new Vector2f(appSettings.getFramebufferPixelsHigh(), appSettings.getFramebufferPixelsWide());
+        if ((-1 != mScreenDimensions.y) && (-1 != mScreenDimensions.x)) {
+            if ((screenWidthPixels != mScreenDimensions.x) && (screenHeightPixels != mScreenDimensions.x)) {
+                Log.v(TAG, "--- window configuration ---");
+                Log.v(TAG, "--- width: %d", mScreenDimensions.x);
+                Log.v(TAG, "--- height: %d", mScreenDimensions.y);
+                //a different resolution of the native window requested
+                holder.setFixedSize((int) mScreenDimensions.x, (int) mScreenDimensions.y);
+                Log.v(TAG, "----------------------------");
+            }
         }
+        else {
+            mScreenDimensions.x = screenWidthPixels;
+            mScreenDimensions.y = screenHeightPixels;
+        }
+    }
+
+    public Vector2f getScreenDimensions() {
+        return mScreenDimensions;
     }
 
     private final EGLContextFactory mContextFactory = new EGLContextFactory() {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/VrapiActivityHandler.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/VrapiActivityHandler.java
@@ -145,27 +145,24 @@ class VrapiActivityHandler implements ActivityHandler {
 
         final DisplayMetrics metrics = new DisplayMetrics();
         mActivity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        final VrAppSettings appSettings = mActivity.getAppSettings();
         final int screenWidthPixels = Math.max(metrics.widthPixels, metrics.heightPixels);
         final int screenHeightPixels = Math.min(metrics.widthPixels, metrics.heightPixels);
-
+        final int frameBufferWidth = appSettings.getFramebufferPixelsWide();
+        final int frameBufferHeight = appSettings.getFramebufferPixelsHigh();
         final SurfaceHolder holder = mSurfaceView.getHolder();
         holder.setFormat(PixelFormat.TRANSLUCENT);
 
-        final VrAppSettings appSettings = mActivity.getAppSettings();
-        mScreenDimensions = new Vector2f(appSettings.getFramebufferPixelsHigh(), appSettings.getFramebufferPixelsWide());
-        if ((-1 != mScreenDimensions.y) && (-1 != mScreenDimensions.x)) {
-            if ((screenWidthPixels != mScreenDimensions.x) && (screenHeightPixels != mScreenDimensions.x)) {
+        mScreenDimensions = new Vector2f(screenWidthPixels, screenHeightPixels);
+        if ((-1 != frameBufferHeight) && (-1 != frameBufferWidth)) {
+            if ((screenWidthPixels != frameBufferWidth) && (screenHeightPixels != frameBufferHeight)) {
                 Log.v(TAG, "--- window configuration ---");
-                Log.v(TAG, "--- width: %d", mScreenDimensions.x);
-                Log.v(TAG, "--- height: %d", mScreenDimensions.y);
+                Log.v(TAG, "--- width: %d", frameBufferWidth);
+                Log.v(TAG, "--- height: %d", frameBufferHeight);
                 //a different resolution of the native window requested
-                holder.setFixedSize((int) mScreenDimensions.x, (int) mScreenDimensions.y);
+                holder.setFixedSize((int) frameBufferWidth, (int) frameBufferHeight);
                 Log.v(TAG, "----------------------------");
             }
-        }
-        else {
-            mScreenDimensions.x = screenWidthPixels;
-            mScreenDimensions.y = screenHeightPixels;
         }
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
@@ -96,10 +96,6 @@ public class GVRViewSceneObject extends GVRSceneObject {
         });
     }
 
-    public void setParent(GVRView parentView) {
-
-    }
-
     public GVRView getView() {
         return mView;
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
@@ -17,6 +17,7 @@ package org.gearvrf.scene_objects;
 
 import java.lang.ref.WeakReference;
 
+import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRDrawFrameListener;
 import org.gearvrf.GVRExternalTexture;
@@ -29,7 +30,9 @@ import org.gearvrf.scene_objects.view.GVRView;
 
 import android.graphics.Canvas;
 import android.graphics.SurfaceTexture;
+import android.view.View;
 import android.view.Surface;
+import android.graphics.Rect;
 
 /**
  * This class represents a {@linkplain GVRSceneObject Scene object} that shows a {@link View}
@@ -83,11 +86,18 @@ public class GVRViewSceneObject extends GVRSceneObject {
                         // are ready. They are needed for GVRView.draw().
                         gvrContext.registerDrawFrameListener(new GVRDrawFrameListenerImpl(gvrContext, mSurfaceTexture));
                         gvrView.setSceneObject(GVRViewSceneObject.this);
-                        gvrView.getView().postInvalidate();
+                        gvrView.getView().invalidate();
+                        View surfView = gvrContext.getActivity().getFullScreenView();
+                        if (surfView != null)
+                            surfView.invalidate();
                     }
                 });
             }
         });
+    }
+
+    public void setParent(GVRView parentView) {
+
     }
 
     public GVRView getView() {


### PR DESCRIPTION
Invalidating just the GVRView associated with the GVRViewSceneObject
incorrectly set the clip rectangle to just that view. To fix this,
we have to create a full screen android View and invalidate this
to restore the clip rectangle. This full screen view is only created
when necessary and only one of them is needed.

GearVRf-DCO-1.0-Signed-off-by:  Nola Donato nola.donato@samsung.com