### PR TITLE
Don't add an object to the scene twice (replaces PR #629)

### DIFF
--- a/GVRf/Framework/framework/src/main/.cproject
+++ b/GVRf/Framework/framework/src/main/.cproject
@@ -5,7 +5,6 @@
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.android.toolchain.gcc.1319470856" moduleId="org.eclipse.cdt.core.settings" name="Default">
 				<externalSettings/>
 				<extensions>
-					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
 					<extension id="org.eclipse.cdt.core.VCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>

--- a/GVRf/Framework/framework/src/main/.cproject
+++ b/GVRf/Framework/framework/src/main/.cproject
@@ -5,6 +5,7 @@
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.android.toolchain.gcc.1319470856" moduleId="org.eclipse.cdt.core.settings" name="Default">
 				<externalSettings/>
 				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
 					<extension id="org.eclipse.cdt.core.VCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
@@ -12,7 +13,6 @@
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
@@ -72,10 +72,8 @@
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId="com.android.AndroidPerProjectProfile"/>
 		</scannerConfigBuildInfo>
 	</storageModule>
-	<storageModule moduleId="refreshScope" versionNumber="2">
-		<configuration configurationName="Default">
-			<resource resourceType="PROJECT" workspacePath="/Framework"/>
-		</configuration>
+	<storageModule moduleId="refreshScope" versionNumber="1">
+		<resource resourceType="PROJECT" workspacePath="/Framework"/>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>

--- a/GVRf/Framework/framework/src/main/.project
+++ b/GVRf/Framework/framework/src/main/.project
@@ -12,7 +12,7 @@
 			<arguments>
 				<dictionary>
 					<key>?children?</key>
-					<value>?name?=outputEntries\|?children?=?name?=entry\\\\\\\|\\\|?name?=entry\\\\\\\|\\\|\||</value>
+					<value>?children?=?name?=entry\\\\\\\|\\\|?name?=entry\\\\\\\|\\\|\|?name?=outputEntries\||</value>
 				</dictionary>
 				<dictionary>
 					<key>?name?</key>

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
@@ -641,3 +641,4 @@ final class NativePicker {
     static native float[] pickSceneObjectAgainstBoundingBox(long sceneObject,
             float ox, float oy, float oz, float dx, float dy, float dz);
 }
+

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -159,18 +159,13 @@ void Renderer::cullFromCamera(Scene *scene, Camera* camera,
     build_frustum(frustum, (const float*) glm::value_ptr(vp_matrix));
 
     // 2. Iteratively execute frustum culling for each root object (as well as its children objects recursively)
-    const std::vector<SceneObject*>& root_objects = scene->scene_objects();
-    for (auto it = root_objects.begin(); it != root_objects.end(); ++it) {
-        SceneObject *object = *it;
-        if (DEBUG_RENDERER) {
-            LOGD("FRUSTUM: start frustum culling for root %s\n",
-                    object->name().c_str());
-        }
-        frustum_cull(camera->owner_object()->transform()->position(), object, frustum, scene_objects, scene->get_frustum_culling(), 0);
-        if (DEBUG_RENDERER) {
-            LOGD("FRUSTUM: end frustum culling for root %s\n",
-                    object->name().c_str());
-        }
+    SceneObject *object = scene->getRoot();
+    if (DEBUG_RENDERER) {
+        LOGD("FRUSTUM: start frustum culling for root %s\n", object->name().c_str());
+    }
+    frustum_cull(camera->owner_object()->transform()->position(), object, frustum, scene_objects, scene->get_frustum_culling(), 0);
+    if (DEBUG_RENDERER) {
+        LOGD("FRUSTUM: end frustum culling for root %s\n", object->name().c_str());
     }
     // 3. do occlusion culling, if enabled
     occlusion_cull(scene, scene_objects, shader_manager, vp_matrix);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider.cpp
@@ -35,6 +35,7 @@ void Collider::transformRay(const glm::mat4& matrix, glm::vec3& rayStart, glm::v
     rayStart = glm::vec3(start);
 }
 
+
 void Collider::set_owner_object(SceneObject* obj) {
     if (obj == owner_object())
     {
@@ -50,4 +51,5 @@ void Collider::set_owner_object(SceneObject* obj) {
     }
     Component::set_owner_object(obj);
 }
+
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
@@ -89,8 +89,13 @@ public:
 
     virtual void set_owner_object(SceneObject*);
 
+
     static long long getComponentType() {
         return (long long) getComponentType;
+    }
+
+    static std::vector<Collider*>& getAllColliders() {
+        return allColliders_;
     }
 
     void set_pick_distance(float dist) {
@@ -103,6 +108,10 @@ public:
     static void transformRay(const glm::mat4& matrix, glm::vec3& rayStart, glm::vec3& rayDir);
 
 protected:
+    bool addCollider();
+    bool removeCollider();
+
+    static std::vector<Collider*> allColliders_;
     float pick_distance_;
 
     Collider(const Collider& collider);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
@@ -94,10 +94,6 @@ public:
         return (long long) getComponentType;
     }
 
-    static std::vector<Collider*>& getAllColliders() {
-        return allColliders_;
-    }
-
     void set_pick_distance(float dist) {
         pick_distance_ = dist;
     }
@@ -108,10 +104,6 @@ public:
     static void transformRay(const glm::mat4& matrix, glm::vec3& rayStart, glm::vec3& rayDir);
 
 protected:
-    bool addCollider();
-    bool removeCollider();
-
-    static std::vector<Collider*> allColliders_;
     float pick_distance_;
 
     Collider(const Collider& collider);

--- a/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
@@ -28,7 +28,6 @@ Scene* Scene::main_scene_ = NULL;
 
 Scene::Scene() :
         HybridObject(),
-        scene_objects_(),
         main_camera_rig_(),
         frustum_flag_(false),
         dirtyFlag_(0),
@@ -44,17 +43,15 @@ Scene::~Scene() {
 }
 
 void Scene::addSceneObject(SceneObject* scene_object) {
-    scene_objects_.push_back(scene_object);
+    scene_root_.addChildObject(&scene_root_, scene_object);
 }
 
 void Scene::removeSceneObject(SceneObject* scene_object) {
-    scene_objects_.erase(
-            std::remove(scene_objects_.begin(), scene_objects_.end(),
-                    scene_object), scene_objects_.end());
+    scene_root_.removeChildObject(scene_object);
 }
 
 void Scene::removeAllSceneObjects() {
-    scene_objects_.clear();
+    scene_root_.clear();
     lightList.clear();
     clearAllColliders();
 }
@@ -70,12 +67,10 @@ void Scene::gatherColliders() {
     lockColliders();
     allColliders.clear();
     visibleColliders.clear();
-    for (auto it = scene_objects_.begin(); it != scene_objects_.end(); ++it) {
-        SceneObject* obj = *it;
-        obj->getAllComponents(allColliders, Collider::getComponentType());
-    }
+    scene_root_.getAllComponents(allColliders, Collider::getComponentType());
     unlockColliders();
 }
+
 
 void Scene::pick(SceneObject* sceneobj) {
     if (pick_visible_) {
@@ -111,14 +106,8 @@ void Scene::set_main_scene(Scene* scene) {
 
 
 std::vector<SceneObject*> Scene::getWholeSceneObjects() {
-    std::vector<SceneObject*> scene_objects(scene_objects_);
-    for (int i = 0; i < scene_objects.size(); ++i) {
-        std::vector<SceneObject*> childrenCopy = scene_objects[i]->children();
-        for (auto it = childrenCopy.begin(); it != childrenCopy.end(); ++it) {
-            scene_objects.push_back(*it);
-        }
-    }
-
+    std::vector<SceneObject*> scene_objects;
+    scene_root_.getDescendants(scene_objects);
     return scene_objects;
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/scene.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene.h
@@ -37,12 +37,10 @@ class Scene: public HybridObject {
 public:
     Scene();
     virtual ~Scene();
+    SceneObject* getRoot() { return &scene_root_; }
     void addSceneObject(SceneObject* scene_object);
     void removeSceneObject(SceneObject* scene_object);
     void removeAllSceneObjects();
-    const std::vector<SceneObject*>& scene_objects() {
-        return scene_objects_;
-    }
     const CameraRig* main_camera_rig() {
         return main_camera_rig_;
     }
@@ -59,7 +57,6 @@ public:
 
     void set_occlusion_culling( bool occlusion_flag){ occlusion_flag_ = occlusion_flag; }
     bool get_occlusion_culling(){ return occlusion_flag_; }
-
     void addLight(Light* light);
 
     void resetStats() {
@@ -169,7 +166,7 @@ private:
 
 private:
     static Scene* main_scene_;
-    std::vector<SceneObject*> scene_objects_;
+    SceneObject scene_root_;
     CameraRig* main_camera_rig_;
     int dirtyFlag_;
     bool frustum_flag_;

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
@@ -139,6 +139,15 @@ void SceneObject::removeChildObject(SceneObject* child) {
     dirtyHierarchicalBoundingVolume();
 }
 
+void SceneObject::clear() {
+    std::lock_guard < std::mutex > lock(children_mutex_);
+    for (auto it = children_.begin(); it != children_.end(); ++it) {
+        SceneObject* child = *it;
+        child->parent_ = NULL;
+    }
+    children_.clear();
+}
+
 int SceneObject::getChildrenCount() const {
     return children_.size();
 }
@@ -149,6 +158,15 @@ SceneObject* SceneObject::getChildByIndex(int index) {
     } else {
         std::string error = "SceneObject::getChildByIndex() : Out of index.";
         throw error;
+    }
+}
+
+void SceneObject::getDescendants(std::vector<SceneObject*>& descendants) {
+    std::lock_guard < std::mutex > lock(children_mutex_);
+    for (auto it = children_.begin(); it != children_.end(); ++it) {
+        SceneObject* obj = *it;
+        descendants.push_back(obj);
+        obj->getDescendants(descendants);
     }
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
@@ -115,6 +115,8 @@ public:
 
     void addChildObject(SceneObject* self, SceneObject* child);
     void removeChildObject(SceneObject* child);
+    void getDescendants(std::vector<SceneObject*>& descendants);
+    void clear();
     int getChildrenCount() const;
     SceneObject* getChildByIndex(int index);
     GLuint *get_occlusion_array() {


### PR DESCRIPTION
Cleaned up version of #629 (squashed commits and rebased)

GVRSceneObject.addChildObject will throw an exception if you try to add
a scene object that already has a parent.
Also made a common root object in GVRScene instead of the mChildren
array. Added GVRScene.getRoot() to get the hierarchy root. Perhaps we
can use the root constructively to attach the camera rig, etc.
Made a common root object in Scene (C++ layer)

GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com