### PR TITLE
gradle: prevent the native code from being rebuilt on every build

### DIFF
--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -72,6 +72,8 @@ android {
                 into 'src/main/jni'
                 include 'Android.mk'
             }
+            file('src/main/jni/Android.mk').setLastModified(
+                    file('../' + gvrf_backend + '/src/main/jni/Android.mk').lastModified())
         }
     }
 
@@ -127,6 +129,8 @@ android {
                 into 'src/main/jni'
                 include 'Android.mk'
             }
+            file('src/main/jni/Android.mk').setLastModified(
+                    file('../' + gvrf_backend + '/src/main/jni/Android.mk').lastModified)
         }
         doLast {
             delete 'src/main/jni/Android.mk'


### PR DESCRIPTION
gradle's file copy doesn't copy the timestamp.. and can't be configured to...

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>