### PR TITLE
Assigning mType in GVRBehavior and subclasses

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRSwitch.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRSwitch.java
@@ -32,7 +32,8 @@ import java.util.List;
  */
 public class GVRSwitch extends GVRBehavior
 {
-    static private long TYPE_SWITCH = (System.currentTimeMillis() & 0xfffffff);
+    static private long TYPE_SWITCH = ((long)GVRSwitch.class.hashCode() << 32) & (System
+            .currentTimeMillis() & 0xffffffff);
     protected int mSwitchIndex = 0;
 
     public GVRSwitch(GVRContext gvrContext)


### PR DESCRIPTION
Each subclass of GVRBehavior needs a unique type value. Previous approach
of using System.getCurrentTimeMillis() was creating clashes between multiple subclasses this adds a hashcode of the class with the time stamp to create a unique type. 