### PR TITLE
LOD fixes

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.cpp
@@ -61,11 +61,16 @@ void BoundingVolume::expand(const glm::vec3 point) {
         max_corner_[2] = point[2];
     }
 
+    updateCenterAndRadius();
+}
+
+void BoundingVolume::updateCenterAndRadius() {
     center_ = (min_corner_ + max_corner_) * 0.5f;
-    if (min_corner_ == max_corner_)
-    	radius_ = 0;
-    else
-    	radius_ = glm::length(max_corner_ - min_corner_) * 0.5f;
+    if (min_corner_ == max_corner_) {
+        radius_ = 0;
+    } else {
+        radius_ = glm::length(max_corner_ - min_corner_) * 0.5f;
+    }
 }
 
 /*
@@ -182,9 +187,8 @@ void BoundingVolume::transform(const BoundingVolume &in_volume,
             max_corner_.z += a;
         }
     }
-    // expand with the new corners
-    expand(min_corner_);
-    expand(max_corner_);
+
+    updateCenterAndRadius();
 }
 
 bool BoundingVolume::intersect(glm::vec3& hitPoint, const glm::vec3& rayStart, const glm::vec3& rayDir)  const

--- a/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.cpp
@@ -182,6 +182,9 @@ void BoundingVolume::transform(const BoundingVolume &in_volume,
             max_corner_.z += a;
         }
     }
+    // expand with the new corners
+    expand(min_corner_);
+    expand(max_corner_);
 }
 
 bool BoundingVolume::intersect(glm::vec3& hitPoint, const glm::vec3& rayStart, const glm::vec3& rayDir)  const

--- a/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.h
@@ -59,6 +59,9 @@ public:
     bool intersect(glm::vec3& hitPoint, const glm::vec3& rayStart, const glm::vec3& rayDir)  const;
 
 private:
+    void updateCenterAndRadius();
+
+private:
     glm::vec3 center_;
     float radius_ = 0.0f;
     glm::vec3 min_corner_;

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
@@ -27,10 +27,12 @@
 #include "mesh.h"
 
 namespace gvr {
+bool SceneObject::using_lod_ = false;
+
 SceneObject::SceneObject() :
         HybridObject(), name_(""), children_(), visible_(true), transform_dirty_(false), in_frustum_(
                 false),  enabled_(true),query_currently_issued_(false), vis_count_(0), lod_min_range_(
-                0), lod_max_range_(MAXFLOAT), cull_status_(false), using_lod_(false), bounding_volume_dirty_(
+                0), lod_max_range_(MAXFLOAT), cull_status_(false), bounding_volume_dirty_(
                 true) {
 
     // Occlusion query setup

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
@@ -180,7 +180,7 @@ private:
     std::vector<SceneObject*> children_;
     float lod_min_range_;
     float lod_max_range_;
-    bool using_lod_;
+    static bool using_lod_;
     bool cull_status_;
     bool transform_dirty_;
     BoundingVolume transformed_bounding_volume_;


### PR DESCRIPTION
- BoundingVolume::transform: without the expand calls the center and
the radius would not be recalculated
- SceneObject::frustumCull: crude workaround to force lod check for
all children scene objects; disables optimization but only in case
any scene object uses lod

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>