### PR TITLE
Fixed picking bug (fixes issue #800)

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCameraRigBase.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCameraRigBase.java
@@ -103,7 +103,7 @@ abstract class GVRCameraRigBase extends GVRComponent implements PrettyPrint {
     }
 
     protected abstract void addHeadTransformObject();
-    protected final GVRSceneObject getHeadTransformObject() {
+    public final GVRSceneObject getHeadTransformObject() {
         return headTransformObject;
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
@@ -43,10 +43,8 @@ import org.joml.Vector3f;
  * The picked object contains the collider instance hit, the distance from the
  * camera and the hit position.
  * 
- * If it is attached to a scene object, the picker maintains the list of currently
- * picked objects which can be obtains with getPicked() and continually
- * updates it each frame. (If it is not attached to a scene object,
- * you must manually call doPick() to cause pick events to be generated.)
+ * The picker maintains the list of currently picked objects
+ * (which can be obtains with getPicked()) and continually updates it each frame.
  *
  * In this mode, when the ray from the scene object hits a pickable object,
  * the picker generates one or more pick events (IPickEvents interface)
@@ -71,12 +69,14 @@ public class GVRPicker extends GVRBehavior {
     private Vector3f mRayDirection = new Vector3f(0, 0, -1);
     private float[] mPickRay = new float[6];
 
-    protected boolean mHasChanged;
     protected GVRScene mScene;
     protected GVRPickedObject[] mPicked = null;
 
     /**
      * Construct a picker which picks from a given scene.
+     * Instantiating the picker will cause it to scan the scene
+     * every frame and generate pick events based on the result.
+     *
      * @param context context that owns the scene
      * @param scene scene containing the scene objects to pick from
      */
@@ -84,8 +84,8 @@ public class GVRPicker extends GVRBehavior {
     {
         super(context);
         mScene = scene;
-        mHasChanged = true;
         mType = getComponentType();
+        startListening();
     }
 
     static public long getComponentType() { return TYPE_PICKMANAGER; }
@@ -139,10 +139,6 @@ public class GVRPicker extends GVRBehavior {
     /*
      * Sets the origin and direction of the pick ray.
      * 
-     * If the picker is not attached to a scene object but you
-     * still want to get pick events, you must set the pick
-     * ray manually with this function and call {@link doPick}.
-     * 
      * @param ox    X coordinate of origin.
      * @param oy    Y coordinate of origin.
      * @param oz    Z coordinate of origin.
@@ -169,31 +165,25 @@ public class GVRPicker extends GVRBehavior {
         mRayDirection.x = dx;
         mRayDirection.y = dy;
         mRayDirection.z = dz;
-        mHasChanged = true;
     }
     
     public void onDrawFrame(float frameTime)
     {
-        if (isEnabled() && ((getOwnerObject() != null) || mHasChanged))
+        if (isEnabled())
         {
             doPick();
-            mHasChanged = false;
-        }        
+        }
     }
     
     /**
      * Scans the scene graph to collect picked items
      * and generates appropriate pick events.
      * This function is called automatically by
-     * the picker if it is attached to a scene object.
-     * You can instantiate the picker and not attach
-     * it to a scene object. In this case you must
-     * manually set the pick ray and call doPick()
-     * to generate the pick events.
+     * the picker every frame.
      * @see IPickEvents 
      * @see pickObjects
      */
-    public void doPick()
+    protected void doPick()
     {
         GVRSceneObject owner = getOwnerObject();
         GVRTransform trans = (owner != null) ? owner.getTransform() : null;
@@ -552,7 +542,8 @@ public class GVRPicker extends GVRBehavior {
                                                       float dy, float dz) {
         sFindObjectsLock.lock();
         try {
-            final GVRPickedObject[] result = NativePicker.pickObjects(scene.getNative(), trans.getNative(), ox, oy, oz, dx, dy, dz);
+            long nativeTrans = (trans != null) ? trans.getNative() : 0L;
+            final GVRPickedObject[] result = NativePicker.pickObjects(scene.getNative(), nativeTrans, ox, oy, oz, dx, dy, dz);
             return result;
         } finally {
             sFindObjectsLock.unlock();

--- a/GVRf/Framework/framework/src/main/jni/engine/picker/picker.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/picker/picker.cpp
@@ -27,6 +27,7 @@
 #include "objects/scene.h"
 #include "objects/scene_object.h"
 #include "objects/components/camera_rig.h"
+#include "objects/components/perspective_camera.h"
 #include "objects/components/render_data.h"
 #include "objects/components/mesh_collider.h"
 
@@ -45,13 +46,14 @@ Picker::~Picker() {
  * This function is not thread-safe because it relies on a static
  * array of colliders which could be updated by a different thread.
  */
-void Picker::pickScene(Scene* scene, std::vector<ColliderData>& picklist, Transform* t, float ox,
-        float oy, float oz, float dx, float dy, float dz) {
+void Picker::pickScene(Scene* scene, std::vector<ColliderData>& picklist, Transform* t,
+         float ox, float oy, float oz, float dx, float dy, float dz) {
     glm::vec3 ray_start(ox, oy, oz);
     glm::vec3 ray_dir(dx, dy, dz);
     const std::vector<Component*>& colliders = scene->lockColliders();
+    const glm::mat4& model_matrix = t->getModelMatrix();
 
-    Collider::transformRay(t->getModelMatrix(), ray_start, ray_dir);
+    Collider::transformRay(model_matrix, ray_start, ray_dir);
     for (auto it = colliders.begin(); it != colliders.end(); ++it) {
         Collider* collider = reinterpret_cast<Collider*>(*it);
         SceneObject* owner = collider->owner_object();
@@ -81,7 +83,7 @@ float Picker::pickSceneObject(const SceneObject* scene_object,
     if (scene_object->collider() != 0) {
         Collider* collider = scene_object->collider();
         if (collider->enabled()) {
-            glm::mat4 view_matrix = camera_rig->getHeadTransform()->getModelMatrix();
+            glm::mat4 view_matrix = camera_rig->center_camera()->getViewMatrix();
             glm::vec3 rayStart(0, 0, 0);
             glm::vec3 rayDir(0, 0, -1);
 
@@ -104,20 +106,19 @@ float Picker::pickSceneObject(const SceneObject* scene_object,
  * to the ray to put it into mesh coordinates.
  */
 glm::vec3 Picker::pickSceneObjectAgainstBoundingBox(
-        const SceneObject* scene_object, float ox, float oy, float oz, float dx,
-        float dy, float dz) {
+        const SceneObject* scene_object, float ox, float oy, float oz, float dx, float dy, float dz) {
     RenderData* rd = scene_object->render_data();
 
     if ((rd == NULL) || (rd->mesh() == NULL)) {
         return glm::vec3(std::numeric_limits<float>::infinity());
     }
-    glm::mat4 model_matrix = scene_object->transform()->getModelMatrix();
+    glm::mat4 model_inverse = glm::affineInverse(scene_object->transform()->getModelMatrix());
     const BoundingVolume& bounds = rd->mesh()->getBoundingVolume();
     glm::vec3 rayStart(ox, oy, oz);
     glm::vec3 rayDir(dx, dy, dz);
 
     glm::normalize(rayDir);
-    Collider::transformRay(model_matrix, rayStart, rayDir);
+    Collider::transformRay(model_inverse, rayStart, rayDir);
     ColliderData data = MeshCollider::isHit(bounds, rayStart, rayDir);
     if (data.IsHit) {
         return data.HitPosition;
@@ -133,7 +134,6 @@ glm::vec3 Picker::pickSceneObjectAgainstBoundingBox(
  */
 void Picker::pickVisible(Scene* scene, Transform* t, std::vector<ColliderData>& picklist) {
     const std::vector<Component*>& colliders = scene->lockColliders();
-    glm::mat4 view_matrix = glm::affineInverse(t->getModelMatrix());
 
     for (auto it = colliders.begin(); it != colliders.end(); ++it) {
         Collider* collider = reinterpret_cast<Collider*>(*it);

--- a/GVRf/Framework/framework/src/main/jni/engine/picker/picker_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/picker/picker_jni.cpp
@@ -52,8 +52,8 @@ Java_org_gearvrf_NativePicker_pickScene(JNIEnv * env,
         jfloat dy, jfloat dz) {
     Scene* scene = reinterpret_cast<Scene*>(jscene);
     std::vector<ColliderData> colliders;
-
-    Picker::pickScene(scene, colliders, (Transform*) NULL, ox, oy, oz, dx, dy, dz);
+    Transform* t = scene->main_camera_rig()->getHeadTransform();
+    Picker::pickScene(scene, colliders, t, ox, oy, oz, dx, dy, dz);
     jlongArray jcolliders = env->NewLongArray(colliders.size());
     jlong* ptrArray = env->GetLongArrayElements(jcolliders, 0);
     jlong* ptrs = ptrArray;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider.cpp
@@ -31,16 +31,15 @@ namespace gvr {
  * @param rayStart origin of ray in world coordinates
  * @param rayDir directin of ray in world coordinates
  *
- * To put the ray in model coordinates it is pre-mulitplied by
- * the inverse of the model mtraix
+ * To put the ray in model coordinates it is pre-mulitplied by the input matrix
  */
 void Collider::transformRay(const glm::mat4& model_matrix, glm::vec3& rayStart, glm::vec3& rayDir)
 {
-    glm::mat4 model_inverse = glm::affineInverse(model_matrix);
-    glm::vec4 start = model_inverse * glm::vec4(rayStart, 1);
-    glm::vec4 dir(rayDir, 0);
-    dir = model_inverse * dir;
-    rayDir = glm::vec3(glm::normalize(dir));
+    glm::vec4 start = model_matrix * glm::vec4(rayStart, 1);
+    glm::vec4 end = model_matrix * glm::vec4(rayStart + rayDir, 1);
+
+    rayDir = glm::vec3(end - start);
+    rayDir = glm::normalize(rayDir);
     rayStart = glm::vec3(start);
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider_group.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider_group.cpp
@@ -21,6 +21,8 @@
 #include "collider_group.h"
 
 #include "objects/scene_object.h"
+#include "glm/gtc/matrix_inverse.hpp"
+
 
 namespace gvr {
 
@@ -49,11 +51,11 @@ ColliderData ColliderGroup::isHit(const glm::vec3& rayStart, const glm::vec3& ra
         Transform* transform = ownerObject->transform();
         finalHit.ObjectHit = ownerObject;
         if (nullptr != transform) {
-            glm::mat4 model_matrix = transform->getModelMatrix();
+            glm::mat4 model_inverse = glm::affineInverse(transform->getModelMatrix());
             glm::vec3 O(rayStart);
             glm::vec3 D(rayDir);
 
-            transformRay(model_matrix, O, D);
+            transformRay(model_inverse, O, D);
             for (auto it = colliders_.begin(); it != colliders_.end(); ++it) {
                 ColliderData currentHit = (*it)->isHit(O, D);
                 if (currentHit.IsHit && (currentHit.Distance < finalHit.Distance)) {

--- a/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
@@ -44,8 +44,6 @@ public:
     }
 
     ColliderData isHit(const glm::vec3& rayStart, const glm::vec3& rayDir);
-    static float rayTriangleIntersect(glm::vec3& hitPos, const glm::vec3& rayStart, const glm::vec3& rayDir,
-                                      const glm::vec3& V1, const glm::vec3& V2, const glm::vec3& V3);
     static ColliderData isHit(const BoundingVolume& bounds, const glm::vec3& rayStart, const glm::vec3& rayDir);
 
 private:
@@ -54,7 +52,8 @@ private:
     MeshCollider& operator=(const MeshCollider& mesh_collider);
     MeshCollider& operator=(MeshCollider&& mesh_collider);
     static ColliderData isHit(const Mesh& mesh, const glm::vec3& rayStart, const glm::vec3& rayDir);
-
+    static float rayTriangleIntersect(glm::vec3& hitPos, const glm::vec3& rayStart, const glm::vec3& rayDir,
+                               const glm::vec3& V1, const glm::vec3& V2, const glm::vec3& V3);
 private:
     bool useMeshBounds_;
     Mesh* mesh_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/sphere_collider.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/sphere_collider.cpp
@@ -115,21 +115,22 @@ ColliderData SphereCollider::isHit(const glm::mat4& model_matrix, const glm::vec
      */
     glm::vec3 start(rayStart);
     glm::vec3 dir(rayDir);
-    transformRay(model_matrix, start, dir);
+    glm::mat4 model_inverse = glm::affineInverse(model_matrix);
 
+    transformRay(model_inverse, start, dir);
     /*
      * Compute the intersection of the ray and sphere in local coordinates.
      * The distance will be in world coordinates.
      */
-    glm::vec3 hitPoint;
+    glm::vec3 hitPos;
     glm::vec3 hitNormal;
 
-    if (glm::intersectRaySphere(start, dir, center, radius, hitPoint, hitNormal))
+    if (glm::intersectRaySphere(start, dir, center, radius, hitPos, hitNormal))
     {
-        glm::vec4 p = glm::vec4(hitPoint, 1);
+        glm::vec4 p = glm::vec4(hitPos, 1);
 
         hitData.IsHit = true;
-        hitData.HitPosition = hitPoint;
+        hitData.HitPosition = hitPos;
         p = model_matrix * p;
         hitData.Distance = glm::length(rayStart - glm::vec3(p));
     }


### PR DESCRIPTION
The wrong matrix was being used for transforming the picking ray causing
it to pick the wrong thing.
Now the picker actually looks at the object it is attached to and gets
its position and orientation from that. Before it was incorrectly always
using the camera view matrix no matter what it was attached to. Some of
the demos have bugs because they attach the picker to the wrong object
and that used to work. I am doing a pull request for these demos.
Removed logging and exposed GVRCameraRigBase.getHeadTransformObject.

GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com