### PR TITLE
Cleanup of generateVAO() to remove special casing of TextureShader. Reuse VAO and VBOids and make generateVAO() private.

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -695,10 +695,10 @@ void Renderer::renderMaterialShader(RenderState& rstate, RenderData* render_data
     Mesh* mesh = render_data->mesh();
 
     GLuint programId = -1;
+    ShaderBase* shader = NULL;
 
     try {
          //TODO: Improve this logic to avoid a big "switch case"
-        ShaderBase* shader = NULL;
         if (rstate.material_override != nullptr)
             curr_material = rstate.material_override;
          switch (curr_material->shader_type()) {
@@ -759,11 +759,6 @@ void Renderer::renderMaterialShader(RenderState& rstate, RenderData* render_data
                  glLineWidth(1.0f);
              }
          }
-         programId = shader->getProgramId();
-         if (programId != -1)
-         {
-             mesh->generateVAO(programId);
-         }
          shader->render(&rstate, render_data, curr_material);
     } catch (const std::string &error) {
         LOGE(
@@ -771,6 +766,11 @@ void Renderer::renderMaterialShader(RenderState& rstate, RenderData* render_data
                 render_data->owner_object()->name().c_str(),
                 error.c_str());
         shader_manager->getErrorShader()->render(&rstate, render_data, curr_material);
+    }
+    programId = shader->getProgramId();
+    if (programId != -1)
+    {
+        mesh->generateVAO(programId);
     }
     glBindVertexArray(mesh->getVAOId(programId));
     if (mesh->indices().size() > 0) {

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -768,10 +768,7 @@ void Renderer::renderMaterialShader(RenderState& rstate, RenderData* render_data
         shader_manager->getErrorShader()->render(&rstate, render_data, curr_material);
     }
     programId = shader->getProgramId();
-    if (programId != -1)
-    {
-        mesh->generateVAO(programId);
-    }
+
     glBindVertexArray(mesh->getVAOId(programId));
     if (mesh->indices().size() > 0) {
         glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT, 0);

--- a/GVRf/Framework/framework/src/main/jni/objects/mesh.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/mesh.cpp
@@ -321,18 +321,16 @@ void Mesh::createBuffer(std::vector<GLfloat>& buffer, int attrLength)
     }
 }
 
-static void generateAndBindID(GLuint& id)
-{
-
-    glGenBuffers(1, &id);
-    glBindBuffer(GL_ARRAY_BUFFER, id);
-}
 
 const GLuint Mesh::getVAOId(int programId) {
     if (programId == -1)
     {
         LOGI("!! %p Prog Id -- %d ", this, programId);
         return 0;
+    }
+    if (vao_dirty_)
+    {
+        generateVAO(programId);
     }
     auto it = program_ids_.find(programId);
     if (it != program_ids_.end())
@@ -361,11 +359,6 @@ void Mesh::generateVAO(int programId) {
     }
     obtainDeleter();
 
-    GLuint vaoID_;
-    GLuint triangle_vboID_;
-
-    GLuint static_vboID_;
-
     if (vertices_.size() == 0 && normals_.size() == 0
             && tex_coords_.size() == 0) {
         std::string error = "no vertex data yet, shouldn't call here. ";
@@ -373,17 +366,33 @@ void Mesh::generateVAO(int programId) {
         return;
     }
 
-    glGenVertexArrays(1, &vaoID_);
+    GLuint vaoID_;
+    GLuint triangle_vboID_;
+    GLuint static_vboID_;
+    auto it = program_ids_.find(programId);
+    if (it != program_ids_.end())
+    {
+
+        GLVaoVboId ids = it->second;
+        vaoID_ = ids.vaoID;
+        triangle_vboID_ = ids.triangle_vboID;
+        static_vboID_ = ids.static_vboID;
+    }
+    else
+    {
+        glGenVertexArrays(1, &vaoID_);
+        glGenBuffers(1, &triangle_vboID_);
+        glGenBuffers(1, &static_vboID_);
+    }
+
+
     glBindVertexArray(vaoID_);
-    glGenBuffers(1, &triangle_vboID_);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, triangle_vboID_);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER,
             sizeof(unsigned short) * indices_.size(), &indices_[0],
             GL_STATIC_DRAW);
     numTriangles_ = indices_.size() / 3;
-    int maxDumpSize = vertices_.size();
-    if (maxDumpSize > 5)
-        maxDumpSize = 5;
+
     attrMapping.clear();
     int totalStride;
     int attrLength;
@@ -391,7 +400,7 @@ void Mesh::generateVAO(int programId) {
 
     std::vector<GLfloat> buffer;
     createBuffer(buffer, attrLength);
-    generateAndBindID(static_vboID_);
+    glBindBuffer(GL_ARRAY_BUFFER, static_vboID_);
 
     glBufferData(GL_ARRAY_BUFFER, sizeof(GLfloat) * buffer.size(),
             &buffer[0], GL_STATIC_DRAW);
@@ -409,11 +418,14 @@ void Mesh::generateVAO(int programId) {
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
-    GLVaoVboId id;
-    id.vaoID = vaoID_;
-    id.static_vboID = static_vboID_;
-    id.triangle_vboID = triangle_vboID_;
-    program_ids_[programId] = id;
+    if (it == program_ids_.end())
+    {
+        GLVaoVboId id;
+        id.vaoID = vaoID_;
+        id.static_vboID = static_vboID_;
+        id.triangle_vboID = triangle_vboID_;
+        program_ids_[programId] = id;
+    }
     vao_dirty_ = false;
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/mesh.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/mesh.h
@@ -69,6 +69,19 @@ public:
         deleteVaos();
     }
 
+    void deleteVaoForProgram(int programId)
+    {
+        auto it = program_ids_.find(programId);
+        if (it != program_ids_.end())
+        {
+            GLVaoVboId ids = it->second;
+            deleter_->queueVertexArray(ids.vaoID);
+            deleter_->queueBuffer(ids.static_vboID);
+            deleter_->queueBuffer(ids.triangle_vboID);
+            program_ids_.erase(it);
+        }
+    }
+
     void deleteVaos() {
         for (auto it : program_ids_ )
         {
@@ -282,8 +295,6 @@ public:
         LOGD("SHADER: setVertexAttrib %s\n", key.c_str());
     }
 
-    // generate VAO
-    void generateVAO(int programId);
 
     const GLuint getVAOId(int programId);
 
@@ -357,6 +368,8 @@ private:
     Mesh(const Mesh& mesh);
     Mesh(Mesh&& mesh);
     Mesh& operator=(const Mesh& mesh);
+    // generate VAO
+    void generateVAO(int programId);
 
 
 private:

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/texture_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/texture_shader.cpp
@@ -202,7 +202,6 @@ void TextureShader::render(RenderState* rstate,
         program_ = program_no_light_;
     }
     GLuint programId = program_->id();
-    render_data->mesh()->generateVAO(programId);
     GL(glUseProgram(programId));
     GL(glActiveTexture (GL_TEXTURE0));
     GL(glBindTexture(texture->getTarget(), texture->getId()));


### PR DESCRIPTION
Discussed with @roshanch the following cleanup of generateVAO() usage. Tested shadow, jassimp, simplescene, litshader, multilight samples.

Remove the special case for TextureShader to call generateVAO(). Now generateVAO() will be called just before the glBindVertexArray(mesh->getVAOId(programId)) call and after the shader->render() call.

TextureShader's render method sets the proper program instance for the light and no_light case and the programId will be valid after the call to render().