### PR TITLE
Added Selectable and Movable objects in 3DCursor

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/MovableBehavior.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/MovableBehavior.java
@@ -1,0 +1,215 @@
+package org.gearvrf.io.cursor3d;
+
+import org.gearvrf.GVRComponent;
+import org.gearvrf.GVRSceneObject;
+import org.gearvrf.utility.Log;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+/**
+ * This class defines a {@link SelectableBehavior} that can be attached to a {@link GVRSceneObject}.
+ * In addition to all the functionality of a {@link SelectableBehavior} this makes the associated
+ * {@link GVRSceneObject} movable with a {@link Cursor}.
+ */
+public class MovableBehavior extends SelectableBehavior {
+    public static final String TAG = MovableBehavior.class.getSimpleName();
+    static private long TYPE_MOVABLE = ((long)MovableBehavior.class.hashCode() << 32) & (System
+            .currentTimeMillis() & 0xffffffff);;
+    private Vector3f prevCursorPosition;
+    private Quaternionf rotation;
+    private Vector3f cross;
+
+    private GVRSceneObject selected;
+    private GVRSceneObject cursorSceneObject;
+    private Cursor cursor;
+    private CursorManager cursorManager;
+
+    /**
+     * Creates a {@link MovableBehavior} to be attached to any {@link GVRSceneObject}. The
+     * instance thus created will not change the appearance of the linked {@link GVRSceneObject}
+     * according to the {@link ObjectState}.
+     *
+     * @param cursorManager the {@link CursorManager} instance
+     */
+    public MovableBehavior(CursorManager cursorManager) {
+        this(cursorManager, false);
+    }
+
+    /**
+     * Creates a {@link MovableBehavior} which is to be attached to a {@link GVRSceneObject}
+     * with a specific hierarchy where, the {@link GVRSceneObject} to be attached has a root node at
+     * the top and a child for each of the states of the {@link MovableBehavior}.
+     * The order of the child nodes has to follow {@link ObjectState#DEFAULT},
+     * {@link ObjectState#BEHIND}, {@link ObjectState#COLLIDING}, and {@link ObjectState#CLICKED}
+     * from left to right.The {@link MovableBehavior} handles all the {@link CursorEvent}s on the
+     * linked {@link GVRSceneObject} and maintains the {@link ObjectState} as well as moving the
+     * {@link GVRSceneObject} with the movement of a {@link Cursor}. It also makes the correct child
+     * {@link GVRSceneObject} visible according to the {@link ObjectState}. It is recommended that
+     * the different nodes representing different {@link ObjectState} share a common set of vertices
+     * if possible. Not having the needed hierarchy will result in an
+     * {@link IllegalArgumentException} when calling
+     * {@link GVRSceneObject#attachComponent(GVRComponent)}
+     *
+     * @param cursorManager       the {@link CursorManager} instance
+     * @param initializeAllStates flag to indicate whether to initialize all
+     *                            possible {@link ObjectState}s. <code>true</code> initialize all
+     *                            states in order from left to right:{@link ObjectState#DEFAULT},
+     *                            {@link ObjectState#BEHIND}, {@link ObjectState#COLLIDING}, and
+     *                            {@link ObjectState#CLICKED}. <code>false</code> initializes only
+     *                            the {@link ObjectState#DEFAULT} state. Which does not require the
+     *                            attached  {@link GVRSceneObject} to have a hierarchy.
+     */
+    public MovableBehavior(CursorManager cursorManager, boolean initializeAllStates) {
+        super(cursorManager, initializeAllStates);
+        initialize(cursorManager);
+    }
+
+    /**
+     * Creates a {@link MovableBehavior} which is to be attached to a {@link GVRSceneObject}
+     * with a specific hierarchy where, the {@link GVRSceneObject} to be attached has a root node at
+     * the top and a child for each of the states of the {@link MovableBehavior}.
+     * The {@link MovableBehavior} handles all the {@link CursorEvent}s on the linked
+     * {@link GVRSceneObject} and maintains the {@link ObjectState} as well as moves the associated
+     * {@link GVRSceneObject} with the {@link Cursor}. It also makes the correct child
+     * {@link GVRSceneObject} visible according to the {@link ObjectState}. It is recommended to
+     * have a child for each {@link ObjectState} value, however it is possible to have lesser
+     * children as long as the mapping is correctly specified in {@param objectStates}. If the
+     * {@param objectStates} does not match the {@link GVRSceneObject} hierarchy it will result in
+     * an {@link IllegalArgumentException} when calling
+     * {@link GVRSceneObject#attachComponent(GVRComponent)}. To save on memory it is suggested that
+     * the children of the {@link GVRSceneObject} representing different {@link ObjectState}s share
+     * a common set of vertices if possible.
+     *
+     * @param cursorManager the {@link CursorManager} instance
+     * @param objectStates  array of {@link ObjectState}s that maps each child of the attached
+     *                      {@link GVRSceneObject} with an {@link ObjectState}. Where the first
+     *                      element of the array maps to the left most/first child of the attached
+     *                      {@link GVRSceneObject}. This array should contain
+     *                      {@link ObjectState#DEFAULT} as one of its elements else it will result
+     *                      in an {@link IllegalArgumentException}.
+     */
+    public MovableBehavior(CursorManager cursorManager, ObjectState[] objectStates) {
+        super(cursorManager, objectStates);
+        initialize(cursorManager);
+    }
+
+    private void initialize(CursorManager cursorManager) {
+        prevCursorPosition = new Vector3f();
+        rotation = new Quaternionf();
+        cross = new Vector3f();
+        this.cursorManager = cursorManager;
+        mType = getComponentType();
+    }
+
+    @Override
+    void handleClickEvent(CursorEvent event) {
+        if (selected != null && cursor != event.getCursor()) {
+            // We have a selected object but not the correct cursor
+            return;
+        }
+
+        cursor = event.getCursor();
+        cursorSceneObject = event.getCursor().getSceneObject();
+        prevCursorPosition.set(cursor.getPositionX(), cursor.getPositionY(), cursor
+                .getPositionZ());
+        selected = getOwnerObject();
+        if (cursor.getCursorType() == CursorType.OBJECT) {
+            Vector3f position = new Vector3f(cursor.getPositionX(), cursor.getPositionY(),
+                    cursor.getPositionZ());
+
+            selected.getTransform().setPosition(-position.x + selected.getTransform()
+                    .getPositionX(), -position.y + selected.getTransform()
+                    .getPositionY(), -position.z + selected.getTransform().getPositionZ());
+            cursorSceneObject.addChildObject(selected);
+        }
+    }
+
+    @Override
+    void handleDragEvent(CursorEvent event) {
+        if (cursor.getCursorType() == CursorType.LASER && cursor == event.getCursor()) {
+            Cursor cursor = event.getCursor();
+            Vector3f cursorPosition = new Vector3f(cursor.getPositionX(), cursor.getPositionY
+                    (), cursor.getPositionZ());
+            rotateObjectToFollowCursor(cursorPosition);
+            prevCursorPosition = cursorPosition;
+        }
+    }
+
+    @Override
+    void handleCursorLeave(CursorEvent event) {
+        if (event.isActive() && cursor == event.getCursor()) {
+            if (cursor.getCursorType() == CursorType.LASER) {
+                Vector3f cursorPosition = new Vector3f(cursor.getPositionX(), cursor
+                        .getPositionY(), cursor.getPositionZ());
+                rotateObjectToFollowCursor(cursorPosition);
+                prevCursorPosition = cursorPosition;
+            } else if (cursor.getCursorType() == CursorType.OBJECT) {
+                Log.d(TAG, "handleCursorLeave");
+                handleClickReleased(event);
+            }
+        }
+    }
+
+    @Override
+    void handleClickReleased(CursorEvent event) {
+
+        if (selected != null && cursor != event.getCursor()) {
+            // We have a selected object but not the correct cursor
+            return;
+        }
+
+        if (selected != null && cursor.getCursorType() == CursorType.OBJECT) {
+            Vector3f position = new Vector3f(cursor.getPositionX(), cursor.getPositionY
+                    (), cursor.getPositionZ());
+            cursorSceneObject.removeChildObject(selected);
+            selected.getTransform().setPosition(+position.x + selected.getTransform()
+                    .getPositionX(), +position.y + selected.getTransform()
+                    .getPositionY(), +position.z + selected.getTransform().getPositionZ());
+        }
+        selected = null;
+        // object has been moved, invalidate all other cursors to check for events
+        for (Cursor remaining : cursorManager.getActiveCursors()) {
+            if (cursor != remaining) {
+                remaining.invalidate();
+            }
+        }
+    }
+
+    private void rotateObjectToFollowCursor(Vector3f cursorPosition) {
+        computeRotation(prevCursorPosition, cursorPosition);
+        getOwnerObject().getTransform().rotateWithPivot(rotation.w, rotation.x, rotation.y,
+                rotation.z, 0,
+                0, 0);
+        getOwnerObject().getTransform().setRotation(1, 0, 0, 0);
+    }
+
+    /*
+    formulae for quaternion rotation taken from
+    http://lolengine.net/blog/2014/02/24/quaternion-from-two-vectors-final
+    */
+    private void computeRotation(Vector3f start, Vector3f end) {
+        float norm_u_norm_v = (float) Math.sqrt(start.dot(start) * end.dot(end));
+        float real_part = norm_u_norm_v + start.dot(end);
+
+        if (real_part < 1.e-6f * norm_u_norm_v) {
+        /* If u and v are exactly opposite, rotate 180 degrees
+         * around an arbitrary orthogonal axis. Axis normalisation
+         * can happen later, when we normalise the quaternion. */
+            real_part = 0.0f;
+            if (Math.abs(start.x) > Math.abs(start.z)) {
+                cross = new Vector3f(-start.y, start.x, 0.f);
+            } else {
+                cross = new Vector3f(0.f, -start.z, start.y);
+            }
+        } else {
+                /* Otherwise, build quaternion the standard way. */
+            start.cross(end, cross);
+        }
+        rotation.set(cross.x, cross.y, cross.z, real_part).normalize();
+    }
+
+    public static long getComponentType() {
+        return TYPE_MOVABLE;
+    }
+}
+

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/SelectableBehavior.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/SelectableBehavior.java
@@ -1,0 +1,418 @@
+package org.gearvrf.io.cursor3d;
+
+import android.util.SparseArray;
+import android.view.KeyEvent;
+
+import org.gearvrf.GVRBehavior;
+import org.gearvrf.GVRComponent;
+import org.gearvrf.GVRSceneObject;
+import org.gearvrf.GVRSwitch;
+import org.gearvrf.GVRTransform;
+
+import java.util.HashMap;
+
+/**
+ * This class defines a {@link GVRBehavior} that can be attached to a {@link GVRSceneObject}, it
+ * handles all the {@link CursorEvent}s on the associated {@link GVRSceneObject} and
+ * maintains the correct {@link ObjectState} based on the {@link CursorEvent}s received. This
+ * class can associate a child {@link GVRSceneObject} with each {@link ObjectState} and is
+ * responsible for making the correct {@link GVRSceneObject} visible according to the
+ * {@link ObjectState}.
+ */
+public class SelectableBehavior extends GVRBehavior {
+    private static final String TAG = SelectableBehavior.class.getSimpleName();
+    static private long TYPE_SELECTABLE = ((long)SelectableBehavior.class.hashCode() << 32) & (System
+            .currentTimeMillis() & 0xffffffff);;
+    private static final String DEFAULT_ASSET_NEEDED = "Asset for Default state should be " +
+            "specified";
+    private GVRSwitch gvrSwitch;
+    private ObjectState state = ObjectState.DEFAULT;
+    private HashMap<ObjectState, Integer> stateIndexMap;
+    private boolean previousActive;
+    private boolean previousOver;
+    private SparseArray<ObjectState> states;
+    protected ObjectState currentState = ObjectState.DEFAULT;
+    private StateChangedListener stateChangedListener;
+    private CursorManager cursorManager;
+
+    /**
+     * Set a {@link StateChangedListener} using
+     * {@link SelectableBehavior#setStateChangedListener(StateChangedListener)} to get updates about
+     * the change of the state of the {@link SelectableBehavior}
+     */
+    public interface StateChangedListener {
+        /**
+         * is called whenever the state of the {@link SelectableBehavior} changes.
+         *
+         * @param prev    the previous state
+         * @param current current state to be set.
+         */
+        void onStateChanged(ObjectState prev, ObjectState current);
+    }
+
+    /**
+     * Define all possible states the {@link SelectableBehavior} can be in
+     */
+    public enum ObjectState {
+        /**
+         * The state in which the {@link SelectableBehavior} is initially. This represents the
+         * normal
+         * appearance of the associated {@link GVRSceneObject}
+         */
+        DEFAULT,
+        /**
+         * This state means that a {@link Cursor} is behind the associated {@link GVRSceneObject}.
+         * Recommended appearance of the associated {@link GVRSceneObject} in this state is a wire
+         * frame or a transparent texture, to allow the {@link Cursor} to be visible to the user.
+         */
+        BEHIND,
+        /**
+         * This state means that a
+         * {@link Cursor} is intersecting with the associated {@link GVRSceneObject}
+         * It is recommended that the appearance of the associated {@link GVRSceneObject} in this
+         * state changes from the {@link ObjectState#DEFAULT} to make the user aware of a collision.
+         */
+        COLLIDING,
+        /**
+         * This state means that a {@link Cursor} is intersecting with the associated
+         * {@link GVRSceneObject} and {@link CursorEvent#isActive} returns true. It is recommended
+         * that the appearance of the associated {@link GVRSceneObject} in this state changes
+         * from the {@link ObjectState#DEFAULT} to make the user aware of the clicked state.
+         */
+        CLICKED
+    }
+
+    /**
+     * Creates a {@link SelectableBehavior} to be attached to any {@link GVRSceneObject}. The
+     * instance thus created will not change the appearance of the linked {@link GVRSceneObject}
+     * according to the {@link ObjectState}.
+     *
+     * @param cursorManager
+     */
+    public SelectableBehavior(CursorManager cursorManager) {
+        this(cursorManager, false);
+    }
+
+    /**
+     * Creates a {@link SelectableBehavior} which is to be attached to a {@link GVRSceneObject}
+     * with a specific hierarchy where, the attached {@link GVRSceneObject} has a separate child
+     * {@link GVRSceneObject} for each {@link ObjectState}. The order of the child nodes has to
+     * follow {@link ObjectState#DEFAULT}, {@link ObjectState#BEHIND}, {@link ObjectState#COLLIDING},
+     * and {@link ObjectState#CLICKED} from left to right where {@link ObjectState#DEFAULT}
+     * corresponds to the first/left most child. The {@link SelectableBehavior} handles all the
+     * {@link CursorEvent}s on the linked {@link GVRSceneObject} and maintains the
+     * {@link ObjectState}. It also makes the correct child {@link GVRSceneObject} visible according
+     * to the {@link ObjectState}. It is recommended that the different nodes representing different
+     * {@link ObjectState} share a common set of vertices if possible. Not having the needed
+     * hierarchy will result in an {@link IllegalArgumentException} when calling
+     * {@link GVRSceneObject#attachComponent(GVRComponent)}
+     *
+     * @param cursorManager       the {@link CursorManager} instance
+     * @param initializeAllStates flag to indicate whether to initialize all
+     *                            possible {@link ObjectState}s. <code>true</code> initialize all
+     *                            states in order from left to right:{@link ObjectState#DEFAULT},
+     *                            {@link ObjectState#BEHIND}, {@link ObjectState#COLLIDING}, and
+     *                            {@link ObjectState#CLICKED}. <code>false</code> initializes only
+     *                            the {@link ObjectState#DEFAULT} state. Which does not require the
+     *                            attached  {@link GVRSceneObject} to have a hierarchy.
+     */
+    public SelectableBehavior(CursorManager cursorManager, boolean initializeAllStates) {
+        this(cursorManager, initializeAllStates ? new ObjectState[]{ObjectState.DEFAULT,
+                ObjectState.BEHIND, ObjectState.COLLIDING, ObjectState.CLICKED} : new ObjectState[]{
+                ObjectState.DEFAULT});
+    }
+
+    /**
+     * Creates a {@link SelectableBehavior} which is to be attached to a {@link GVRSceneObject}
+     * with a specific hierarchy where, the {@link GVRSceneObject} to be attached has a root node at
+     * the top and a child for each of the states of the {@link SelectableBehavior}.
+     * The {@link SelectableBehavior} handles all the {@link CursorEvent}s on the linked
+     * {@link GVRSceneObject} and maintains the {@link ObjectState}. It also makes the correct child
+     * {@link GVRSceneObject} visible according to the {@link ObjectState}. It is recommended to
+     * have a child for each {@link ObjectState} value, however it is possible to have lesser
+     * children as long as the mapping is correctly specified in {@param objectStates}. If the
+     * {@param objectStates} does not match the {@link GVRSceneObject} hierarchy it will result in
+     * an {@link IllegalArgumentException} when calling
+     * {@link GVRSceneObject#attachComponent(GVRComponent)}. To save on memory it is suggested that
+     * the children of the {@link GVRSceneObject} representing different {@link ObjectState}s share
+     * a common set of vertices if possible.
+     *
+     * @param cursorManager the {@link CursorManager} instance
+     * @param objectStates  array of {@link ObjectState}s that maps each child of the attached
+     *                      {@link GVRSceneObject} with an {@link ObjectState}. Where the first
+     *                      element of the array maps to the left most/first child of the attached
+     *                      {@link GVRSceneObject}. This array should contain
+     *                      {@link ObjectState#DEFAULT} as one of its elements else it will result
+     *                      in an {@link IllegalArgumentException}.
+     */
+    public SelectableBehavior(CursorManager cursorManager, ObjectState[] objectStates) {
+        super(cursorManager.getGvrContext());
+        mType = getComponentType();
+        this.cursorManager = cursorManager;
+        states = new SparseArray<ObjectState>();
+        stateIndexMap = new HashMap<ObjectState, Integer>();
+
+        boolean defaultState = false;
+        for (int i = 0; i < objectStates.length; i++) {
+            if (objectStates[i] == ObjectState.DEFAULT) {
+                defaultState = true;
+            }
+            stateIndexMap.put(objectStates[i], i);
+        }
+
+        if (!defaultState) {
+            throw new IllegalArgumentException(DEFAULT_ASSET_NEEDED);
+        }
+        setState(ObjectState.DEFAULT);
+    }
+
+    @Override
+    public void onAttach(GVRSceneObject sceneObject) {
+
+        if (stateIndexMap.size() > 1 && sceneObject.getChildrenCount() != stateIndexMap.size()) {
+            throw new IllegalArgumentException("Num of children in model:" + sceneObject
+                    .getChildrenCount() + " does not match the states array:" + stateIndexMap
+                    .size());
+        }
+
+        if (stateIndexMap.size() > 1) {
+            gvrSwitch = new GVRSwitch(sceneObject.getGVRContext());
+            sceneObject.attachComponent(gvrSwitch);
+        }
+        cursorManager.addSelectableObject(sceneObject);
+    }
+
+    /**
+     * Gets the current {@link ObjectState} of the {@link SelectableBehavior}
+     *
+     * @return
+     */
+    public ObjectState getState() {
+        return state;
+    }
+
+    private boolean isHigherOrEqualStatePresent(ObjectState targetState) {
+
+        for (int i = 0; i < states.size(); i++) {
+            if (states.get(i) != null && targetState.ordinal() <= states.get(i).ordinal()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void setButtonPress(int cursorId) {
+        states.remove(cursorId);
+        if (!isHigherOrEqualStatePresent(ObjectState.CLICKED)) {
+            currentState = ObjectState.CLICKED;
+            setState(currentState);
+        }
+        states.put(cursorId, ObjectState.CLICKED);
+    }
+
+    private void setIntersect(int cursorId) {
+        states.remove(cursorId);
+        if (!isHigherOrEqualStatePresent(ObjectState.CLICKED)) {
+            currentState = ObjectState.COLLIDING;
+            setState(currentState);
+        }
+        states.put(cursorId, ObjectState.COLLIDING);
+    }
+
+    private void setWireFrame(int cursorId) {
+        states.remove(cursorId);
+        if (!isHigherOrEqualStatePresent(ObjectState.BEHIND)) {
+            currentState = ObjectState.BEHIND;
+            setState(currentState);
+        }
+        states.put(cursorId, ObjectState.BEHIND);
+    }
+
+    private ObjectState getHighestPriorityState() {
+        ObjectState highestPriority = ObjectState.DEFAULT;
+        for (int i = 0; i < states.size(); i++) {
+            ObjectState state = states.get(i);
+
+            if (state != null && state.ordinal() > highestPriority.ordinal()) {
+                highestPriority = state;
+            }
+        }
+        return highestPriority;
+    }
+
+    private void setDefault(int cursorId) {
+        states.remove(cursorId);
+        ObjectState highestPriority = getHighestPriorityState();
+        if (currentState != highestPriority) {
+            currentState = highestPriority;
+            setState(currentState);
+        }
+        states.put(cursorId, ObjectState.DEFAULT);
+    }
+
+    private void setState(ObjectState state) {
+        if (this.state != state && stateChangedListener != null) {
+            stateChangedListener.onStateChanged(this.state, state);
+        }
+        this.state = state;
+        Integer childIndex = stateIndexMap.get(state);
+        if (childIndex != null && gvrSwitch != null) {
+            gvrSwitch.setSwitchIndex(childIndex);
+        }
+    }
+
+    void handleCursorEvent(CursorEvent event) {
+        Cursor cursor = event.getCursor();
+        float cursorDistance = getDistance(cursor.getPositionX(), cursor.getPositionY(), cursor
+                .getPositionZ());
+        float soDistance = getDistance(getOwnerObject());
+        boolean isOver = event.isOver();
+        boolean isActive = event.isActive();
+        boolean isColliding = event.isColliding();
+        int cursorId = event.getCursor().getId();
+        KeyEvent keyEvent = event.getKeyEvent();
+
+        ObjectState state = states.get(cursorId);
+        if (state == null) {
+            return;
+        }
+        switch (state) {
+            case DEFAULT:
+                if (!isOver) {
+                    break;
+                }
+                if (isColliding) {
+                    if (isActive && previousOver && !previousActive) {
+                        if (keyEvent != null && keyEvent.getAction() == KeyEvent.ACTION_DOWN) {
+                            setButtonPress(cursorId);
+                            handleClickEvent(event);
+                        }
+                    } else if (!isActive) {
+                        setIntersect(cursorId);
+                    }
+                } else if (cursorDistance > soDistance) {
+                    setWireFrame(cursorId);
+                }
+                break;
+            case CLICKED:
+                if (isOver && isColliding) {
+                    if (isActive) {
+                        handleDragEvent(event);
+                    } else {
+                        setIntersect(cursorId);
+                        handleClickReleased(event);
+                    }
+                } else {
+                    if (isActive) {
+                        if (event.getCursor().getCursorType() == CursorType.OBJECT) {
+                            setDefault(cursorId);
+                        }
+                        handleCursorLeave(event);
+                    } else {
+                        setDefault(cursorId);
+                        handleClickReleased(event);
+                    }
+                }
+                break;
+            case COLLIDING:
+                if (!isOver) {
+                    setDefault(cursorId);
+                    break;
+                }
+                if (isColliding) {
+                    if (isActive) {
+                        if (keyEvent != null && keyEvent.getAction() == KeyEvent.ACTION_DOWN) {
+                            setButtonPress(cursorId);
+                            handleClickEvent(event);
+                        }
+                    }
+                } else {
+                    if (cursorDistance > soDistance) {
+                        setWireFrame(cursorId);
+                    } else if (cursorDistance < soDistance) {
+                        setDefault(cursorId);
+                    }
+                }
+                break;
+            case BEHIND:
+                if (!isOver) {
+                    setDefault(cursorId);
+                    break;
+                }
+                if (isColliding) {
+                    if (isActive) {
+                        if (keyEvent != null && keyEvent.getAction() == KeyEvent.ACTION_DOWN) {
+                            setButtonPress(cursorId);
+                            handleClickEvent(event);
+                        }
+                    } else {
+                        setIntersect(cursorId);
+                    }
+                } else if (cursorDistance < soDistance) {
+                    setDefault(cursorId);
+                }
+                break;
+        }
+        previousOver = event.isOver();
+        previousActive = event.isActive();
+    }
+
+    void handleClickEvent(CursorEvent event) {
+    }
+
+    void handleClickReleased(CursorEvent event) {
+    }
+
+    void handleCursorLeave(CursorEvent event) {
+    }
+
+    void handleDragEvent(CursorEvent event) {
+    }
+
+    float getDistance(GVRSceneObject object) {
+        GVRTransform transform = object.getTransform();
+        float x = transform.getPositionX();
+        float y = transform.getPositionY();
+        float z = transform.getPositionZ();
+        return (float) Math.sqrt(x * x + y * y + z * z);
+    }
+
+    float getDistance(float x, float y, float z) {
+        return (float) Math.sqrt(x * x + y * y + z * z);
+    }
+
+    void onCursorDeactivated(Cursor cursor) {
+        int cursorId = cursor.getId();
+        ObjectState state = states.get(cursorId);
+        if (state != null) {
+            states.remove(cursorId);
+            if (currentState == state) {
+                ObjectState highestPrioritState = getHighestPriorityState();
+                setState(highestPrioritState);
+            }
+        }
+
+        if (getOwnerObject().getParent() == cursor.getSceneObject()) {
+            cursor.getSceneObject().removeChildObject(getOwnerObject());
+        }
+    }
+
+    void onCursorActivated(Cursor cursor) {
+        states.put(cursor.getId(), ObjectState.DEFAULT);
+    }
+
+    /**
+     * Set the {@link StateChangedListener} to be associated with the {@link SelectableBehavior}.
+     * The {@link StateChangedListener#onStateChanged(ObjectState, ObjectState)} is called every
+     * time the state of the {@link SelectableBehavior} is changed.
+     *
+     * @param listener the {@link StateChangedListener}
+     */
+    public void setStateChangedListener(StateChangedListener listener) {
+        stateChangedListener = listener;
+    }
+
+    public static long getComponentType() {
+        return TYPE_SELECTABLE;
+    }
+}

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorManager.java
@@ -83,7 +83,7 @@ class SensorManager {
         }
 
         // Well at least we are not comparing against all scene objects.
-        if (objectSensor != null && objectSensor.isEnabled()) {
+        if (objectSensor != null && objectSensor.isEnabled() && object.isEnabled()) {
 
             /**
              * Compare ray against the hierarchical bounding volume and then add


### PR DESCRIPTION
1. Adding SelectableObject and MovableObject support in 3DCursorLibrary
   reduces complexity of Applications using the 3DCursor.
2. Moved processing cursor events inside the CursorManager
3. In GVRBaseSensor avoid forwarding events to GVRSceneObjects that are not
   enabled.


Depends on https://github.com/Samsung/GearVRf/pull/651 and https://github.com/Samsung/GearVRf/pull/646

GearVRf-DCO-1.0-Signed-off-by: Parth Mehta <parth.mehta@samsung.com>