### PR TITLE
3DCursor: Use the setEnable call to switch assets

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/AnimatedCursorAsset.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/AnimatedCursorAsset.java
@@ -23,6 +23,7 @@ import org.gearvrf.GVRHybridObject;
 import org.gearvrf.GVRMaterial;
 import org.gearvrf.GVRMesh;
 import org.gearvrf.GVRRenderData;
+import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRTexture;
 import org.gearvrf.ZipLoader;
 import org.gearvrf.animation.GVRAnimation;
@@ -74,12 +75,12 @@ class AnimatedCursorAsset extends MeshCursorAsset {
         int key = sceneObject.getId();
         GVRImageFrameAnimation animation = animations.get(key);
         if (animation == null) {
-            GVRRenderData renderData = renderDataArray.get(key);
-            if (renderData == null) {
+            GVRSceneObject assetSceneObject = sceneObjectArray.get(key);
+            if (assetSceneObject == null) {
                 Log.e(TAG, "Render data not found, should not happen");
                 return;
             }
-
+            GVRRenderData renderData = assetSceneObject.getRenderData();
             GVRMaterial loadingMaterial = renderData.getMaterial();
             loadingMaterial.setMainTexture(loaderTextures.get(0));
             animation = new GVRImageFrameAnimation(loadingMaterial,
@@ -142,7 +143,7 @@ class AnimatedCursorAsset extends MeshCursorAsset {
         animations.remove(sceneObject.getId());
 
         // check if there are cursors still using the textures
-        if (renderDataArray.size() == 0) {
+        if (sceneObjectArray.size() == 0) {
             loaderTextures.clear();
             loaderTextures = null;
         }

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/Cursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/Cursor.java
@@ -151,6 +151,11 @@ public abstract class Cursor {
         cursorTheme = theme;
         audioManager.loadTheme(cursorTheme);
         theme.load(cursorSceneObject);
+        if(scene != null) {
+            // new objects have been added to the cursorSceneObject
+            // force bind shaders
+            scene.bindShaders(cursorSceneObject.getMainSceneObject());
+        }
         if (currentCursorAsset != null) {
             currentCursorAsset = cursorTheme.getAsset(currentCursorAsset.getAction());
             if (currentCursorAsset == null) {

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorSceneObject.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorSceneObject.java
@@ -110,40 +110,20 @@ class CursorSceneObject {
         }
     }
 
-    void attachRenderData(GVRRenderData renderData) {
-        // wait for completion of the collision test
-        synchronized (lock) {
-            meshSceneObject.attachRenderData(renderData);
-        }
-    }
-
-    void detachRenderData() {
-        // wait for completion of the collision test
-        synchronized (lock) {
-            meshSceneObject.detachRenderData();
-        }
-    }
-
-    void addExternalChildObject(GVRSceneObject sceneObject) {
-        externalSceneObject.addChildObject(sceneObject);
-    }
-
     void addChildObject(GVRSceneObject sceneObject) {
-        meshSceneObject = getMeshObject(sceneObject);
         cursor.addChildObject(sceneObject);
     }
 
-    void removeExternalChildObject(GVRSceneObject sceneObject) {
-        externalSceneObject.removeChildObject(sceneObject);
+    void set(GVRSceneObject sceneObject){
+        meshSceneObject = getMeshObject(sceneObject);
+    }
+
+    void reset(){
+        meshSceneObject = null;
     }
 
     void removeChildObject(GVRSceneObject sceneObject) {
-        meshSceneObject = cursor;
         cursor.removeChildObject(sceneObject);
-    }
-
-    boolean hasMesh() {
-        return meshSceneObject.hasMesh();
     }
 
     void setScale(float scale) {

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/IoDevice.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/IoDevice.java
@@ -269,6 +269,19 @@ public class IoDevice {
         }
     }
 
+    /**
+     * Use this method to turn on and off the visibility of the {@link Cursor}
+     *
+     * @param visible <code>true</code> makes the {@link Cursor} visible and
+     *              <code>false</code> turns off its visibility.
+     */
+    protected void setVisible(boolean visible) {
+        GVRSceneObject sceneObject = gvrCursorController.getSceneObject();
+        if (sceneObject != null && sceneObject.isEnabled() != visible) {
+            sceneObject.setEnable(visible);
+        }
+    }
+
     void setSceneObject(GVRSceneObject cursor) {
         gvrCursorController.setSceneObject(cursor);
     }

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursorAsset.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursorAsset.java
@@ -19,6 +19,7 @@ package org.gearvrf.io.cursor3d;
 import android.util.SparseArray;
 
 import org.gearvrf.GVRContext;
+import org.gearvrf.GVRSceneObject;
 import org.gearvrf.animation.GVRAnimation;
 import org.gearvrf.animation.GVRAnimationEngine;
 import org.gearvrf.animation.GVRRepeatMode;
@@ -53,8 +54,9 @@ class ObjectCursorAsset extends CursorAsset {
             Log.e(TAG, "Model not found, should not happen");
             return;
         }
+        sceneObject.set(modelSceneObject);
+        modelSceneObject.setEnable(true);
 
-        sceneObject.addChildObject(modelSceneObject);
         for (GVRAnimation animation : modelSceneObject.getAnimations()) {
             animation.setRepeatMode(GVRRepeatMode.REPEATED);
             animation.setRepeatCount(LOOP_REPEAT_COUNT);
@@ -76,8 +78,11 @@ class ObjectCursorAsset extends CursorAsset {
     @Override
     void reset(CursorSceneObject sceneObject) {
         super.reset(sceneObject);
+
         GVRModelSceneObject modelSceneObject = objects.get(sceneObject.getId());
-        sceneObject.removeChildObject(modelSceneObject);
+
+        sceneObject.reset();
+        modelSceneObject.setEnable(false);
         for (GVRAnimation animation : modelSceneObject.getAnimations()) {
             if (animation.isFinished() == false) {
                 animation.setRepeatMode(GVRRepeatMode.ONCE);
@@ -91,14 +96,19 @@ class ObjectCursorAsset extends CursorAsset {
     void load(CursorSceneObject sceneObject) {
         int key = sceneObject.getId();
         GVRModelSceneObject modelSceneObject = objects.get(key);
+
         if (modelSceneObject == null) {
             modelSceneObject = loadModelSceneObject();
             objects.put(key, modelSceneObject);
         }
+        sceneObject.addChildObject(modelSceneObject);
+        modelSceneObject.setEnable(false);
     }
 
     @Override
     void unload(CursorSceneObject sceneObject) {
+        GVRSceneObject assetSceneObject = objects.get(sceneObject.getId());
+        sceneObject.removeChildObject(assetSceneObject);
         objects.remove(sceneObject.getId());
     }
 }


### PR DESCRIPTION
* Exposed a setVisible() call to hide the Cursor
* Also call bindShaders() after scene objects have been added
to a root node

GearVRf-DCO-1.0-Signed-off-by: Rahul Rudradevan
r.rudradevan@samsung.com