### PR TITLE
Support for GVRExternalTexture in GVRVideoSceneObject

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRVideoSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRVideoSceneObject.java
@@ -25,7 +25,6 @@ import org.gearvrf.GVRMaterialShaderId;
 import org.gearvrf.GVRMesh;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRMaterial.GVRShaderType;
-import org.gearvrf.GVRTexture;
 
 import android.graphics.SurfaceTexture;
 import android.media.MediaPlayer;
@@ -48,7 +47,7 @@ public class GVRVideoSceneObject extends GVRSceneObject {
     /**
      * Play a video on a {@linkplain GVRSceneObject scene object} with an
      * arbitrarily complex geometry, using the Android {@link MediaPlayer}
-     *
+     * 
      * @param gvrContext
      *            current {@link GVRContext}
      * @param mesh


### PR DESCRIPTION
A GVRExternalTexture can be provided to create a VideoScene object. This way a MediaPlayer can be shared among multiple GVRVideoSceneObject, also the GVRExternalTexture can be used by application.

GearVRf-DCO-1.0-Signed-off-by: Deepak Rawat
deepak.rawat@samsung.com