### PR TITLE
Only reduce bone count for shadow mapping

### DIFF
--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
@@ -9,7 +9,15 @@ layout(location = 1) in vec2 a_texcoord;
 layout(location = 2) in vec3 a_normal;
 
 #ifdef HAS_VertexSkinShader
+#ifdef HAS_SHADOWS
+//
+// shadow mapping uses more uniforms
+// so we dont get as many bones
+//
 uniform mat4 u_bone_matrix[50];
+#else
+uniform mat4 u_bone_matrix[60];
+#endif
 in vec4 a_bone_weights;
 in ivec4 a_bone_indices;
 #endif


### PR DESCRIPTION
Shadow mapping uses more uniform space and we dont have room for as many
bones. We will use 50 bones when shadow mapping but increase to 60 when
not shadowing. This fixes a problem with the java script rowing guy -
his head wasn't animating because the bones were ignored.