### PR TITLE
Support for non-indexed drawing and line width

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRCylinderSceneObject.java
@@ -540,6 +540,7 @@ public class GVRCylinderSceneObject extends GVRSceneObject {
         params.SliceNumber = sliceNumber;
         params.StackNumber = stackNumber;
         params.FacingOut = facingOut;
+        params.Material = new GVRMaterial(gvrContext);
         
         generateComplexCylinderObject(gvrContext, params, stackSegmentNumber, sliceSegmentNumber);
     }

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -751,7 +751,9 @@ void Renderer::renderMaterialShader(RenderState& rstate, RenderData* render_data
              shader_manager->getErrorShader()->render(&rstate, render_data, curr_material);
              return;
          }
-         if (render_data->draw_mode() == GL_LINE_STRIP) {
+         if ((render_data->draw_mode() == GL_LINE_STRIP) ||
+             (render_data->draw_mode() == GL_LINES) ||
+             (render_data->draw_mode() == GL_LINE_LOOP)) {
              if (curr_material->hasUniform("line_width")) {
                  float lineWidth = curr_material->getFloat("line_width");
                  glLineWidth(lineWidth);

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -221,7 +221,7 @@ void Renderer::renderCamera(Scene* scene, Camera* camera, int framebufferId,
     GL(glBlendEquation (GL_FUNC_ADD));
     GL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
     GL(glDisable (GL_POLYGON_OFFSET_FILL));
-
+    GL(glLineWidth(1.0f));
     if (post_effects.size() == 0) {
         GL(glBindFramebuffer(GL_FRAMEBUFFER, framebufferId));
         GL(glViewport(viewportX, viewportY, viewportWidth, viewportHeight));
@@ -756,12 +756,12 @@ void Renderer::renderMaterialShader(RenderState& rstate, RenderData* render_data
                  float lineWidth = curr_material->getFloat("line_width");
                  glLineWidth(lineWidth);
                  shader->render(&rstate, render_data, curr_material);
-                 glLineWidth(1.0f);
              }
          }
          else {
-             shader->render(&rstate, render_data, curr_material);
-         }
+             glLineWidth(1.0f);
+        }
+         shader->render(&rstate, render_data, curr_material);
     } catch (const std::string &error) {
         LOGE(
                 "Error detected in Renderer::renderRenderData; name : %s, error : %s",

--- a/GVRf/Framework/framework/src/main/jni/objects/material.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/material.h
@@ -175,6 +175,10 @@ public:
         }
     }
 
+    bool hasTexture() const {
+        return (main_texture != NULL) || (textures_.size() > 0);
+    }
+
     bool hasUniform(const std::string& key) const {
         if (vec3s_.find(key) != vec3s_.end()) {
             return true;

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/assimp_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/assimp_shader.cpp
@@ -200,7 +200,6 @@ AssimpShader::~AssimpShader() {
 
 void AssimpShader::render(RenderState* rstate,
         RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture;
     int feature_set = material->get_shader_feature_set();
 
@@ -228,8 +227,6 @@ void AssimpShader::render(RenderState* rstate,
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
 
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
 
@@ -254,7 +251,7 @@ void AssimpShader::render(RenderState* rstate,
         if (u_bone_matrices_ == -1) {
             LOGD("Warning! Unable to get the location of uniform u_bone_matrix[0]\n");
         }
-
+        Mesh* mesh = render_data->mesh();
         mesh->setBoneLoc(a_bone_indices_, a_bone_weights_);
         mesh->generateBoneArrayBuffers();
 
@@ -268,12 +265,6 @@ void AssimpShader::render(RenderState* rstate,
 
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("AssimpShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/bounding_box_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/bounding_box_shader.cpp
@@ -53,18 +53,8 @@ BoundingBoxShader::~BoundingBoxShader() {
 
 void BoundingBoxShader::render(const glm::mat4& mvp_matrix,
         RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
-
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(mvp_matrix));
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("BoundingBoxShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/cubemap_reflection_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/cubemap_reflection_shader.cpp
@@ -113,7 +113,6 @@ CubemapReflectionShader::~CubemapReflectionShader() {
 }
 
 void CubemapReflectionShader::render(RenderState* rstate, RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
@@ -124,10 +123,7 @@ void CubemapReflectionShader::render(RenderState* rstate, RenderData* render_dat
         throw error;
     }
 
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
-
     glUniformMatrix4fv(u_mv_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mv));
     glUniformMatrix4fv(u_mv_it_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mv_it));
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
@@ -138,12 +134,6 @@ void CubemapReflectionShader::render(RenderState* rstate, RenderData* render_dat
     glUniform1i(u_texture_, 0);
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("CubemapReflectionShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/cubemap_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/cubemap_shader.cpp
@@ -101,7 +101,6 @@ CubemapShader::~CubemapShader() {
 }
 
 void CubemapShader::render(RenderState* rstate, RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
@@ -110,11 +109,7 @@ void CubemapShader::render(RenderState* rstate, RenderData* render_data, Materia
         std::string error = "CubemapShader::render : texture with wrong target";
         throw error;
     }
-
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
-
     glUniformMatrix4fv(u_model_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_model));
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
     glActiveTexture (GL_TEXTURE0);
@@ -122,12 +117,6 @@ void CubemapShader::render(RenderState* rstate, RenderData* render_data, Materia
     glUniform1i(u_texture_, 0);
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("CubemapShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/custom_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/custom_shader.cpp
@@ -278,14 +278,10 @@ void CustomShader::render(RenderState* rstate, RenderData* render_data, Material
         }
         checkGlError("CustomShader after bones");
     }
-    /*
-     * Update vertex information
-     */
     mesh->bindVertexAttributes(program_->id());
-    mesh->generateVAO();  // setup VAO
-
-    ///////////// uniform /////////
-
+    /*
+     * Update values of uniform variables
+     */
     {
         std::lock_guard<std::mutex> lock(uniformVariablesLock_);
         for (auto it = uniformVariables_.begin(); it != uniformVariables_.end(); ++it) {
@@ -316,7 +312,9 @@ void CustomShader::render(RenderState* rstate, RenderData* render_data, Material
     if (u_right_ != 0) {
         glUniform1i(u_right_, rstate->uniforms.u_right ? 1 : 0);
     }
-
+    /*
+     * Bind textures
+     */
     int texture_index = 0;
     {
         std::lock_guard<std::mutex> lock(textureVariablesLock_);
@@ -326,7 +324,6 @@ void CustomShader::render(RenderState* rstate, RenderData* render_data, Material
             texture_index++;
         }
     }
-
     /*
      * Update the uniforms for the lights
      */
@@ -345,11 +342,6 @@ void CustomShader::render(RenderState* rstate, RenderData* render_data, Material
     if (castShadow){
     	Light::bindShadowMap(program_->id(), texture_index);
     }
-
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT, 0);
-    glBindVertexArray(0);
     checkGlError("CustomShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/error_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/error_shader.cpp
@@ -51,25 +51,14 @@ ErrorShader::~ErrorShader() {
 }
 
 void ErrorShader::render(RenderState* rstate, RenderData* render_data, Material* mtl_unused) {
-    Mesh* mesh = render_data->mesh();
     float r = 0.0f;
     float g = 1.0f;
     float b = 0.0f;
     float a = 1.0f;
 
-    Material* material = render_data->pass(0)->material();
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
-
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
     glUniform4f(u_color_, r, g, b, a);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("ErrorShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/lightmap_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/lightmap_shader.cpp
@@ -74,13 +74,10 @@ LightMapShader::~LightMapShader() {
 void LightMapShader::render(RenderState* rstate,
         RenderData* render_data, Material* material) {
 
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     Texture* lightmap_texture = material->getTexture("lightmap_texture");
     glm::vec2 lightmap_offset = material->getVec2("lightmap_offset");
     glm::vec2 lightmap_scale = material->getVec2("lightmap_scale");
-
-    mesh->generateVAO();
 
     glUseProgram(program_->id());
 
@@ -96,11 +93,6 @@ void LightMapShader::render(RenderState* rstate,
 
     glUniform2f(u_lightmap_offset_, lightmap_offset.x, lightmap_offset.y);
     glUniform2f(u_lightmap_scale_, lightmap_scale.x, lightmap_scale.y);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT, 0);
-    glBindVertexArray(0);
-
     checkGlError("LightMapShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/oes_horizontal_stereo_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/oes_horizontal_stereo_shader.cpp
@@ -69,7 +69,6 @@ OESHorizontalStereoShader::~OESHorizontalStereoShader() {
 
 void OESHorizontalStereoShader::render(RenderState* rstate,
         RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
@@ -87,8 +86,6 @@ void OESHorizontalStereoShader::render(RenderState* rstate,
         mono_rendering  = false;
     }
 
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
 
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
@@ -98,12 +95,6 @@ void OESHorizontalStereoShader::render(RenderState* rstate,
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
     glUniform1i(u_right_, mono_rendering || rstate->uniforms.u_right ? 1 : 0);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("OESHorizontalStereoShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/oes_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/oes_shader.cpp
@@ -64,7 +64,6 @@ OESShader::~OESShader() {
 }
 
 void OESShader::render(RenderState* rstate, RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
@@ -74,22 +73,13 @@ void OESShader::render(RenderState* rstate, RenderData* render_data, Material* m
         throw error;
     }
 
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
-
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
     glActiveTexture (GL_TEXTURE0);
     glBindTexture(texture->getTarget(), texture->getId());
     glUniform1i(u_texture_, 0);
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("OESShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/oes_vertical_stereo_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/oes_vertical_stereo_shader.cpp
@@ -69,7 +69,6 @@ OESVerticalStereoShader::~OESVerticalStereoShader() {
 
 void OESVerticalStereoShader::render(RenderState* rstate,
         RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
@@ -87,10 +86,7 @@ void OESVerticalStereoShader::render(RenderState* rstate,
         mono_rendering = false;
     }
 
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
-
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
     glActiveTexture (GL_TEXTURE0);
     glBindTexture(texture->getTarget(), texture->getId());
@@ -98,12 +94,6 @@ void OESVerticalStereoShader::render(RenderState* rstate,
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
     glUniform1i(u_right_, mono_rendering || rstate->uniforms.u_right ? 1 : 0);
-    glBindVertexArray(mesh->getVAOId());
-
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("OESVerticalStereoShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/texture_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/texture_shader.cpp
@@ -173,7 +173,6 @@ TextureShader::~TextureShader() {
 
 void TextureShader::render(RenderState* rstate,
         RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
@@ -195,8 +194,6 @@ void TextureShader::render(RenderState* rstate,
             use_light = true;
         }
     }
-
-    mesh->generateVAO();
 
     if (use_light) {
         GL(glUseProgram(program_light_->id()));
@@ -243,8 +240,6 @@ void TextureShader::render(RenderState* rstate,
         glUniform4f(u_light_specular_intensity_, light_specular_intensity.r,
                 light_specular_intensity.g, light_specular_intensity.b,
                 light_specular_intensity.a);
-
-        glBindVertexArray(mesh->getVAOId());
     } else {
         glUniformMatrix4fv(u_mvp_no_light_, 1, GL_FALSE,
                 glm::value_ptr(rstate->uniforms.u_mvp));
@@ -252,14 +247,8 @@ void TextureShader::render(RenderState* rstate,
         glUniform1i(u_texture_no_light_, 0);
         glUniform3f(u_color_no_light_, color.r, color.g, color.b);
         glUniform1f(u_opacity_no_light_, opacity);
-        glBindVertexArray(mesh->getVAOId());
     }
-
-    GL(glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0));
-    GL(glBindVertexArray(0));
-
-    checkGlError("TextureShader::render");
+   checkGlError("TextureShader::render");
 }
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_fbo_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_fbo_shader.cpp
@@ -68,7 +68,6 @@ void UnlitFboShader::recycle() {
 
 void UnlitFboShader::render(RenderState* rstate,
         RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
@@ -78,8 +77,6 @@ void UnlitFboShader::render(RenderState* rstate,
         throw error;
     }
 
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
 
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
@@ -88,12 +85,6 @@ void UnlitFboShader::render(RenderState* rstate,
     glUniform1i(u_texture_, 0);
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(),
-            GL_UNSIGNED_SHORT, 0);
-    glBindVertexArray(0);
-
     checkGlError("UnlitFboShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_horizontal_stereo_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_horizontal_stereo_shader.cpp
@@ -68,7 +68,6 @@ UnlitHorizontalStereoShader::~UnlitHorizontalStereoShader() {
 
 void UnlitHorizontalStereoShader::render(RenderState* rstate,
         RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
@@ -86,8 +85,6 @@ void UnlitHorizontalStereoShader::render(RenderState* rstate,
         mono_rendering  = false;
     }
 
-    mesh->generateVAO();
-
     glUseProgram(program_->id());
 
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
@@ -97,12 +94,6 @@ void UnlitHorizontalStereoShader::render(RenderState* rstate,
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
     glUniform1i(u_right_, mono_rendering || rstate->uniforms.u_right ? 1 : 0);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("HorizontalStereoUnlitShader::render");
 }
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_vertical_stereo_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_vertical_stereo_shader.cpp
@@ -68,7 +68,6 @@ UnlitVerticalStereoShader::~UnlitVerticalStereoShader() {
 
 void UnlitVerticalStereoShader::render(RenderState* rstate,
         RenderData* render_data, Material* material) {
-    Mesh* mesh = render_data->mesh();
     Texture* texture = material->getTexture("main_texture");
     glm::vec3 color = material->getVec3("color");
     float opacity = material->getFloat("opacity");
@@ -86,9 +85,7 @@ void UnlitVerticalStereoShader::render(RenderState* rstate,
         mono_rendering = false;
     }
 
-    mesh->generateVAO();
-
-    glUseProgram(program_->id());
+   glUseProgram(program_->id());
 
     glUniformMatrix4fv(u_mvp_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_mvp));
     glActiveTexture (GL_TEXTURE0);
@@ -97,12 +94,6 @@ void UnlitVerticalStereoShader::render(RenderState* rstate,
     glUniform3f(u_color_, color.r, color.g, color.b);
     glUniform1f(u_opacity_, opacity);
     glUniform1i(u_right_, mono_rendering || rstate->uniforms.u_right ? 1 : 0);
-
-    glBindVertexArray(mesh->getVAOId());
-    glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT,
-            0);
-    glBindVertexArray(0);
-
     checkGlError("UnlitShader::render");
 }
 


### PR DESCRIPTION
1. Fixed regression with non-textured meshes
2. Moved mesh handling into the renderer (one place) and out of all the shaders (code duplicated in many places)
3. Added support for line width (set "line_width" uniform in GVRMaterial)
4. Fixed regression in GVRCylinderSceneObject

This pull request fixes the problem with drawing polylines

GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com