### PR TITLE
Asset loader: expose events, fix opacity export

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContext.java
@@ -617,8 +617,7 @@ public abstract class GVRContext implements IEventReceiver {
      *             File does not exist or cannot be read
      */
     public GVRModelSceneObject loadModelFromSD(String externalFile, EnumSet<GVRImportSettings> settings) throws IOException {
-        return mImporter.loadModel(externalFile,
-                GVRResourceVolume.VolumeType.ANDROID_SDCARD, settings, true, null);
+        return mImporter.loadModel("sd:" + externalFile, settings, true, null);
     }
 
     /**
@@ -665,7 +664,7 @@ public abstract class GVRContext implements IEventReceiver {
      *
      */
     public GVRModelSceneObject loadModel(String assetFile, EnumSet<GVRImportSettings> settings, GVRScene scene) throws IOException {
-        return mImporter.loadModel(assetFile, GVRResourceVolume.VolumeType.ANDROID_ASSETS, settings, true, scene);
+        return mImporter.loadModel(assetFile, settings, true, scene);
     }
 
     /**
@@ -688,7 +687,7 @@ public abstract class GVRContext implements IEventReceiver {
      *
      */
     public GVRModelSceneObject loadModel(String assetFile, EnumSet<GVRImportSettings> settings) throws IOException {
-        return mImporter.loadModel(assetFile, GVRResourceVolume.VolumeType.ANDROID_ASSETS, settings, true, null);
+        return mImporter.loadModel(assetFile, settings, true, null);
     }
 
     /**
@@ -731,9 +730,7 @@ public abstract class GVRContext implements IEventReceiver {
      *
      */
     public GVRSceneObject loadModelFromURL(String urlString, boolean cacheEnabled) throws IOException {
-        return mImporter.loadModel(urlString,
-                GVRResourceVolume.VolumeType.NETWORK,
-                GVRImportSettings.getRecommendedSettings(), cacheEnabled, null);
+        return mImporter.loadModel(urlString, GVRImportSettings.getRecommendedSettings(), cacheEnabled, null);
     }
 
     
@@ -755,8 +752,7 @@ public abstract class GVRContext implements IEventReceiver {
      *
      */
     public GVRSceneObject loadModelFromURL(String urlString, EnumSet<GVRImportSettings> settings) throws IOException {
-        return mImporter.loadModel(urlString,
-                GVRResourceVolume.VolumeType.NETWORK, settings, true, null);
+        return mImporter.loadModel(urlString, settings, true, null);
     }
 
     /**

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRResourceVolume.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRResourceVolume.java
@@ -21,6 +21,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.gearvrf.utility.FileNameUtils;
+
 import android.os.Environment;
 
 /**
@@ -78,6 +80,35 @@ public class GVRResourceVolume {
         this(gvrContext, volume, null);
     }
 
+    /**
+     * Constructor. Creates a {@link GVRResourceVolume} object based on a filename.
+     * @param filename A filename, relative to the root of the volume.
+     *            If the filename starts with "sd:" the file is assumed to reside on the SD Card.
+     *            If the filename starts with "http:" or "https:" it is assumed to be a URL.
+     *            Otherwise the file is assumed to be relative to the "assets" directory.
+     * @param context The GVR Context.
+     */
+    public GVRResourceVolume(GVRContext context, String filename)
+    {
+        String fname = filename.toLowerCase();
+        gvrContext = context;
+        volumeType = GVRResourceVolume.VolumeType.ANDROID_ASSETS;
+        if (fname.startsWith("sd:"))
+        {
+            String s = FileNameUtils.getParentDirectory(filename);
+            if (s != null)
+            {
+                defaultPath = s.substring(3);
+            }
+            volumeType = GVRResourceVolume.VolumeType.ANDROID_SDCARD;
+        }
+        else if (fname.startsWith("http:") || fname.startsWith("https:"))
+        {
+            volumeType = GVRResourceVolume.VolumeType.NETWORK;
+            defaultPath = FileNameUtils.getURLParentDirectory(filename);
+        }
+    }
+    
     /**
      * Constructor. Creates a {@link GVRResourceVolume} object based on a volume type,
      * and a default path.


### PR DESCRIPTION
Modified asset loader to check filename prefix to determine volume type:
"sd:" indicates SD card, "http:" and "https:" indicate URL, otherwise
assets directory.

Expose asset event handler for users to handle asset loading events

Make Jassimp export opacity correctly (addresses issue in PR #617)
cleaned up version of PR #624