### PR TITLE
Trying to fix a build error while building gvr-modelviewer

### DIFF
--- a/GVRf/Extensions/WidgetPlugin/build.gradle
+++ b/GVRf/Extensions/WidgetPlugin/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/GVRf/Extensions/WidgetPlugin/gradle/wrapper/gradle-wrapper.properties
+++ b/GVRf/Extensions/WidgetPlugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed Aug 17 13:01:03 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
seems like an android gradle plugin bug

Reproduced by:
- build framework, widget plugin
- build widget plugin again (gradlew assembleDebug)
- there are Google VR classes (resource-related) in the classes.jar in the framework aar
- modelviewer generates again those classes hence the error

Upgraded the android gradle plugin version of the widget project; no longer
reproducing by following the steps above

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>