### PR TITLE
The CursorEvent getRotation methods need to be public.

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorEvent.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorEvent.java
@@ -240,7 +240,7 @@ public class CursorEvent {
      *
      * @return 'W' quaternion component of the {@link Cursor} that generated this event.
      */
-    float getCursorRotationW() {
+    public float getCursorRotationW() {
         return cursorRotation.w;
     }
 
@@ -253,7 +253,7 @@ public class CursorEvent {
      *
      * @return 'X' quaternion component of the {@link Cursor} that generated this event.
      */
-    float getCursorRotationX() {
+    public float getCursorRotationX() {
         return cursorRotation.x;
     }
 
@@ -266,7 +266,7 @@ public class CursorEvent {
      *
      * @return 'Y' quaternion component of the {@link Cursor} that generated this event.
      */
-    float getCursorRotationY() {
+    public float getCursorRotationY() {
         return cursorRotation.y;
     }
 
@@ -279,7 +279,7 @@ public class CursorEvent {
      *
      * @return 'Z' quaternion component of the {@link Cursor} that generated this event.
      */
-    float getCursorRotationZ() {
+    public float getCursorRotationZ() {
         return cursorRotation.z;
     }
 


### PR DESCRIPTION
A slight oversight on my part. This can be merged immediately.

GearVRf-DCO-1.0-Signed-off-by: Rahul Rudradevan
r.rudradevan@samsung.com