### PR TITLE
Fix for using framework thread

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -111,8 +111,6 @@ abstract class GVRViewManager extends GVRContext {
         }
     }
 
-    void setUseTheFrameworkThread(boolean b) {}
-
     protected boolean updateSensoredScene() {
         if (mSensoredScene != null && mMainScene.equals(mSensoredScene)) {
             return true;


### PR DESCRIPTION
This fixes the setUseFrameworkThread call to use the one in the base class GVRContext. An empty implementation was preventing the framework thread from being created. 

GearVRf-DCO-1.0-Signed-off-by: Parth Mehta parth.mehta@samsung.com
