### PR TITLE
Should free jNode when not needed

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/contrib/jassimp2/jassimp.cpp
+++ b/GVRf/Framework/framework/src/main/jni/contrib/jassimp2/jassimp.cpp
@@ -860,6 +860,8 @@ static bool loadSceneNode(JNIEnv *env, const aiNode *cNode, jobject parent, jobj
 	if (NULL != loadedNode)
 	{
 		*loadedNode = jNode;
+	} else {
+	    DeleteLocalRef refNode(env, jNode);
 	}
 
 	return true;


### PR DESCRIPTION
This fixes the JNI table overflow issue for models which have large hierarchy of nodes. Models exported as FBX from DAZ studio has very large hierarchy, so they can be used to review this pull request.

GearVRf-DCO-1.0-Signed-off-by: 
Deepak Rawat deepak.rawat@samsung.com