### PR TITLE
Remove onStep() for mainScene

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/GVRViewManager.java
@@ -798,10 +798,6 @@ class GVRViewManager extends GVRContext implements RotationSensorListener {
                 public void run() {
                     try {
                         mScript.onStep();
-
-                        // Issue "onStep" to the scene
-                        GVRViewManager.this.getEventManager().sendEvent(
-                            mMainScene, ISceneEvents.class, "onStep");
                     } catch (final Exception exc) {
                         Log.e(TAG, "Exception from onStep: %s", exc.toString());
                         exc.printStackTrace();

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -639,12 +639,6 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
             recursivelySendSimpleEvent(mSceneRoot, "onAfterInit");
         }
 
-        @Override
-        public void onStep() {
-            // Send "onStep" to all scene objects and their children
-            recursivelySendSimpleEvent(mSceneRoot, "onStep");
-         }
-
         private void recursivelySendSimpleEvent(GVRSceneObject sceneObject, String eventName) {
             getGVRContext().getEventManager().sendEvent(
                     sceneObject, ISceneObjectEvents.class, eventName);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/ISceneEvents.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/ISceneEvents.java
@@ -1,6 +1,6 @@
 package org.gearvrf;
 
-public interface ISceneEvents extends ILifeCycleEvents {
+public interface ISceneEvents extends IEvents {
     /**
      * Called when the scene has been initialized.
      * @param gvrContext
@@ -9,4 +9,9 @@ public interface ISceneEvents extends ILifeCycleEvents {
      *         The GVRScene.
      */
     void onInit(GVRContext gvrContext, GVRScene scene);
+
+    /**
+     * Called after all handlers of onInit are completed.
+     */
+    void onAfterInit();
 }


### PR DESCRIPTION
This onStep() traverses through all the sceneObjects in the scene. We don't need this one as we don't have any use case where we override the onStep() on sceneObject.

GearVRf-DCO-1.0-Signed-off-by: Roshan Chaudhari  roshan.c@samsung.com