### PR TITLE
Include the HEAD commit id in the native binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ import-summary.txt
 !**/libgdx.so
 
 .externalNativeBuild
+buildinfo.h
+buildinfo.cpp

--- a/GVRf/Framework/backend_oculus/build.gradle
+++ b/GVRf/Framework/backend_oculus/build.gradle
@@ -39,7 +39,22 @@ android {
         }
     }
 
-    task buildNative(type: Exec) {
+    task buildInfo(type:Exec){
+        commandLine 'git log -n 1 --format=%H'.split()
+        def source = new File(projectDir.absolutePath + '/src/main/jni', 'buildinfo.cpp')
+        standardOutput = new ByteArrayOutputStream()
+
+        doLast {
+            source.text = '#include "util/gvr_log.h"\n'
+            source.text += '#include <jni.h>\n\n'
+            source.text += 'jint JNI_OnLoad(JavaVM *vm, void *reserved) {\n'
+            source.text += '    LOGI("BACKEND_OCULUS HEAD: '+ standardOutput.toString().trim() + '");\n'
+            source.text += '    return JNI_VERSION_1_6;\n'
+            source.text += '}'
+        }
+    }
+
+    task buildNative(type: Exec, dependsOn: buildInfo) {
         if (rootProject.hasProperty("OVR_MOBILE_SDK")) {
             environment 'OVR_MOBILE_SDK', rootProject.property("OVR_MOBILE_SDK")
         } else {

--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -21,7 +21,22 @@ android {
         }
     }
 
-    task buildNative(type: Exec) {
+    task buildInfo(type:Exec){
+        commandLine 'git log -n 1 --format=%H'.split()
+        def source = new File(projectDir.absolutePath + '/src/main/jni', 'buildinfo.cpp')
+        standardOutput = new ByteArrayOutputStream()
+
+        doLast {
+            source.text = '#include "util/gvr_log.h"\n'
+            source.text += '#include <jni.h>\n\n'
+            source.text += 'jint JNI_OnLoad(JavaVM *vm, void *reserved) {\n'
+            source.text += '    LOGI("FRAMEWORK HEAD: '+ standardOutput.toString().trim() + '");\n'
+            source.text += '    return JNI_VERSION_1_6;\n'
+            source.text += '}'
+        }
+    }
+
+    task buildNative(type: Exec, dependsOn: buildInfo)  {
         def ndkbuild = ""
         if (rootProject.hasProperty("ANDROID_NDK_HOME")) {
             ndkbuild = rootProject.property("ANDROID_NDK_HOME")


### PR DESCRIPTION
On library load this gets printed out:
```
FRAMEWORK HEAD: <commit-id>
BACKEND_<blah> HEAD: <commit-id>
```
You can also just search for prefix in the binary.

The task is not aware of local changes to the tree.
The Java classes will be marked in a subsequent pull request.
Works on Windows.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>