### PR TITLE
Fix the type of exception thrown by the shader_manager

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/shaders/shader_manager.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/shader_manager.h
@@ -166,8 +166,8 @@ public:
         if (it != custom_shaders_.end()) {
             return it->second;
         } else {
-            LOGE("ShaderManager::getCustomShader()");
-            throw "ShaderManager::getCustomShader()";
+            LOGE("ShaderManager::getCustomShader() %d", id);
+            throw std::string("ShaderManager::getCustomShader()");
         }
     }
 


### PR DESCRIPTION
We catch std::string

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>