### PR TITLE
Fix the splash screen dismissal logic

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -101,7 +101,11 @@ abstract class GVRViewManager extends GVRContext {
         if (mNextMainScene == scene) {
             mNextMainScene = null;
             if (mOnSwitchMainScene != null) {
-                mOnSwitchMainScene.run();
+                try {
+                    mOnSwitchMainScene.run();
+                } catch (final Exception exc) {
+                    Log.e(TAG, "onSwitchMainScene runnable threw " + exc);
+                }
                 mOnSwitchMainScene = null;
             }
         }
@@ -346,10 +350,11 @@ abstract class GVRViewManager extends GVRContext {
             // splash screen post-init animations
             long currentTime = doMemoryManagementAndPerFrameCallbacks();
 
-            if (mSplashScreen != null && (currentTime >= mSplashScreen.mTimeout || mSplashScreen.closeRequested())) {
-                if (mSplashScreen.closeRequested()
-                        || mMain.getSplashMode() == GVRScript.SplashMode.AUTOMATIC) {
+            final boolean timeoutExpired = (null == mSplashScreen
+                    || (0 <= mMain.getSplashDisplayTime() && currentTime >= mSplashScreen.mTimeout));
 
+            if (mSplashScreen != null && (timeoutExpired || mSplashScreen.closeRequested())) {
+                if (mSplashScreen.closeRequested() || mMain.getSplashMode() == GVRScript.SplashMode.AUTOMATIC) {
                     final SplashScreen splashScreen = mSplashScreen;
                     new GVROpacityAnimation(mSplashScreen, mMain.getSplashFadeTime(), 0) //
                             .setOnFinish(new GVROnFinish() {


### PR DESCRIPTION
When in "automatic" mode we were dismissing the splash screen before onInit completes causing issues noticeable in gvr-meshanimation, gvr-accessibility and gvr-modelviewer.

Note that now the fw will wait correctly for onInit to complete and that may take time. For example, gvr-jassimp loads a tree model from the network so the splash screen stays on for some time.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>