### PR TITLE
 Fix for the external renderer

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -1046,24 +1046,26 @@ void Renderer::renderMaterialShader(RenderState& rstate, RenderData* render_data
                 error.c_str());
         shader_manager->getErrorShader()->render(&rstate, render_data, curr_material);
     }
+
     programId = shader->getProgramId();
-
-    glBindVertexArray(mesh->getVAOId(programId));
-    if (mesh->indices().size() > 0) {
-        if(use_multiview)
-            glDrawElementsInstanced(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT, NULL, 2 );
-        else
-            glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT, 0);
+    //there is no program associated with EXTERNAL_RENDERER_SHADER
+    if (-1 != programId) {
+        glBindVertexArray(mesh->getVAOId(programId));
+        if (mesh->indices().size() > 0) {
+            if(use_multiview) {
+                glDrawElementsInstanced(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT, NULL, 2 );
+            } else {
+                glDrawElements(render_data->draw_mode(), mesh->indices().size(), GL_UNSIGNED_SHORT, 0);
+            }
+        } else {
+            if(use_multiview) {
+                glDrawArraysInstanced(render_data->draw_mode(), 0, mesh->vertices().size(),2);
+            } else {
+                glDrawArrays(render_data->draw_mode(), 0, mesh->vertices().size());
+            }
+        }
     }
-    else {
-        if(use_multiview)
-            glDrawArraysInstanced(render_data->draw_mode(), 0, mesh->vertices().size(),2);
-        else
-            glDrawArrays(render_data->draw_mode(), 0, mesh->vertices().size());
-    }
-    glBindVertexArray(0);
     checkGlError("renderMesh::renderMaterialShader");
-
 }
 
 bool Renderer::checkTextureReady(Material* material) {

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/external_renderer_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/external_renderer_shader.cpp
@@ -69,6 +69,8 @@ void ExternalRendererShader::render(RenderState* rstate, RenderData* render_data
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
+    glActiveTexture(GL_TEXTURE0);
+
     TextureCapturer *capturer(render_data->get_texture_capturer());
     if (!capturer || !capturer->getAndClearPendingCapture()) {
         // Original rendering


### PR DESCRIPTION
the custom shader could leave another texture unit active leading
to confusion in the external renderer

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>