### PR TITLE
Support to copy AAR files

### DIFF
--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -192,3 +192,16 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile fileTree(dir: 'src/main/libs', include: ['*.jar'])
 }
+
+task copyAARFiles(type: Copy) {
+    if (rootProject.hasProperty("LIBS_DIRECTORY")) {
+        def libsdir = rootProject.property("LIBS_DIRECTORY")
+        from 'build/outputs/aar'
+        into libsdir
+        include '**/*.aar'
+    }
+}
+
+assembleDebug {}.doLast{
+    tasks.copyAARFiles.execute()
+}

--- a/GVRf/Framework/gradle.properties
+++ b/GVRf/Framework/gradle.properties
@@ -1,0 +1,23 @@
+## Project-wide Gradle settings.
+#
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Thu May 05 12:55:40 PDT 2016
+android.useDeprecatedNdk=true
+org.gradle.jvmargs=-Xmx2048M
+# Un-comment and add the path to ndk directory
+#ANDROID_NDK_HOME=
+# Un-comment and add the path to ovr directory
+#OVR_MOBILE_SDK=
+# Un-comment and add the path to a directory where all built AAR files will be coppied after build finish
+#LIBS_DIRECTORY=

--- a/GVRf/Framework/gradle/wrapper/gradle-wrapper.properties
+++ b/GVRf/Framework/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Fri Jul 15 14:05:20 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip


### PR DESCRIPTION
For now only added the support in Framework so that whenever build framework by opening the Framework project and do build it will copy the generated AAR file to the path specified in LIBS_DIRECTORY

I want to do similar change in Extensions projects.

GearVRf-DCO-1.0-Signed-off-by: Deepak Rawat
deepak.rawat@samsung.com