### PR TITLE
Added GVRMaterial::setLineWidth, fixed polyline performance bug

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMaterial.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMaterial.java
@@ -633,6 +633,28 @@ public class GVRMaterial extends GVRHybridObject implements
         }
     }
 
+    /**
+     * Gets the line width for line drawing.
+     * 
+     * @see GVRRenderData.setDrawMode
+     */
+    public float getLineWidth() {
+        return NativeMaterial.getFloat(getNative(), "line_width");
+    }
+    
+    /**
+     * Sets the line width for line drawing.
+     * 
+     * By default, the line width is 1. It is applied when the
+     * draw mode is GL_LINES, GL_LINE_STRIP or GL_LINE_LOOP.
+     * 
+     * @param lineWidth new line width.
+     * @see GVRRenderData.setDrawMode
+     */
+    public void setLineWidth(float lineWidth) {
+        NativeMaterial.setFloat(getNative(), "line_width", lineWidth);
+    }
+    
     public float getFloat(String key) {
         return NativeMaterial.getFloat(getNative(), key);
     }

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -757,12 +757,11 @@ void Renderer::renderMaterialShader(RenderState& rstate, RenderData* render_data
              if (curr_material->hasUniform("line_width")) {
                  float lineWidth = curr_material->getFloat("line_width");
                  glLineWidth(lineWidth);
-                 shader->render(&rstate, render_data, curr_material);
+             }
+             else {
+                 glLineWidth(1.0f);
              }
          }
-         else {
-             glLineWidth(1.0f);
-        }
          shader->render(&rstate, render_data, curr_material);
     } catch (const std::string &error) {
         LOGE(


### PR DESCRIPTION
renderer was accidentally calling the shader twice

GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com