### PR TITLE
Allow including extra modules from possibly another repos without

### DIFF
--- a/GVRf/Framework/settings.gradle
+++ b/GVRf/Framework/settings.gradle
@@ -3,3 +3,7 @@ if (!hasProperty("ARM64")) {
     include ':backend_oculus'
     include ':backend_daydream'
 }
+
+if(file("../../../extra_settings.gradle").exists()) {
+    apply from: '../../../extra_settings.gradle'
+}

--- a/GVRf/tools/Framework/settings.gradle
+++ b/GVRf/tools/Framework/settings.gradle
@@ -8,3 +8,8 @@ include ':framework-tests'
 project(':framework-tests').projectDir = file('demos/framework-tests')
 include ':gvr-unittestutils'
 project(':gvr-unittestutils').projectDir = file('demos/gvr-unittestutils')
+
+
+if(file("../../../../extra_settings.gradle").exists()) {
+    apply from: '../../../../extra_settings.gradle'
+}


### PR DESCRIPTION
having to update the master settings.gradle.

For example, to include a backend xyz create extra_settings.gradle in
the directory where the GearVRf/ directory is, with the following contents:

include ':backend_xyz'
project(':backend_xyz').projectDir=new File('../../../SomeOtherRepo/GVRf/Framework/backend_xyz')

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>