### PR TITLE
fix culling issue #787

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
@@ -324,16 +324,16 @@ BoundingVolume& SceneObject::getBoundingVolume() {
         // || !transform_->isModelMatrixValid()) {
         mesh_bounding_volume = rdata->mesh()->getBoundingVolume();
         if (mesh_bounding_volume.radius() > 0) {
-            mesh_bounding_volume.transform(rdata->mesh()->getBoundingVolume(), transform()->getModelMatrix());
-            transformed_bounding_volume_ = mesh_bounding_volume;
+            BoundingVolume mesh_volume = mesh_bounding_volume;
+            transformed_bounding_volume_.transform(mesh_volume, transform()->getModelMatrix());
         }
     }
     // 2. Aggregate with all its children's bounding volumes
     std::vector<SceneObject*> childrenCopy = children();
     for (auto it = childrenCopy.begin(); it != childrenCopy.end(); ++it) {
-        mesh_bounding_volume = (*it)->getBoundingVolume();
-        if (mesh_bounding_volume.radius() > 0) {
-            transformed_bounding_volume_.expand(mesh_bounding_volume);
+        BoundingVolume child_bounding_volume = (*it)->getBoundingVolume();
+        if (child_bounding_volume.radius() > 0) {
+            transformed_bounding_volume_.expand(child_bounding_volume);
         }
     }
     bounding_volume_dirty_ = false;

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
@@ -324,8 +324,8 @@ BoundingVolume& SceneObject::getBoundingVolume() {
         // || !transform_->isModelMatrixValid()) {
         mesh_bounding_volume = rdata->mesh()->getBoundingVolume();
         if (mesh_bounding_volume.radius() > 0) {
-            BoundingVolume mesh_volume = mesh_bounding_volume;
-            transformed_bounding_volume_.transform(mesh_volume, transform()->getModelMatrix());
+            mesh_bounding_volume.transform(rdata->mesh()->getBoundingVolume(), transform()->getModelMatrix());
+            transformed_bounding_volume_ = mesh_bounding_volume;
         }
     }
     // 2. Aggregate with all its children's bounding volumes


### PR DESCRIPTION
Initially, when we were calculating mesh_bounding_volume for a parent, we were taking children's bounding volume too, now mesh_bounding_volume contains transform_bounding volume of a parent only whereas transform_bounding_volume will store all the sub-tree nodes' bounding volumes. 