### PR TITLE
fixes for supporting larger images

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -667,6 +667,21 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                 mSplashScreen = null;
             }
 
+            // execute pending runnables now so any necessary gl calls
+            // are done before onInit().  As an example the request to
+            // get the GL_MAX_TEXTURE_SIZE needs to be fulfilled.
+            synchronized (mRunnables) {
+                Runnable runnable = null;
+                while ((runnable = mRunnables.poll()) != null) {
+                    try {
+                        runnable.run();
+                    } catch (final Exception exc) {
+                        Log.e(TAG, "Runnable-on-GL %s threw %s", runnable, exc.toString());
+                        exc.printStackTrace();
+                    }
+                }
+            }
+
             runOnTheFrameworkThread(new Runnable() {
                 @Override
                 public void run() {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/asynchronous/AsyncBitmapTexture.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/asynchronous/AsyncBitmapTexture.java
@@ -53,6 +53,7 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.view.Display;
 import android.view.WindowManager;
+import android.content.pm.ApplicationInfo;
 
 /**
  * Async resource loading: bitmap textures.
@@ -138,7 +139,7 @@ class AsyncBitmapTexture {
      * A multiple of the "memory class" - <i>e.g.</i> 7.5% of a 32M heap is a
      * 2.4M image; 6% is 1.92M
      */
-    private static final float MAXIMUM_IMAGE_FACTOR = 0.125f;
+    private static final float MAXIMUM_IMAGE_FACTOR = 0.625f;
 
     /**
      * When {@link #fractionalDecode(FractionalDecodeShim, Options, int, int)}
@@ -304,7 +305,12 @@ class AsyncBitmapTexture {
         private static void getMemoryClass(Context context) {
             ActivityManager activityManager = (ActivityManager) context
                     .getSystemService(Activity.ACTIVITY_SERVICE);
-            memoryClass = activityManager.getMemoryClass() * 1024 * 1024;
+            ApplicationInfo info = context.getApplicationInfo();
+            if((info.flags & ApplicationInfo.FLAG_LARGE_HEAP) == ApplicationInfo.FLAG_LARGE_HEAP) {
+                memoryClass = activityManager.getLargeMemoryClass() * 1024 * 1024;
+            } else {
+                memoryClass = activityManager.getMemoryClass() * 1024 * 1024;
+            }
             Log.d(TAG, "MemoryClass = %dM", memoryClass / (1024 * 1024));
         }
 


### PR DESCRIPTION
fixes for supporting larger images.

1) use getLargeMemoryClass() if largeHeap is set in the application's
AndroidManifest.xml.

2) ensure pending gl runnables are run before onInit.  this is necessary
for ensuring glMaxTexureSize gets set correctly.

3) increase the MAXIMUM_IMAGE_FACTOR

this will address #695 

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com