### PR TITLE
Fixes for 3DCursorLibrary and org.gearvrf.io

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorSceneObject.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorSceneObject.java
@@ -115,11 +115,16 @@ class CursorSceneObject {
     }
 
     void set(GVRSceneObject sceneObject){
-        meshSceneObject = getMeshObject(sceneObject);
+        GVRSceneObject sceneObjectWithMesh = getMeshObject(sceneObject);
+        synchronized (lock) {
+            meshSceneObject = sceneObjectWithMesh;
+        }
     }
 
     void reset(){
-        meshSceneObject = null;
+        synchronized (lock) {
+            meshSceneObject = null;
+        }
     }
 
     void removeChildObject(GVRSceneObject sceneObject) {

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/IoDevice.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/IoDevice.java
@@ -317,11 +317,7 @@ public class IoDevice {
      * @return the value of the near depth. By default the value is set to 0.
      */
     protected float getNearDepth() {
-        if (gvrCursorController instanceof GVRExternalCursorController) {
-            return ((GVRExternalCursorController) gvrCursorController).getNearDepth();
-        } else {
-            throw new UnsupportedOperationException("getNearDepth not supported");
-        }
+        return gvrCursorController.getNearDepth();
     }
 
     void setFarDepth(float farDepth) {
@@ -337,11 +333,7 @@ public class IoDevice {
      * Float#MAX_VALUE}.
      */
     protected float getFarDepth() {
-        if (gvrCursorController instanceof GVRExternalCursorController) {
-            return ((GVRExternalCursorController) gvrCursorController).getFarDepth();
-        } else {
-            throw new UnsupportedOperationException("getFarDepth not supported");
-        }
+            return gvrCursorController.getFarDepth();
     }
 
     /**

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursor.java
@@ -100,7 +100,7 @@ class ObjectCursor extends Cursor {
     private ControllerEventListener listener = new ControllerEventListener() {
         @Override
         public void onEvent(GVRCursorController controller) {
-            if(scene == null){
+            if (scene == null) {
                 return;
             }
 
@@ -192,5 +192,12 @@ class ObjectCursor extends Cursor {
     void setIoDevice(IoDevice ioDevice) {
         super.setIoDevice(ioDevice);
         ioDevice.setNearDepth(POINT_CURSOR_NEAR_DEPTH);
+    }
+
+    void destroyIoDevice(IoDevice ioDevice) {
+        super.destroyIoDevice(ioDevice);
+        if (active) {
+            active = false;
+        }
     }
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCursorController.java
@@ -529,7 +529,7 @@ public abstract class GVRCursorController {
      * @return value representing the near depth. By default the value returned
      * is zero.
      */
-    protected float getNearDepth() {
+    public float getNearDepth() {
         return nearDepth;
     }
 
@@ -539,7 +539,7 @@ public abstract class GVRCursorController {
      * @return value representing the far depth. By default the value returned
      * is negative {@link Float#MAX_VALUE}.
      */
-    protected float getFarDepth() {
+    public float getFarDepth() {
         return farDepth;
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorManager.java
@@ -17,6 +17,7 @@ package org.gearvrf;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.gearvrf.GVRCursorController.ActiveState;
 import org.gearvrf.utility.Log;
@@ -34,7 +35,7 @@ class SensorManager {
     private static SensorManager instance;
 
     private SensorManager() {
-        sensors = new HashMap<GVRBaseSensor, Integer>();
+        sensors = new ConcurrentHashMap<GVRBaseSensor, Integer>();
     }
 
     static SensorManager getInstance(){


### PR DESCRIPTION
org.gearvrf.io:
SensorManager.java
1. Changed sensors map to a ConcurrentHashMap. This is needed when sensors are added/removed to the scene while iterating/handling a sensor event.

GVRCursorController.java
1. Expose getNear/FarDepth() calls for use in enabling and disabling settings cursor in CursorManager.

GVRGazeCursorController.java
1. Reduced the TAP_TIMEOUT to make clicking more responsive and enable double clicking on objects.
2. Added a HandlerThread to process events on the GazeCursorController. Previously events were being processed on the Main thread(when receiving
    touch events) as well as the GlThread(onDrawFrame)

3DCursorLibrary:
CursorManager.java
1. Added enable/disableSettingsCursor calls to enable applications to use
    a settings cursor to interract with a GVRViewSceneObject.
2. In cursorEventListener Traverse SceneGraph to find Selectable/MovableBehavior components instead of just checking the parent of the object with CursorEvent.
3. Added a convinience method getGVRContext() to avoid having to pass GVRContext as well as CursorManager.

CursorSceneObject.java
1. Added a lock arround methods accessing meshSceneObject

MovableBehavior.java
1. Added locks arround selected variable as it can be accessed from multiple threads

ObjectCursor.java
1. Added destroyIoDevice call to set active to false for a cursor which is removed from the scene when active=true

SelectableBehavior.java
1. Added behavior and cursor arguments to StateChangeListener
2. Setting state before calling handleClickEvent and handleClickReleased