### PR TITLE
Add a bind method to GVRRenderTexture.

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/GVRRenderTexture.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/GVRRenderTexture.java
@@ -87,6 +87,15 @@ public class GVRRenderTexture extends GVRTexture {
         return NativeRenderTexture.readRenderResult(getNative(), readbackBuffer);
     }
 
+    /**
+     * Bind the framebuffer for this GVRRenderTexture.
+     *      
+     *      Before calling this, remember to retrieve the currently bound framebuffer (with glGetIntegerv(GL_FRAMEBUFFER_BINDING, int[])) so you can restore it after issuing calls to this GVRRenderTexture.
+     */
+    public void bind() {
+        NativeRenderTexture.bind(getNative());
+    }
+
     private int mWidth, mHeight;
 }
 
@@ -96,4 +105,6 @@ class NativeRenderTexture {
     static native long ctorMSAA(int width, int height, int sampleCount);
 
     static native boolean readRenderResult(long ptr, int[] readbackBuffer);
+
+    static native void bind(long ptr);
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.h
@@ -64,6 +64,10 @@ public:
         return gl_frame_buffer_->id();
     }
 
+    void bind() {
+        glBindFramebuffer(GL_FRAMEBUFFER, gl_frame_buffer_->id());
+    }
+
     int width() const {
         return width_;
     }

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture_jni.cpp
@@ -44,6 +44,9 @@ Java_org_gearvrf_NativeRenderTexture_endRendering(JNIEnv * env, jobject obj,
 JNIEXPORT bool JNICALL
 Java_org_gearvrf_NativeRenderTexture_readRenderResult(JNIEnv * env, jobject obj,
         jlong ptr, jintArray jreadback_buffer);
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeRenderTexture_bind(JNIEnv * env, jobject obj, jlong ptr);
 }
 ;
 
@@ -101,5 +104,12 @@ Java_org_gearvrf_NativeRenderTexture_readRenderResult(JNIEnv * env, jobject obj,
 
     return rv;
 }
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeRenderTexture_bind(JNIEnv * env, jobject obj, jlong ptr) {
+    RenderTexture *render_texture = reinterpret_cast<RenderTexture*>(ptr);
+    render_texture->bind();
+}
+
 
 }


### PR DESCRIPTION
In a recent hackathon, this was all that needed to be added for that
team to do some fancy render to texture stuff.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com