### PR TITLE
Collision event generation fix

### DIFF
--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRCollisionInfo.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRCollisionInfo.java
@@ -6,12 +6,14 @@ class GVRCollisionInfo {
     public final long bodyB;
     public final float[] normal;
     public final float distance;
+    public final boolean isHit;
 
-    public GVRCollisionInfo(long bodyA, long bodyB, float normal[], float distance) {
+    public GVRCollisionInfo(long bodyA, long bodyB, float normal[], float distance, boolean isHit) {
         this.bodyA = bodyA;
         this.bodyB = bodyB;
         this.normal = normal;
         this.distance = distance;
+        this.isHit = isHit;
     }
 
     @Override

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
@@ -40,7 +40,6 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
     }
 
     private final LongSparseArray<GVRRigidBody> mRigidBodies = new LongSparseArray<GVRRigidBody>();
-    private final LinkedList<GVRCollisionInfo> mPreviousCollisions = new LinkedList<GVRCollisionInfo>();
     private final GVRCollisionMatrix mCollisionMatrix;
 
     public GVRWorld(GVRContext gvrContext) {
@@ -111,24 +110,17 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
     private void generateCollisionEvents() {
         GVRCollisionInfo collisionInfos[] = NativePhysics3DWorld.listCollisions(getNative());
 
-        String eventName = "onEnter";
-        for (GVRCollisionInfo info : collisionInfos) {
+        String onEnter = "onEnter";
+        String onExit = "onExit";
 
-            if (mPreviousCollisions.contains(info)) {
-                //eventName = "onInside";
-                mPreviousCollisions.remove(info);
-            } else {
-                sendCollisionEvent(info, eventName);
+        for (GVRCollisionInfo info : collisionInfos) {
+            if (info.isHit) {
+                sendCollisionEvent(info, onEnter);
+            }
+            else {
+                sendCollisionEvent(info, onExit);
             }
         }
-
-        eventName = "onExit";
-        for (GVRCollisionInfo cp: mPreviousCollisions) {
-            sendCollisionEvent(cp, eventName);
-        }
-
-        mPreviousCollisions.clear();
-        Collections.addAll(mPreviousCollisions, collisionInfos);
     }
 
     private void sendCollisionEvent(GVRCollisionInfo info, String eventName) {

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/bullet/bullet_world.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/bullet/bullet_world.h
@@ -26,6 +26,8 @@
 #include <BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.h>
 
 #include "glm/glm.hpp"
+#include <utility>
+#include <map>
 
 namespace gvr {
 
@@ -43,8 +45,7 @@ class BulletWorld : public Physics3DWorld {
 
     void step(float timeStep);
 
-    void listCollisions(
-            std::vector <ContactPoint> &contactPoints); //index counts how many iteration it's on list, if <0 should be taken out
+    void listCollisions(std::list <ContactPoint> &contactPoints);
 
  private:
     void initialize();
@@ -52,6 +53,7 @@ class BulletWorld : public Physics3DWorld {
     void finalize();
 
  private:
+    std::map<std::pair <long,long>, ContactPoint> prevCollisions;
     btDynamicsWorld *mPhysicsWorld;
     btCollisionConfiguration *mCollisionConfiguration;
     btCollisionDispatcher *mDispatcher;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics3d/physics_3dworld_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics3d/physics_3dworld_jni.cpp
@@ -101,15 +101,15 @@ JNIEXPORT jobjectArray JNICALL
 Java_org_gearvrf_physics_NativePhysics3DWorld_listCollisions(JNIEnv * env, jobject obj, jlong jworld) {
 
     jclass collisionInfoClass = env->FindClass("org/gearvrf/physics/GVRCollisionInfo");
-    jmethodID collisionInfoConstructor = env->GetMethodID(collisionInfoClass, "<init>", "(JJ[FF)V");
+    jmethodID collisionInfoConstructor = env->GetMethodID(collisionInfoClass, "<init>", "(JJ[FFZ)V");
 
     BulletWorld *world = reinterpret_cast <BulletWorld*> (jworld);
-    std::vector <ContactPoint> contactPoints;
+    std::list <ContactPoint> contactPoints;
 
     world->listCollisions(contactPoints);
 
     int size = contactPoints.size();
-    jobjectArray jnewlist = env->NewObjectArray(size, collisionInfoClass, NULL);
+    jobjectArray jNewList = env->NewObjectArray(size, collisionInfoClass, NULL);
 
     int i = 0;
     for (auto it = contactPoints.begin(); it != contactPoints.end(); ++it) {
@@ -120,15 +120,16 @@ Java_org_gearvrf_physics_NativePhysics3DWorld_listCollisions(JNIEnv * env, jobje
 
         jobject contactObject = env->NewObject(collisionInfoClass, collisionInfoConstructor,
                                                (jlong)data.body0, (jlong)data.body1,
-                                               (jfloatArray)normal, (jfloat)data.distance);
+                                               (jfloatArray)normal, (jfloat)data.distance,
+                                               (jboolean)data.isHit);
 
-        env->SetObjectArrayElement(jnewlist, i++, contactObject);
+        env->SetObjectArrayElement(jNewList, i++, contactObject);
         env->DeleteLocalRef(contactObject);
+        env->DeleteLocalRef(normal);
     }
 
     env->DeleteLocalRef(collisionInfoClass);
-
-    return jnewlist;
+    return jNewList;
 }
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics_world.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics_world.h
@@ -22,6 +22,7 @@
 
 #include "physics_rigidbody.h"
 #include "../objects/scene_object.h"
+#include <list>
 
 namespace gvr {
 
@@ -30,6 +31,7 @@ struct ContactPoint {
 	PhysicsRigidBody* body1 = 0;
 	float normal[3] = {0.0f, 0.0f, 0.0f};
 	float distance = 0.0f;
+	bool isHit = true;
 };
 
 class PhysicsWorld : public Component {
@@ -48,7 +50,7 @@ class PhysicsWorld : public Component {
 
 	void step(float timeStep);
 
-	void listCollisions(std::vector<ContactPoint>& contactPoints);
+	void listCollisions(std::list<ContactPoint>& contactPoints);
 };
 
 }


### PR DESCRIPTION
The list of event collisions is filtered on the native side, and the Java layer only has to send its events, avoiding some crashes and improving a little bit the performance. 

GearVRf-DCO-1.0-Signed-off-by: JulianaFigueira juliana.f@samsung.com