### PR TITLE
Remove the com.android.support depdency from the 3DCursorLibrary

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/build.gradle
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/build.gradle
@@ -57,7 +57,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:21.0.0'
     compile(name: 'framework-debug', ext: 'aar')
 }
 


### PR DESCRIPTION
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>