### PR TITLE
Put back adding owner of component as child

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRSceneObject.java
@@ -718,7 +718,38 @@ public class GVRSceneObject extends GVRHybridObject implements PrettyPrint, IScr
         child.mParent = null;
         NativeSceneObject.removeChildObject(getNative(), child.getNative());
     }
+    /**
+     * Add the owner of {@code childComponent} as a child of this object. (owner object of the
+     * Adding a child will increase the
+     * {@link getChildrenCount() getChildrenCount()} for this scene object.
+     * If the component is not attached to a scene object this function does nothing.
+     * 
+     * @param childComponent
+     *            {@link GVRComponent Component} whose owner is added as a child of this
+     *            object.
+     */
+    public void addChildObject(GVRComponent childComponent) {
+        if (childComponent.getOwnerObject() != null) {
+            addChildObject(childComponent.getOwnerObject());
+        }
+    }
 
+    /**
+     * Remove the owner of {@code childComponent} as a child of this object.
+     * Removing a child will decrease
+     * the {@link getChildrenCount() getChildrenCount()} for this scene object.
+     * If the component is not attached to a scene object this function does nothing.
+     * 
+     * @param childComponent
+     *            {@link GVRComponent Component} whose owner is removeed as a child of this
+     *            object.
+     */
+    public void removeChildObject(GVRComponent childComponent) {
+        if (childComponent.getOwnerObject() != null) {
+            removeChildObject(childComponent.getOwnerObject());
+        }
+    }
+    
     /**
      * Performs case-sensitive search
      * 


### PR DESCRIPTION
These APIs are confusing but solar system used them so they are back now. I tested with the solar system sample.

GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com