### PR TITLE
Bugfix for GVRBehavior getType

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBehavior.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBehavior.java
@@ -36,7 +36,6 @@ import java.lang.reflect.Method;
 public class GVRBehavior extends GVRComponent implements GVRDrawFrameListener
 {
     protected boolean mIsListening;
-    protected long mType;    
     private boolean mHasFrameCallback;
     static private long TYPE_BEHAVIOR = (System.currentTimeMillis() & 0xfffffff);
     


### PR DESCRIPTION
mType does not need to be declared as a field in GVRBehavior, it is
already a field in GVRComponent. The bug was causing
GVRSceneObject.getComponent(long type) to not work correctly