### PR TITLE
Fixes in 3DCursorLibrary and SensorManager

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/Cursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/Cursor.java
@@ -524,6 +524,20 @@ public abstract class Cursor {
         }
     }
 
+    void transferIoDevice(Cursor targetCursor) {
+        IoDevice targetIoDevice = targetCursor.getIoDevice();
+        targetIoDevice.removeControllerEventListener(targetCursor.getControllerEventListener());
+        targetIoDevice.resetSceneObject();
+        if (IoDeviceLoader.isMouseIoDevice(targetIoDevice)) {
+            if (targetCursor.mouseEventListener != null) {
+                targetCursor.ioDevice.removeControllerEventListener(targetCursor
+                        .mouseEventListener);
+            }
+        }
+        ioDevice = targetIoDevice;
+        setupIoDevice(targetIoDevice);
+    }
+
     private enum State {
         FRONT, BACK, LEFT, RIGHT, FRONT_RIGHT, FRONT_LEFT, BACK_RIGHT, BACK_LEFT
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorManager.java
@@ -78,12 +78,23 @@ class SensorManager {
                 }
             }
 
-            for (GVRSceneObject object : scene.getSceneObjects()) {
-                recurseSceneObject(controller, object, null, markActiveNodes);
+            if(isValidRay(controller.getRay())) {
+                for (GVRSceneObject object : scene.getSceneObjects()) {
+                    recurseSceneObject(controller, object, null, markActiveNodes);
+                }
             }
             for (GVRBaseSensor sensor : sensors.keySet()) {
                 sensor.processList(controller);
             }
+        }
+    }
+
+    private boolean isValidRay(Vector3f ray) {
+        if(ray == null || Float.isNaN(ray.x) || Float.isNaN(ray.y) || Float.isNaN(ray.z) ||
+                (ray.x == 0 && ray.y == 0 && ray.z == 0)) {
+            return false;
+        } else {
+            return true;
         }
     }
 
@@ -100,7 +111,6 @@ class SensorManager {
          * the children accordingly.
          */
         Vector3f ray = controller.getRay();
-
         if (!object.intersectsBoundingVolume(ORIGIN[0], ORIGIN[1],
                 ORIGIN[2], ray.x, ray.y, ray.z)) {
             return;


### PR DESCRIPTION
1. Added check for valid ray from CursorController before performing picking in SensorManager.
2. Added transferIoDevice() call to enableSettingsCursor() so IoDevice is not disabled and re-enabled when using the settings cursor

GearVRf-DCO-1.0-Signed-off-by: Parth Mehta parth.mehta@samsung.com