### PR TITLE
Add stencil buffer support

### DIFF
--- a/GVRf/Framework/backend_daydream/src/main/jni/daydream_renderer.cpp
+++ b/GVRf/Framework/backend_daydream/src/main/jni/daydream_renderer.cpp
@@ -112,13 +112,13 @@ void DaydreamRenderer::InitializeGl() {
     specs.push_back(gvr_api_->CreateBufferSpec());
 
     specs[0].SetColorFormat(GVR_COLOR_FORMAT_RGBA_8888);
-    specs[0].SetDepthStencilFormat(GVR_DEPTH_STENCIL_FORMAT_DEPTH_16);
+    specs[0].SetDepthStencilFormat(GVR_DEPTH_STENCIL_FORMAT_DEPTH_24_STENCIL_8);
     specs[0].SetSize(render_size_);
     specs[0].SetSamples(2);
 
     specs[1].SetSize(render_size_);
     specs[1].SetColorFormat(GVR_COLOR_FORMAT_RGBA_8888);
-    specs[1].SetDepthStencilFormat(GVR_DEPTH_STENCIL_FORMAT_DEPTH_16);
+    specs[1].SetDepthStencilFormat(GVR_DEPTH_STENCIL_FORMAT_DEPTH_24_STENCIL_8);
     specs[1].SetSamples(2);
     swapchain_.reset(new gvr::SwapChain(gvr_api_->CreateSwapChain(specs)));
 

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -155,7 +155,7 @@ void GVRActivity::onSurfaceChanged(JNIEnv& env) {
         }
 
         for (int eye = 0; eye < (use_multiview ? 1 :VRAPI_FRAME_LAYER_EYE_MAX); eye++) {
-            bool b = frameBuffer_[eye].create(mColorTextureFormatConfiguration, mWidthConfiguration,
+            frameBuffer_[eye].create(mColorTextureFormatConfiguration, mWidthConfiguration,
                     mHeightConfiguration, mMultisamplesConfiguration, mResolveDepthConfiguration,
                     mDepthTextureFormatConfiguration);
         }

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_framebufferobject.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_framebufferobject.cpp
@@ -144,6 +144,9 @@ void FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
         mResolveFrameBuffers = new GLuint[mTextureSwapChainLength];
     }
 
+    const GLenum depthStencilAttachment =
+            VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
+
     for (int i = 0; i < mTextureSwapChainLength; ++i) {
 
         const GLuint colorTexture = vrapi_GetTextureSwapChainHandle(mColorTextureSwapChain, i);
@@ -160,11 +163,7 @@ void FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
                                                                GL_COLOR_ATTACHMENT0, colorTexture,
                                                                0, multisamples, 0, 2));
                 if (VRAPI_TEXTURE_FORMAT_NONE != depthFormat) {
-                    GL(glFramebufferTextureMultisampleMultiviewOVR(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, mDepthBuffers[i], 0, multisamples, 0, 2));
-                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
-                        GL(glFramebufferTextureMultisampleMultiviewOVR(
-                                GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, mDepthBuffers[i], 0, multisamples, 0, 2));
-                    }
+                    GL(glFramebufferTextureMultisampleMultiviewOVR(GL_DRAW_FRAMEBUFFER, depthStencilAttachment, mDepthBuffers[i], 0, multisamples, 0, 2));
                 }
             }
             else {
@@ -172,10 +171,7 @@ void FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
                                                         GL_TEXTURE_2D,
                                                         colorTexture, 0, multisamples));
                 if (VRAPI_TEXTURE_FORMAT_NONE != depthFormat) {
-                    GL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]));
-                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
-                        GL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]));
-                    }
+                    GL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, depthStencilAttachment, GL_RENDERBUFFER, mDepthBuffers[i]));
                 }
             }
             GLenum renderStatus = GL( glCheckFramebufferStatus(GL_FRAMEBUFFER) );
@@ -188,19 +184,13 @@ void FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
             if(use_multiview){
                 GL( glFramebufferTextureMultisampleMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, mColorBuffer, 0 , multisamples , 0 , 2  ) );
                 if (depthFormat != VRAPI_TEXTURE_FORMAT_NONE) {
-                    GL( glFramebufferTextureMultisampleMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, mDepthBuffers[i], 0 , multisamples , 0 , 2  ) );
-                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
-                        GL( glFramebufferTextureMultisampleMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, mDepthBuffers[i], 0 , multisamples , 0 , 2  ) );
-                    }
+                    GL( glFramebufferTextureMultisampleMultiviewOVR( GL_DRAW_FRAMEBUFFER, depthStencilAttachment, mDepthBuffers[i], 0 , multisamples , 0 , 2  ) );
                 }
             }
             else {
                 GL( glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, mColorBuffer) );
                 if (depthFormat != VRAPI_TEXTURE_FORMAT_NONE) {
-                    GL( glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]) );
-                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
-                        GL( glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]) );
-                    }
+                    GL( glFramebufferRenderbuffer( GL_FRAMEBUFFER, depthStencilAttachment, GL_RENDERBUFFER, mDepthBuffers[i]) );
                 }
             }
             GLenum renderStatus = GL( glCheckFramebufferStatus(GL_FRAMEBUFFER) );
@@ -233,25 +223,16 @@ void FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
                 GL( glFramebufferTextureMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, colorTexture, 0 , 0 , 2 ) );
                 if (depthFormat != VRAPI_TEXTURE_FORMAT_NONE) {
                     const GLuint texture = resolveDepth ? depthTexture : mDepthBuffers[i];
-                    GL( glFramebufferTextureMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, texture, 0 , 0 , 2 ) );
-                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
-                        GL( glFramebufferTextureMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, texture, 0 , 0 , 2 ) );
-                    }
+                    GL( glFramebufferTextureMultiviewOVR( GL_DRAW_FRAMEBUFFER, depthStencilAttachment, texture, 0 , 0 , 2 ) );
                 }
             }
             else {
                 GL( glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTexture, 0) );
                 if (depthFormat != VRAPI_TEXTURE_FORMAT_NONE) {
                     if (resolveDepth) {
-                        GL( glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTexture, 0) );
-                        if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
-                            GL( glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthTexture, 0) );
-                        }
+                        GL( glFramebufferTexture2D(GL_FRAMEBUFFER, depthStencilAttachment, GL_TEXTURE_2D, depthTexture, 0) );
                     } else {
-                        GL( glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]) );
-                        if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
-                            GL( glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]) );
-                        }
+                        GL( glFramebufferRenderbuffer(GL_FRAMEBUFFER, depthStencilAttachment, GL_RENDERBUFFER, mDepthBuffers[i]) );
                     }
                 }
             }

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_framebufferobject.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_framebufferobject.cpp
@@ -39,21 +39,15 @@ void FrameBufferObject::clear() {
     mDepthBuffers = NULL;
 }
 
-bool FrameBufferObject::create(const ovrTextureFormat colorFormat, const int width, const int height,
+void FrameBufferObject::create(const ovrTextureFormat colorFormat, const int width, const int height,
         const int multisamples, bool resolveDepth, const ovrTextureFormat depthFormat) {
     clearGLError("FrameBufferObject::create: GL error on entry");
 
     mWidth = width;
     mHeight = height;
     mMultisamples = multisamples;
-    ovrTextureType tex_target;
-
-    if(use_multiview)
-        tex_target = VRAPI_TEXTURE_TYPE_2D_ARRAY;
-    else
-        tex_target = VRAPI_TEXTURE_TYPE_2D;
-
-    mColorTextureSwapChain = vrapi_CreateTextureSwapChain(tex_target, colorFormat, width, height, 1, true);
+    ovrTextureType tex_target = use_multiview ? VRAPI_TEXTURE_TYPE_2D_ARRAY : VRAPI_TEXTURE_TYPE_2D;
+    mColorTextureSwapChain = vrapi_CreateTextureSwapChain(tex_target, colorFormat, mWidth, mHeight, 1, true);
 
     if (nullptr == mColorTextureSwapChain) {
         FAIL("vrapi_CreateTextureSwapChain for mColorTextureSwapChain failed");
@@ -71,69 +65,42 @@ bool FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
     PFNGLFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVRPROC glFramebufferTextureMultisampleMultiviewOVR =
             (PFNGLFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVRPROC) eglGetProcAddress( "glFramebufferTextureMultisampleMultiviewOVR" );
 
-    enum multisample_t {
-        MSAA_OFF, MSAA_RENDER_TO_TEXTURE, MSAA_BLIT
-    };
-
-    multisample_t multisampleMode;
     if (multisamples > 1) {
         if ((glFramebufferTextureMultisampleMultiviewOVR != NULL || glFramebufferTexture2DMultisampleEXT != NULL)
                 && resolveDepth == false) {
-            multisampleMode = MSAA_RENDER_TO_TEXTURE;
+            mMultisampleMode = MSAA_RENDER_TO_TEXTURE;
         } else {
-            multisampleMode = MSAA_BLIT;
+            mMultisampleMode = MSAA_BLIT;
         }
     } else {
-        multisampleMode = MSAA_OFF;
+        mMultisampleMode = MSAA_OFF;
     }
     if(use_multiview)
         LOGV("FrameBufferObject::create: multisampleMode: %d, glRenderbufferStorageMultisampleEXT: %p, glFramebufferTexture2DMultisampleEXT: %p",
-                multisampleMode, glFramebufferTextureMultisampleMultiviewOVR, glFramebufferTextureMultiviewOVR);
+                mMultisampleMode, glFramebufferTextureMultisampleMultiviewOVR, glFramebufferTextureMultiviewOVR);
     else
         LOGV("FrameBufferObject::create: multisampleMode: %d, glRenderbufferStorageMultisampleEXT: %p, glFramebufferTexture2DMultisampleEXT: %p",
-                multisampleMode, glRenderbufferStorageMultisampleEXT, glFramebufferTexture2DMultisampleEXT);
+                mMultisampleMode, glRenderbufferStorageMultisampleEXT, glFramebufferTexture2DMultisampleEXT);
 
-    if (MSAA_BLIT == multisampleMode) {
-        GLenum internalFormat;
-        switch (colorFormat) {
-        case VRAPI_TEXTURE_FORMAT_565:
-            internalFormat = GL_RGB565;
-            break;
-        case VRAPI_TEXTURE_FORMAT_5551:
-            internalFormat = GL_RGB5_A1;
-            break;
-        case VRAPI_TEXTURE_FORMAT_4444:
-            internalFormat = GL_RGBA4;
-            break;
-        case VRAPI_TEXTURE_FORMAT_8888:
-            internalFormat = GL_RGBA8;
-            break;
-        case VRAPI_TEXTURE_FORMAT_8888_sRGB:
-            internalFormat = GL_SRGB8_ALPHA8;
-            break;
-        case VRAPI_TEXTURE_FORMAT_RGBA16F:
-            internalFormat = GL_RGBA16F;
-            break;
-        default:
-            FAIL("unknown colorFormat %i", colorFormat);
-        }
+    if (MSAA_BLIT == mMultisampleMode) {
+        GLenum internalFormat = translateVrapiFormatToInternal(colorFormat);
 
         if(use_multiview){
             GL( glGenTextures( 1, &mColorBuffer ) );
             GL( glBindTexture( GL_TEXTURE_2D_ARRAY, mColorBuffer ) );
-            GL( glTexStorage3D( GL_TEXTURE_2D_ARRAY, 1, internalFormat, width, height, 2 ) );
+            GL( glTexStorage3D( GL_TEXTURE_2D_ARRAY, 1, internalFormat, mWidth, mHeight, 2 ) );
         }
         else {
             GL( glGenRenderbuffers(1, &mColorBuffer) );
             GL( glBindRenderbuffer(GL_RENDERBUFFER, mColorBuffer));
-            GL( glRenderbufferStorageMultisample(GL_RENDERBUFFER, multisamples, internalFormat, width, height) );
+            GL( glRenderbufferStorageMultisample(GL_RENDERBUFFER, multisamples, internalFormat, mWidth, mHeight) );
             GL( glBindRenderbuffer(GL_RENDERBUFFER, 0) );
         }
     }
 
     if (depthFormat != VRAPI_TEXTURE_FORMAT_NONE) {
         if (resolveDepth) {
-            mDepthTextureSwapChain = vrapi_CreateTextureSwapChain(tex_target, depthFormat, width, height, 1, true);
+            mDepthTextureSwapChain = vrapi_CreateTextureSwapChain(tex_target, depthFormat, mWidth, mHeight, 1, true);
             if (nullptr == mDepthTextureSwapChain) {
                 FAIL("vrapi_CreateTextureSwapChain for mDepthTextureSwapChain failed");
             }
@@ -143,42 +110,28 @@ bool FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
             mDepthTextureSwapChainLength = 0;
         }
 
-        if (!resolveDepth || MSAA_BLIT == multisampleMode) {
-            GLenum internalFormat;
-            switch (depthFormat) {
-            case VRAPI_TEXTURE_FORMAT_DEPTH_16:
-                internalFormat = GL_DEPTH_COMPONENT16;
-                break;
-            case VRAPI_TEXTURE_FORMAT_DEPTH_24:
-                internalFormat = GL_DEPTH_COMPONENT24;
-                break;
-            case VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8:
-                internalFormat = GL_DEPTH24_STENCIL8;
-                break;
-            default:
-                FAIL("unknown depthFormat %i", depthFormat);
-            }
+        if (!resolveDepth || MSAA_BLIT == mMultisampleMode) {
+            GLenum internalFormat = translateVrapiFormatToInternal(depthFormat);
 
             mDepthBuffers = new GLuint[mTextureSwapChainLength];
             if(use_multiview){
                 for (int i = 0; i < mTextureSwapChainLength; ++i) {
                     GL( glGenTextures( 1, &mDepthBuffers[i] ) );
                     GL( glBindTexture( GL_TEXTURE_2D_ARRAY, mDepthBuffers[i] ) );
-                    GL( glTexStorage3D( GL_TEXTURE_2D_ARRAY, 1, internalFormat, width, height, 2 ) );
+                    GL( glTexStorage3D( GL_TEXTURE_2D_ARRAY, 1, internalFormat, mWidth, mHeight, 2 ) );
                     GL( glBindTexture( GL_TEXTURE_2D_ARRAY, 0 ) );
                 }
-
             }
             else {
                 for (int i = 0; i < mTextureSwapChainLength; ++i) {
                     GL( glGenRenderbuffers(1, &mDepthBuffers[i]) );
                     GL( glBindRenderbuffer(GL_RENDERBUFFER, mDepthBuffers[i]) );
-                    if (multisampleMode == MSAA_RENDER_TO_TEXTURE) {
-                        GL( glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, multisamples, internalFormat, width, height) );
-                    } else if (multisampleMode == MSAA_BLIT) {
-                        GL( glRenderbufferStorageMultisample(GL_RENDERBUFFER, multisamples, internalFormat, width, height) );
+                    if (mMultisampleMode == MSAA_RENDER_TO_TEXTURE) {
+                        GL( glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, multisamples, internalFormat, mWidth, mHeight) );
+                    } else if (mMultisampleMode == MSAA_BLIT) {
+                        GL( glRenderbufferStorageMultisample(GL_RENDERBUFFER, multisamples, internalFormat, mWidth, mHeight) );
                     } else {
-                        GL( glRenderbufferStorage(GL_RENDERBUFFER, internalFormat, width, height) );
+                        GL( glRenderbufferStorage(GL_RENDERBUFFER, internalFormat, mWidth, mHeight) );
                     }
                     GL( glBindRenderbuffer(GL_RENDERBUFFER, 0) );
                 }
@@ -187,7 +140,7 @@ bool FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
     }
 
     mRenderFrameBuffers = new GLuint[mTextureSwapChainLength];
-    if (MSAA_BLIT == multisampleMode) {
+    if (MSAA_BLIT == mMultisampleMode) {
         mResolveFrameBuffers = new GLuint[mTextureSwapChainLength];
     }
 
@@ -196,23 +149,33 @@ bool FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
         const GLuint colorTexture = vrapi_GetTextureSwapChainHandle(mColorTextureSwapChain, i);
         const GLuint depthTexture = (mDepthTextureSwapChain != nullptr)
                                 ? vrapi_GetTextureSwapChainHandle(mDepthTextureSwapChain, i) : 0;
-        GLenum colorTextureTarget = use_multiview ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
+
         GL( glGenFramebuffers(1, &mRenderFrameBuffers[i]) );
         GL( glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mRenderFrameBuffers[i]) );
 
-        if (MSAA_RENDER_TO_TEXTURE == multisampleMode) {
+        if (MSAA_RENDER_TO_TEXTURE == mMultisampleMode) {
 
             if(use_multiview){
-                GL( glFramebufferTextureMultisampleMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, colorTexture, 0 , multisamples , 0 , 2  ) );
+                GL(glFramebufferTextureMultisampleMultiviewOVR(GL_DRAW_FRAMEBUFFER,
+                                                               GL_COLOR_ATTACHMENT0, colorTexture,
+                                                               0, multisamples, 0, 2));
                 if (VRAPI_TEXTURE_FORMAT_NONE != depthFormat) {
-                    GL( glFramebufferTextureMultisampleMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, mDepthBuffers[i], 0 , multisamples , 0 , 2  ) );
+                    GL(glFramebufferTextureMultisampleMultiviewOVR(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, mDepthBuffers[i], 0, multisamples, 0, 2));
+                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
+                        GL(glFramebufferTextureMultisampleMultiviewOVR(
+                                GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, mDepthBuffers[i], 0, multisamples, 0, 2));
+                    }
                 }
             }
             else {
-                GL( glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                        colorTexture, 0, multisamples) );
+                GL(glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                                        GL_TEXTURE_2D,
+                                                        colorTexture, 0, multisamples));
                 if (VRAPI_TEXTURE_FORMAT_NONE != depthFormat) {
-                    GL( glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]) );
+                    GL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]));
+                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
+                        GL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]));
+                    }
                 }
             }
             GLenum renderStatus = GL( glCheckFramebufferStatus(GL_FRAMEBUFFER) );
@@ -220,18 +183,24 @@ bool FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
                 FAIL("fbo %i not complete: 0x%x", mRenderFrameBuffers[i], renderStatus );
             }
         }
-        else if (multisampleMode == MSAA_BLIT) {
+        else if (mMultisampleMode == MSAA_BLIT) {
 
             if(use_multiview){
                 GL( glFramebufferTextureMultisampleMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, mColorBuffer, 0 , multisamples , 0 , 2  ) );
                 if (depthFormat != VRAPI_TEXTURE_FORMAT_NONE) {
                     GL( glFramebufferTextureMultisampleMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, mDepthBuffers[i], 0 , multisamples , 0 , 2  ) );
+                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
+                        GL( glFramebufferTextureMultisampleMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, mDepthBuffers[i], 0 , multisamples , 0 , 2  ) );
+                    }
                 }
             }
             else {
                 GL( glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, mColorBuffer) );
                 if (depthFormat != VRAPI_TEXTURE_FORMAT_NONE) {
                     GL( glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]) );
+                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
+                        GL( glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]) );
+                    }
                 }
             }
             GLenum renderStatus = GL( glCheckFramebufferStatus(GL_FRAMEBUFFER) );
@@ -260,15 +229,13 @@ bool FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
                 FAIL("fbo %i not complete: 0x%x", mResolveFrameBuffers[i], resolveStatus);
             }
         } else {
-            //LOGE("non multisample");
             if(use_multiview){
                 GL( glFramebufferTextureMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, colorTexture, 0 , 0 , 2 ) );
                 if (depthFormat != VRAPI_TEXTURE_FORMAT_NONE) {
-                    if (resolveDepth) {
-                        GL( glFramebufferTextureMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, depthTexture, 0 , 0 , 2 ) );
-                    } else {
-                        //LOGE("using texture depth");
-                        GL( glFramebufferTextureMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, mDepthBuffers[i], 0 , 0 , 2 ) );
+                    const GLuint texture = resolveDepth ? depthTexture : mDepthBuffers[i];
+                    GL( glFramebufferTextureMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, texture, 0 , 0 , 2 ) );
+                    if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
+                        GL( glFramebufferTextureMultiviewOVR( GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, texture, 0 , 0 , 2 ) );
                     }
                 }
             }
@@ -277,8 +244,14 @@ bool FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
                 if (depthFormat != VRAPI_TEXTURE_FORMAT_NONE) {
                     if (resolveDepth) {
                         GL( glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTexture, 0) );
+                        if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
+                            GL( glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthTexture, 0) );
+                        }
                     } else {
                         GL( glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]) );
+                        if (VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8 == depthFormat) {
+                            GL( glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]) );
+                        }
                     }
                 }
             }
@@ -288,12 +261,10 @@ bool FrameBufferObject::create(const ovrTextureFormat colorFormat, const int wid
             }
         }
 
-        GL( glScissor(0, 0, width, height) );
-        GL( glViewport(0, 0, width, height) );
-        GL( glBindFramebuffer(GL_FRAMEBUFFER, 0) );
+        glScissor(0, 0, mWidth, mHeight);
+        glViewport(0, 0, mWidth, mHeight);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
     }
-
-    return true;
 }
 
 void FrameBufferObject::destroy() {
@@ -371,6 +342,43 @@ void FrameBufferObject::resolve() {
 
 void FrameBufferObject::advance() {
     mTextureSwapChainIndex = (mTextureSwapChainIndex + 1) % mTextureSwapChainLength;
+}
+
+GLenum FrameBufferObject::translateVrapiFormatToInternal(const ovrTextureFormat format) const {
+    GLenum internalFormat;
+    switch (format) {
+        case VRAPI_TEXTURE_FORMAT_565:
+            internalFormat = GL_RGB565;
+            break;
+        case VRAPI_TEXTURE_FORMAT_5551:
+            internalFormat = GL_RGB5_A1;
+            break;
+        case VRAPI_TEXTURE_FORMAT_4444:
+            internalFormat = GL_RGBA4;
+            break;
+        case VRAPI_TEXTURE_FORMAT_8888:
+            internalFormat = GL_RGBA8;
+            break;
+        case VRAPI_TEXTURE_FORMAT_8888_sRGB:
+            internalFormat = GL_SRGB8_ALPHA8;
+            break;
+        case VRAPI_TEXTURE_FORMAT_RGBA16F:
+            internalFormat = GL_RGBA16F;
+            break;
+        case VRAPI_TEXTURE_FORMAT_DEPTH_16:
+            internalFormat = GL_DEPTH_COMPONENT16;
+            break;
+        case VRAPI_TEXTURE_FORMAT_DEPTH_24:
+            internalFormat = GL_DEPTH_COMPONENT24;
+            break;
+        case VRAPI_TEXTURE_FORMAT_DEPTH_24_STENCIL_8:
+            internalFormat = GL_DEPTH24_STENCIL8;
+            break;
+        default:
+            FAIL("unknown format %i", format);
+    }
+
+    return internalFormat;
 }
 
 } //namespace gvr

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_framebufferobject.h
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_framebufferobject.h
@@ -26,7 +26,7 @@ class FrameBufferObject {
 public:
 
     void clear();
-    bool create(const ovrTextureFormat colorFormat, const int width, const int height,
+    void create(const ovrTextureFormat colorFormat, const int width, const int height,
             const int multisamples, bool resolveDepth, const ovrTextureFormat depthFormat);
     void destroy();
     void bind();
@@ -47,6 +47,15 @@ public:
     GLuint mColorBuffer = 0;
     GLuint* mRenderFrameBuffers = nullptr;
     GLuint* mResolveFrameBuffers = nullptr;
+
+private:
+    enum multisample_t {
+        MSAA_OFF, MSAA_RENDER_TO_TEXTURE, MSAA_BLIT
+    };
+
+    multisample_t mMultisampleMode;
+
+    GLenum translateVrapiFormatToInternal(const ovrTextureFormat format) const;
 };
 
 } //namespace gvr

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRConfigurationManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRConfigurationManager.java
@@ -205,8 +205,8 @@ abstract class GVRConfigurationManager {
         return false;
     }
 
-    public void configureRendering(){
-        NativeConfigurationManager.configureRendering(mPtr);
+    public void configureRendering(boolean useStencil){
+        NativeConfigurationManager.configureRendering(mPtr, useStencil);
     }
 
     /**
@@ -239,7 +239,7 @@ abstract class GVRConfigurationManager {
 
 class NativeConfigurationManager {
     static native long ctor();
-    public static native int getMaxLights(long jConfigurationManager);
-    public static native void configureRendering(long jConfigurationManager);
+    static native int getMaxLights(long jConfigurationManager);
+    static native void configureRendering(long jConfigurationManager, boolean useStencil);
     static native void delete(long jConfigurationManager);
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderData.java
@@ -74,6 +74,7 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      * {@link #TRANSPARENT} object.
      */
     public abstract static class GVRRenderingOrder {
+        public static final int STENCIL = -1000;
         /**
          * Rendered first, below any other objects at the same distance from the
          * camera
@@ -595,8 +596,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      *            The rendering options bit mask.
      * @see GVRRenderMaskBit
      */
-    public void setRenderMask(int renderMask) {
+    public GVRRenderData setRenderMask(int renderMask) {
         NativeRenderData.setRenderMask(getNative(), renderMask);
+        return this;
     }
 
     /**
@@ -613,8 +615,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      * @param renderingOrder
      *            See {@link GVRRenderingOrder}
      */
-    public void setRenderingOrder(int renderingOrder) {
+    public GVRRenderData setRenderingOrder(int renderingOrder) {
         NativeRenderData.setRenderingOrder(getNative(), renderingOrder);
+        return this;
     }
 
     /**
@@ -658,13 +661,13 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      *            {@code false} if not.
      * @param pass
      */
-    public void setCullTest(boolean cullTest) {
+    public GVRRenderData setCullTest(boolean cullTest) {
         if (cullTest) {
             setCullFace(GVRCullFaceEnum.Back);
         } else {
             setCullFace(GVRCullFaceEnum.None);
         }
-
+        return this;
     }
 
     /**
@@ -676,8 +679,8 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      *            to discard front faces, {@code GVRCullFaceEnum.None} Tells
      *            Graphics API to not discard any face
      */
-    public void setCullFace(GVRCullFaceEnum cullFace) {
-        setCullFace(cullFace, 0);
+    public GVRRenderData setCullFace(GVRCullFaceEnum cullFace) {
+        setCullFace(cullFace, 0); return this;
     }
 
     /**
@@ -691,12 +694,13 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      * @param passIndex
      *            The rendering pass to set cull face state
      */
-    public void setCullFace(GVRCullFaceEnum cullFace, int passIndex) {
+    public GVRRenderData setCullFace(GVRCullFaceEnum cullFace, int passIndex) {
         if (passIndex < mRenderPassList.size()) {
             mRenderPassList.get(passIndex).setCullFace(cullFace);
         } else {
             Log.e(TAG, "Trying to set cull face to a invalid pass. Pass " + passIndex + " was not created.");
         }
+        return this;
     }
 
     /**
@@ -714,8 +718,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      *            {@code true} if {@code GL_POLYGON_OFFSET_FILL} should be
      *            enabled, {@code false} if not.
      */
-    public void setOffset(boolean offset) {
+    public GVRRenderData setOffset(boolean offset) {
         NativeRenderData.setOffset(getNative(), offset);
+        return this;
     }
 
     /**
@@ -737,8 +742,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      *            value is 0.
      * @see #setOffset(boolean)
      */
-    public void setOffsetFactor(float offsetFactor) {
+    public GVRRenderData setOffsetFactor(float offsetFactor) {
         NativeRenderData.setOffsetFactor(getNative(), offsetFactor);
+        return this;
     }
 
     /**
@@ -760,8 +766,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      *            0.
      * @see #setOffset(boolean)
      */
-    public void setOffsetUnits(float offsetUnits) {
+    public GVRRenderData setOffsetUnits(float offsetUnits) {
         NativeRenderData.setOffsetUnits(getNative(), offsetUnits);
+        return this;
     }
 
     /**
@@ -779,8 +786,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      *            {@code true} if {@code GL_DEPTH_TEST} should be enabled,
      *            {@code false} if not.
      */
-    public void setDepthTest(boolean depthTest) {
+    public GVRRenderData setDepthTest(boolean depthTest) {
         NativeRenderData.setDepthTest(getNative(), depthTest);
+        return this;
     }
 
     /**
@@ -798,8 +806,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      *            {@code true} if {@code GL_BLEND} should be enabled,
      *            {@code false} if not.
      */
-    public void setAlphaBlend(boolean alphaBlend) {
+    public GVRRenderData setAlphaBlend(boolean alphaBlend) {
         NativeRenderData.setAlphaBlend(getNative(), alphaBlend);
+        return this;
     }
 
     /**
@@ -879,8 +888,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      *            {@code true} if {@code GL_ALPHA_TO_COVERAGE} should be enabled,
      *            {@code false} if not.
      */
-    public void setAlphaToCoverage(boolean alphaToCoverage) {
+    public GVRRenderData setAlphaToCoverage(boolean alphaToCoverage) {
         NativeRenderData.setAlphaToCoverage(getNative(), alphaToCoverage);
+        return this;
     }
 
     /**
@@ -893,8 +903,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      * @param sampleCoverage
      *                 Specifies the coverage of the modification mask.
      */
-    public void setSampleCoverage(float sampleCoverage) {
+    public GVRRenderData setSampleCoverage(float sampleCoverage) {
         NativeRenderData.setSampleCoverage(getNative(),sampleCoverage);
+        return this;
     }
     
     /**
@@ -908,8 +919,9 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      * @param invertCoverageMask
      *          Specifies whether the modification mask implied by value is inverted or not.
      */
-    public void setInvertCoverageMask(boolean invertCoverageMask){
+    public GVRRenderData setInvertCoverageMask(boolean invertCoverageMask){
         NativeRenderData.setInvertCoverageMask(getNative(),invertCoverageMask);
+        return this;
     }
 
     /**
@@ -924,7 +936,7 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      * 
      * @param drawMode
      */
-    public void setDrawMode(int drawMode) {
+    public GVRRenderData setDrawMode(int drawMode) {
         if (drawMode != GL_POINTS && drawMode != GL_LINES
                 && drawMode != GL_LINE_STRIP && drawMode != GL_LINE_LOOP
                 && drawMode != GL_TRIANGLES && drawMode != GL_TRIANGLE_STRIP
@@ -933,6 +945,7 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
                     "drawMode must be one of GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_LINE_LOOP, GL_TRIANGLES, GL_TRIANGLE_FAN, GL_TRIANGLE_STRIP.");
         }
         NativeRenderData.setDrawMode(getNative(), drawMode);
+        return this;
     }
 
     /**
@@ -968,9 +981,11 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
      * non-transparent shadows. This function lets you disable shadow-casting.
      * @param castShadows true to cast shadows, false to not cast shadows
      */
-    public void setCastShadows(boolean castShadows) {
+    public GVRRenderData setCastShadows(boolean castShadows) {
         NativeRenderData.setCastShadows(getNative(), castShadows);
+        return this;
     }
+
     @Override
     public void prettyPrint(StringBuffer sb, int indent) {
         GVRMesh mesh = null;
@@ -1004,6 +1019,37 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
         return sb.toString();
     }
 
+    /**
+     * See https://www.khronos.org/opengles/sdk/docs/man3/html/glStencilFunc.xhtml
+     */
+    public GVRRenderData setStencilFunc(int func, int ref, int mask) {
+        NativeRenderData.setStencilFunc(getNative(), func, ref, mask);
+        return this;
+    }
+
+    /**
+     * See https://www.khronos.org/opengles/sdk/docs/man/xhtml/glStencilOp.xml
+     */
+    public GVRRenderData setStencilOp(int fail, int zfail, int zpass) {
+        NativeRenderData.setStencilOp(getNative(), fail, zfail, zpass);
+        return this;
+    }
+
+    /**
+     * See https://www.khronos.org/opengles/sdk/docs/man/xhtml/glStencilMask.xml
+     */
+    public GVRRenderData setStencilMask(int mask) {
+        NativeRenderData.setStencilMask(getNative(), mask);
+        return this;
+    }
+
+    /**
+     * @param flag enable or disable stencil testing; disabled by default
+     */
+    public GVRRenderData setStencilTest(boolean flag) {
+        NativeRenderData.setStencilTest(getNative(), flag);
+        return this;
+    }
 }
 
 class NativeRenderData {
@@ -1051,7 +1097,7 @@ class NativeRenderData {
 
     static native boolean getAlphaBlend(long renderData);
 
-    public static native void setAlphaBlend(long renderData, boolean alphaBlend);
+    static native void setAlphaBlend(long renderData, boolean alphaBlend);
 
     static native void setAlphaBlendFunc(long renderData, int sourceBlend, int destBlend);
 
@@ -1061,23 +1107,31 @@ class NativeRenderData {
 
     static native boolean getAlphaToCoverage(long renderData);
 
-    public static native void setAlphaToCoverage(long renderData, boolean alphaToCoverage);    
+    static native void setAlphaToCoverage(long renderData, boolean alphaToCoverage);
 
     static native float getSampleCoverage(long renderData);
 
-    public static native void setSampleCoverage(long renderData,float sampleCoverage);
+    static native void setSampleCoverage(long renderData,float sampleCoverage);
     
     static native boolean getInvertCoverageMask(long renderData);
 
-    public static native void setInvertCoverageMask(long renderData,boolean invertCoverageMask);
+    static native void setInvertCoverageMask(long renderData,boolean invertCoverageMask);
 
-    public static native int getDrawMode(long renderData);
+    static native int getDrawMode(long renderData);
 
-    public static native void setDrawMode(long renderData, int draw_mode);
+    static native void setDrawMode(long renderData, int draw_mode);
 
-    public static native void setTextureCapturer(long renderData, long texture_capturer);
+    static native void setTextureCapturer(long renderData, long texture_capturer);
 
-    public static native void setCastShadows(long renderData, boolean castShadows);
+    static native void setCastShadows(long renderData, boolean castShadows);
 
-    public static native boolean getCastShadows(long renderData);
+    static native boolean getCastShadows(long renderData);
+
+    static native void setStencilFunc(long renderData, int func, int ref, int mask);
+
+    static native void setStencilOp(long renderData, int fail, int zfail, int zpass);
+
+    static native void setStencilMask(long renderData, int mask);
+
+    static native void setStencilTest(long renderData, boolean flag);
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRTransform.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRTransform.java
@@ -39,7 +39,8 @@ public class GVRTransform extends GVRComponent {
         super(gvrContext, NativeTransform.ctor());
         setOwnerObject(owner);
     }
-    
+
+
     private GVRTransform(GVRContext gvrContext, long ptr) {
         super(gvrContext, ptr);
     }
@@ -87,8 +88,9 @@ public class GVRTransform extends GVRComponent {
      * @param z
      *            'Z' component of the absolute position.
      */
-    public void setPosition(float x, float y, float z) {
+    public GVRTransform setPosition(float x, float y, float z) {
         NativeTransform.setPosition(getNative(), x, y, z);
+        return this;
     }
 
     /**
@@ -99,8 +101,9 @@ public class GVRTransform extends GVRComponent {
      * @param x
      *            New 'X' component of the absolute position.
      */
-    public void setPositionX(float x) {
+    public GVRTransform setPositionX(float x) {
         NativeTransform.setPositionX(getNative(), x);
+        return this;
     }
 
     /**
@@ -111,8 +114,9 @@ public class GVRTransform extends GVRComponent {
      * @param y
      *            New 'Y' component of the absolute position.
      */
-    public void setPositionY(float y) {
+    public GVRTransform setPositionY(float y) {
         NativeTransform.setPositionY(getNative(), y);
+        return this;
     }
 
     /**
@@ -123,8 +127,9 @@ public class GVRTransform extends GVRComponent {
      * @param z
      *            New 'Z' component of the absolute position.
      */
-    public void setPositionZ(float z) {
+    public GVRTransform setPositionZ(float z) {
         NativeTransform.setPositionZ(getNative(), z);
+        return this;
     }
 
     /**
@@ -213,8 +218,9 @@ public class GVRTransform extends GVRComponent {
      * @param z
      *            'Z' component of the quaternion.
      */
-    public void setRotation(float w, float x, float y, float z) {
+    public GVRTransform setRotation(float w, float x, float y, float z) {
         NativeTransform.setRotation(getNative(), w, x, y, z);
+        return this;
     }
 
     /**
@@ -254,8 +260,9 @@ public class GVRTransform extends GVRComponent {
      * @param z
      *            Scaling factor on the 'Z' axis.
      */
-    public void setScale(float x, float y, float z) {
+    public GVRTransform setScale(float x, float y, float z) {
         NativeTransform.setScale(getNative(), x, y, z);
+        return this;
     }
 
     /**
@@ -264,8 +271,9 @@ public class GVRTransform extends GVRComponent {
      * @param x
      *            Scaling factor on the 'X' axis.
      */
-    public void setScaleX(float x) {
+    public GVRTransform setScaleX(float x) {
         NativeTransform.setScaleX(getNative(), x);
+        return this;
     }
 
     /**
@@ -274,8 +282,9 @@ public class GVRTransform extends GVRComponent {
      * @param y
      *            Scaling factor on the 'Y' axis.
      */
-    public void setScaleY(float y) {
+    public GVRTransform setScaleY(float y) {
         NativeTransform.setScaleY(getNative(), y);
+        return this;
     }
 
     /**
@@ -284,8 +293,9 @@ public class GVRTransform extends GVRComponent {
      * @param z
      *            Scaling factor on the 'Z' axis.
      */
-    public void setScaleZ(float z) {
+    public GVRTransform setScaleZ(float z) {
         NativeTransform.setScaleZ(getNative(), z);
+        return this;
     }
 
     /**
@@ -340,11 +350,12 @@ public class GVRTransform extends GVRComponent {
      *            An array of 16 {@code float}s representing a 4x4 matrix in
      *            OpenGL-compatible column-major format.
      */
-    public void setModelMatrix(float[] mat) {
+    public GVRTransform setModelMatrix(float[] mat) {
         if (mat.length != 16) {
             throw new IllegalArgumentException("Size not equal to 16.");
         }
         NativeTransform.setModelMatrix(getNative(), mat);
+        return this;
     }
 
     /**
@@ -355,8 +366,9 @@ public class GVRTransform extends GVRComponent {
      *            A {@code Matrix4f} representing a 4x4 matrix in
      *            OpenGL-compatible column-major format.
      */
-    public void setModelMatrix(Matrix4f mat) {
+    public GVRTransform setModelMatrix(Matrix4f mat) {
         setModelMatrix(mat.get(new float[16]));
+        return this;
     }
 
     /**
@@ -396,8 +408,9 @@ public class GVRTransform extends GVRComponent {
      * @param z
      *            'Z' component of the axis.
      */
-    public void setRotationByAxis(float angle, float x, float y, float z) {
+    public GVRTransform setRotationByAxis(float angle, float x, float y, float z) {
         NativeTransform.setRotationByAxis(getNative(), angle * TO_RADIANS, x, y, z);
+        return this;
     }
 
     /**

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -27,6 +27,7 @@ import org.gearvrf.script.GVRScriptManager;
 import org.gearvrf.utility.Log;
 import org.gearvrf.utility.Threads;
 import org.gearvrf.utility.VrAppSettings;
+import org.gearvrf.utility.VrAppSettings.EyeBufferParams.DepthFormat;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -184,7 +185,8 @@ abstract class GVRViewManager extends GVRContext {
 
         mPreviousTimeNanos = GVRTime.getCurrentTime();
         mRenderBundle = makeRenderBundle();
-        getActivity().getConfigurationManager().configureRendering();
+        final DepthFormat depthFormat = getActivity().getAppSettings().getEyeBufferParams().getDepthFormat();
+        getActivity().getConfigurationManager().configureRendering(DepthFormat.DEPTH_24_STENCIL_8 == depthFormat);
 
         setMainSceneImpl(new GVRScene(GVRViewManager.this));
     }

--- a/GVRf/Framework/framework/src/main/jni/configuration_manager.cpp
+++ b/GVRf/Framework/framework/src/main/jni/configuration_manager.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <GLES3/gl3.h>
+#include <engine/renderer/renderer.h>
 #include "configuration_manager.h"
 
 namespace gvr {
@@ -25,8 +26,9 @@ namespace gvr {
     }
 
 
-    void ConfigurationManager::configureRendering() {
+    void ConfigurationManager::configureRendering(bool useStencil) {
         calculateMaxLights();
+        Renderer::getInstance()->setUseStencilBuffer(useStencil);
     }
 
     /*

--- a/GVRf/Framework/framework/src/main/jni/configuration_manager.h
+++ b/GVRf/Framework/framework/src/main/jni/configuration_manager.h
@@ -25,7 +25,7 @@ namespace gvr {
 
         virtual ~ConfigurationManager();
 
-        void configureRendering();
+        void configureRendering(bool useStencil);
         int getMaxLights();
 
     private:

--- a/GVRf/Framework/framework/src/main/jni/configuration_manager_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/configuration_manager_jni.cpp
@@ -28,7 +28,7 @@ namespace gvr {
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_NativeConfigurationManager_configureRendering(JNIEnv *env, jobject obj,
-                                                                           jlong jConfigurationManager);
+                                                                           jlong jConfigurationManager, jboolean useStencil);
 
     JNIEXPORT int JNICALL
     Java_org_gearvrf_NativeConfigurationManager_getMaxLights(JNIEnv *env, jobject obj,
@@ -45,9 +45,9 @@ namespace gvr {
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_NativeConfigurationManager_configureRendering(JNIEnv *env, jobject obj,
-                                                                   jlong jConfigurationManager) {
+                                                                   jlong jConfigurationManager, jboolean useStencil) {
         ConfigurationManager *configuration_manager = reinterpret_cast<ConfigurationManager *>(jConfigurationManager);
-        configuration_manager->configureRendering();
+        configuration_manager->configureRendering(useStencil);
     }
 
     JNIEXPORT int JNICALL

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.h
@@ -105,7 +105,9 @@ private:
                     std::vector<SceneObject*>& scene_objects,
                     ShaderManager *shader_manager, glm::mat4 vp_matrix);
 
+    void clearBuffers(const Camera& camera) const;
 };
+
 }
 #endif
 

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -130,12 +130,6 @@ void Renderer::state_sort() {
     std::sort(render_data_vector.begin(), render_data_vector.end(),
             compareRenderDataByOrderShaderDistance);
 
-    if (render_data_vector.size()) {
-        useStencilBuffer_ = RenderData::Queue::Stencil == render_data_vector[0]->rendering_order();
-    } else {
-        useStencilBuffer_ = false;
-    }
-
     if (DEBUG_RENDERER) {
         LOGD("SORTING: After sorting");
 

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -18,25 +18,13 @@
  ***************************************************************************/
 
 #include "renderer.h"
-#include "gl/gl_program.h"
 #include "glm/gtc/matrix_inverse.hpp"
 
-#include "eglextension/tiledrendering/tiled_rendering_enhancer.h"
-#include "objects/material.h"
 #include "objects/post_effect_data.h"
 #include "objects/scene.h"
-#include "objects/scene_object.h"
-#include "objects/components/camera.h"
-#include "objects/components/render_data.h"
 #include "objects/textures/render_texture.h"
 #include "shaders/shader_manager.h"
 #include "shaders/post_effect_shader_manager.h"
-#include "util/gvr_gl.h"
-#include "util/gvr_log.h"
-#include "batch_manager.h"
-
-#include <unordered_map>
-#include <unordered_set>
 
 #include "gl_renderer.h"
 #include "vulkan_renderer.h"
@@ -141,6 +129,12 @@ void Renderer::state_sort() {
     // 3. camera distance last to minimize overdraw
     std::sort(render_data_vector.begin(), render_data_vector.end(),
             compareRenderDataByOrderShaderDistance);
+
+    if (render_data_vector.size()) {
+        useStencilBuffer_ = RenderData::Queue::Stencil == render_data_vector[0]->rendering_order();
+    } else {
+        useStencilBuffer_ = false;
+    }
 
     if (DEBUG_RENDERER) {
         LOGD("SORTING: After sorting");

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
@@ -196,6 +196,8 @@ protected:
 public:
     //to be used only on the gl thread
     const std::vector<RenderData*>& getRenderDataVector() const { return render_data_vector; }
+
+    void setUseStencilBuffer(bool enable) { useStencilBuffer_ = enable; }
 };
 extern Renderer* gRenderer;
 }

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
@@ -191,6 +191,7 @@ protected:
     std::vector<RenderData*> render_data_vector;
     int numberDrawCalls;
     int numberTriangles;
+    bool useStencilBuffer_ = false;
 
 public:
     //to be used only on the gl thread

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data.cpp
@@ -63,6 +63,26 @@ void RenderData::setCameraDistanceLambda(std::function<float()> func) {
     cameraDistanceLambda_ = func;
 }
 
+void RenderData::setStencilFunc(int func, int ref, int mask) {
+    stencilFuncFunc_= func;
+    stencilFuncRef_ = ref;
+    stencilFuncMask_ = mask;
+}
+
+void RenderData::setStencilOp(int sfail, int dpfail, int dppass) {
+    stencilOpSfail_ = sfail;
+    stencilOpDpfail_ = dpfail;
+    stencilOpDppass_ = dppass;
+}
+
+void RenderData::setStencilMask(unsigned int mask) {
+    stencilMaskMask_ = mask;
+}
+
+void RenderData::setStencilTest(bool flag) {
+    stencilTestFlag_ = flag;
+}
+
 bool compareRenderDataByOrderShaderDistance(RenderData *i, RenderData *j) {
     //1. rendering order needs to be sorted first to guarantee specified correct order
     if (i->rendering_order() == j->rendering_order()) {

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
@@ -53,7 +53,7 @@ template<typename T> std::string to_string(T value) {
 class RenderData: public Component {
 public:
     enum Queue {
-        Background = 1000, Geometry = 2000, Transparent = 3000, Overlay = 4000
+        Stencil = -1000, Background = 1000, Geometry = 2000, Transparent = 3000, Overlay = 4000
     };
 
     enum RenderMaskBit {
@@ -105,6 +105,15 @@ public:
         draw_mode_ = rdata.draw_mode_;
         texture_capturer = rdata.texture_capturer;
         dirty_flag_ = rdata.dirty_flag_;
+
+        stencilTestFlag_ = rdata.stencilTestFlag_;
+        stencilMaskMask_ = rdata.stencilMaskMask_;
+        stencilFuncFunc_ = rdata.stencilFuncFunc_;
+        stencilFuncRef_ = rdata.stencilFuncRef_;
+        stencilFuncMask_ = rdata.stencilFuncMask_;
+        stencilOpSfail_ = rdata.stencilOpSfail_;
+        stencilOpDpfail_ = rdata.stencilOpDpfail_;
+        stencilOpDppass_ = rdata.stencilOpDppass_;
     }
 
     RenderData(const RenderData& rdata) {
@@ -351,6 +360,15 @@ public:
             render_data_string.append(to_string(invert_coverage_mask_));
             render_data_string.append(to_string(draw_mode_));
 
+            render_data_string.append(to_string(stencilTestFlag_));
+            render_data_string.append(to_string(stencilMaskMask_));
+            render_data_string.append(to_string(stencilFuncFunc_));
+            render_data_string.append(to_string(stencilFuncRef_));
+            render_data_string.append(to_string(stencilFuncMask_));
+            render_data_string.append(to_string(stencilOpSfail_));
+            render_data_string.append(to_string(stencilOpDpfail_));
+            render_data_string.append(to_string(stencilOpDppass_));
+
             hash_code = render_data_string;
             hash_code_dirty_ = false;
 
@@ -359,6 +377,21 @@ public:
     }
 
     void setCameraDistanceLambda(std::function<float()> func);
+
+    void setStencilFunc(int func, int ref, int mask);
+
+    void setStencilOp(int sfail, int dpfail, int dppass);
+
+    void setStencilMask(unsigned int mask);
+
+    bool stencil_test() { return stencilTestFlag_; }
+    int stencil_func_func() { return stencilFuncFunc_; }
+    int stencil_func_ref() { return stencilFuncRef_; }
+    int stencil_func_mask() { return stencilFuncMask_; }
+    unsigned int stencil_mask_mask() { return stencilMaskMask_; }
+    int stencil_op_sfail() { return stencilOpSfail_; }
+    int stencil_op_dpfail() { return stencilOpDpfail_; }
+    int stencil_op_dppass() { return stencilOpDppass_; }
 
 private:
     //  RenderData(const RenderData& render_data);
@@ -397,6 +430,18 @@ private:
     TextureCapturer *texture_capturer;
 
     std::function<float()> cameraDistanceLambda_ = nullptr;
+
+    int stencilFuncFunc_ = 0;
+    int stencilFuncRef_ = 0;
+    int stencilFuncMask_ = 0;
+    int stencilOpSfail_ = 0;
+    int stencilOpDpfail_ = 0;
+    int stencilOpDppass_ = 0;
+    unsigned int stencilMaskMask_ = 0;
+    bool stencilTestFlag_ = false;
+
+public:
+    void setStencilTest(bool flag);
 };
 
 bool compareRenderDataByOrderShaderDistance(RenderData* i, RenderData* j);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data_jni.cpp
@@ -26,150 +26,167 @@
 #include "objects/components/texture_capturer.h"
 
 namespace gvr {
+
 extern "C" {
-JNIEXPORT jlong JNICALL
-Java_org_gearvrf_NativeRenderData_ctor(JNIEnv * env,
-        jobject obj);
+    JNIEXPORT jlong JNICALL
+    Java_org_gearvrf_NativeRenderData_ctor(JNIEnv * env,
+            jobject obj);
 
-JNIEXPORT jlong JNICALL
-Java_org_gearvrf_NativeRenderData_getComponentType(JNIEnv * env, jobject obj);
+    JNIEXPORT jlong JNICALL
+    Java_org_gearvrf_NativeRenderData_getComponentType(JNIEnv * env, jobject obj);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setMesh(JNIEnv * env,
-        jobject obj, jlong jrender_data, jlong jmesh);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setMesh(JNIEnv * env,
+            jobject obj, jlong jrender_data, jlong jmesh);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_addPass(JNIEnv* env,
-        jobject obj, jlong jrender_data, jlong jrender_pass);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_addPass(JNIEnv* env,
+            jobject obj, jlong jrender_data, jlong jrender_pass);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setLight(JNIEnv * env,
-        jobject obj, jlong jrender_data, jlong jlight);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setLight(JNIEnv * env,
+            jobject obj, jlong jrender_data, jlong jlight);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_enableLight(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_enableLight(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_disableLight(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_disableLight(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_enableLightMap(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_enableLightMap(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_disableLightMap(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_disableLightMap(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT jint JNICALL
-Java_org_gearvrf_NativeRenderData_getRenderMask(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT jint JNICALL
+    Java_org_gearvrf_NativeRenderData_getRenderMask(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setRenderMask(JNIEnv * env,
-        jobject obj, jlong jrender_data, jint render_mask);
-JNIEXPORT jint JNICALL
-Java_org_gearvrf_NativeRenderData_getRenderingOrder(
-        JNIEnv * env, jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setRenderMask(JNIEnv * env,
+            jobject obj, jlong jrender_data, jint render_mask);
+    JNIEXPORT jint JNICALL
+    Java_org_gearvrf_NativeRenderData_getRenderingOrder(
+            JNIEnv * env, jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setRenderingOrder(
-        JNIEnv * env, jobject obj, jlong jrender_data, jint rendering_order);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setRenderingOrder(
+            JNIEnv * env, jobject obj, jlong jrender_data, jint rendering_order);
 
-JNIEXPORT jboolean JNICALL
-Java_org_gearvrf_NativeRenderData_getOffset(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT jboolean JNICALL
+    Java_org_gearvrf_NativeRenderData_getOffset(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setOffset(JNIEnv * env,
-        jobject obj, jlong jrender_data, jboolean offset);
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_NativeRenderData_getOffsetFactor(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setOffset(JNIEnv * env,
+            jobject obj, jlong jrender_data, jboolean offset);
+    JNIEXPORT jfloat JNICALL
+    Java_org_gearvrf_NativeRenderData_getOffsetFactor(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setOffsetFactor(JNIEnv * env,
-        jobject obj, jlong jrender_data, jfloat offset_factor);
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_NativeRenderData_getOffsetUnits(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setOffsetFactor(JNIEnv * env,
+            jobject obj, jlong jrender_data, jfloat offset_factor);
+    JNIEXPORT jfloat JNICALL
+    Java_org_gearvrf_NativeRenderData_getOffsetUnits(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setOffsetUnits(JNIEnv * env,
-        jobject obj, jlong jrender_data, jfloat offset_units);
-JNIEXPORT jboolean JNICALL
-Java_org_gearvrf_NativeRenderData_getDepthTest(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setOffsetUnits(JNIEnv * env,
+            jobject obj, jlong jrender_data, jfloat offset_units);
+    JNIEXPORT jboolean JNICALL
+    Java_org_gearvrf_NativeRenderData_getDepthTest(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setDepthTest(JNIEnv * env,
-        jobject obj, jlong jrender_data, jboolean depth_test);
-JNIEXPORT jboolean JNICALL
-Java_org_gearvrf_NativeRenderData_getAlphaBlend(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setDepthTest(JNIEnv * env,
+            jobject obj, jlong jrender_data, jboolean depth_test);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setAlphaBlend(JNIEnv * env,
-        jobject obj, jlong jrender_data, jboolean alpha_blend);
+    JNIEXPORT jboolean JNICALL
+    Java_org_gearvrf_NativeRenderData_getAlphaBlend(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setAlphaBlendFunc(JNIEnv * env,
-        jobject obj, jlong jrender_data, jint sourceBlend, jint destBlend);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setAlphaBlend(JNIEnv * env,
+            jobject obj, jlong jrender_data, jboolean alpha_blend);
 
-JNIEXPORT jint JNICALL
-Java_org_gearvrf_NativeRenderData_getSourceAlphaBlendFunc(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT jboolean JNICALL
+    Java_org_gearvrf_NativeRenderData_getAlphaToCoverage(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT jint JNICALL
-Java_org_gearvrf_NativeRenderData_getDestAlphaBlendFunc(JNIEnv * env,
-         jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setAlphaToCoverage(JNIEnv * env,
+            jobject obj, jlong jrender_data, jboolean alphaToCoverage);
 
-JNIEXPORT jboolean JNICALL
-Java_org_gearvrf_NativeRenderData_getAlphaToCoverage(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setSampleCoverage(JNIEnv * env,
+        jobject obj, jlong jrender_data, jfloat sampleCoverage);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setAlphaToCoverage(JNIEnv * env,
-        jobject obj, jlong jrender_data, jboolean alphaToCoverage);
+    JNIEXPORT jfloat JNICALL
+    Java_org_gearvrf_NativeRenderData_getSampleCoverage(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setSampleCoverage(JNIEnv * env,
-    jobject obj, jlong jrender_data, jfloat sampleCoverage);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setInvertCoverageMask(JNIEnv * env,
+        jobject obj, jlong jrender_data, jboolean invertCoverageMask);
 
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_NativeRenderData_getSampleCoverage(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT jboolean JNICALL
+    Java_org_gearvrf_NativeRenderData_getInvertCoverageMask(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setInvertCoverageMask(JNIEnv * env,
-    jobject obj, jlong jrender_data, jboolean invertCoverageMask);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setCastShadows(JNIEnv * env,
+        jobject obj, jlong jrender_data, jboolean castShadows);
 
-JNIEXPORT jboolean JNICALL
-Java_org_gearvrf_NativeRenderData_getInvertCoverageMask(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT jboolean JNICALL
+    Java_org_gearvrf_NativeRenderData_getCastShadows(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setCastShadows(JNIEnv * env,
-    jobject obj, jlong jrender_data, jboolean castShadows);
+    JNIEXPORT jint JNICALL
+    Java_org_gearvrf_NativeRenderData_getDrawMode(
+            JNIEnv * env, jobject obj, jlong jrender_data);
 
-JNIEXPORT jboolean JNICALL
-Java_org_gearvrf_NativeRenderData_getCastShadows(JNIEnv * env,
-        jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setDrawMode(
+            JNIEnv * env, jobject obj, jlong jrender_data, jint draw_mode);
 
-JNIEXPORT jint JNICALL
-Java_org_gearvrf_NativeRenderData_getDrawMode(
-        JNIEnv * env, jobject obj, jlong jrender_data);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setTextureCapturer(JNIEnv * env, jobject obj,
+            jlong jrender_data, jlong jtexture_capturer);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setDrawMode(
-        JNIEnv * env, jobject obj, jlong jrender_data, jint draw_mode);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setStencilFunc(JNIEnv *env, jclass type, jlong renderData,
+                                                     jint func, jint ref, jint mask);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeRenderData_setTextureCapturer(JNIEnv * env, jobject obj,
-        jlong jrender_data, jlong jtexture_capturer);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setStencilOp(JNIEnv *env, jclass type, jlong renderData,
+                                                   jint fail, jint zfail, jint zpass);
+
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setStencilMask(JNIEnv *env, jclass type, jlong renderData,
+                                                     jint mask);
+
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setStencilTest(JNIEnv *env, jclass type, jlong renderData, jboolean flag);
+
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeRenderData_setAlphaBlendFunc(JNIEnv * env,
+            jobject obj, jlong jrender_data, jint sourceBlend, jint destBlend);
+
+    JNIEXPORT jint JNICALL
+    Java_org_gearvrf_NativeRenderData_getSourceAlphaBlendFunc(JNIEnv * env,
+            jobject obj, jlong jrender_data);
+
+    JNIEXPORT jint JNICALL
+    Java_org_gearvrf_NativeRenderData_getDestAlphaBlendFunc(JNIEnv * env,
+            jobject obj, jlong jrender_data);
 }
-;
+
 
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeRenderData_ctor(JNIEnv * env,
@@ -435,4 +452,32 @@ Java_org_gearvrf_NativeRenderData_getCastShadows(JNIEnv * env,
     RenderData* render_data = reinterpret_cast<RenderData*>(jrender_data);
     return render_data->cast_shadows();
 }
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeRenderData_setStencilFunc(JNIEnv *env, jclass type, jlong renderData,
+                                                 jint func, jint ref, jint mask) {
+    RenderData* rd = reinterpret_cast<RenderData*>(renderData);
+    rd->setStencilFunc(func, ref, mask);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeRenderData_setStencilOp(JNIEnv *env, jclass type, jlong renderData,
+                                                 jint fail, jint zfail, jint zpass) {
+    RenderData* rd = reinterpret_cast<RenderData*>(renderData);
+    rd->setStencilOp(fail, zfail, zpass);
+}
+
+JNIEXPORT void JNICALL
+        Java_org_gearvrf_NativeRenderData_setStencilMask(JNIEnv *env, jclass type, jlong renderData,
+                                                         jint mask) {
+    RenderData* rd = reinterpret_cast<RenderData*>(renderData);
+    rd->setStencilMask(mask);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeRenderData_setStencilTest(JNIEnv *env, jclass type, jlong renderData, jboolean flag) {
+    RenderData* rd = reinterpret_cast<RenderData*>(renderData);
+    rd->setStencilTest(flag);
+}
+
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.cpp
@@ -124,12 +124,8 @@ RenderTexture::RenderTexture(int width, int height, int sample_count,
                 width, height);
     }
     if (jdepth_format != DepthFormat::DEPTH_0) {
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                GL_RENDERBUFFER, renderTexture_gl_render_buffer_->id());
-        if (DepthFormat::DEPTH_24_STENCIL_8 == jdepth_format) {
-            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
-                                      GL_RENDERBUFFER, renderTexture_gl_render_buffer_->id());
-        }
+        GLenum attachment = DepthFormat::DEPTH_24_STENCIL_8 == jdepth_format ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, renderTexture_gl_render_buffer_->id());
     }
 
     glScissor(0, 0, width, height);

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.cpp
@@ -126,6 +126,10 @@ RenderTexture::RenderTexture(int width, int height, int sample_count,
     if (jdepth_format != DepthFormat::DEPTH_0) {
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
                 GL_RENDERBUFFER, renderTexture_gl_render_buffer_->id());
+        if (DepthFormat::DEPTH_24_STENCIL_8 == jdepth_format) {
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                      GL_RENDERBUFFER, renderTexture_gl_render_buffer_->id());
+        }
     }
 
     glScissor(0, 0, width, height);


### PR DESCRIPTION
A simple test: https://github.com/gearvrf/GearVRf-Tests/pull/47

Works with all backends. Stencil attachment added unconditionally for Daydream since it is not yet using the values from gvr.xml. For other backends the depthFormat must be set to DEPTH_24_STENCIL_8.

Creates a special stencil bucket for stencil scene objects that get rendered very first with stencil test on.

GVRTransform, GVRRenderData - all the setters return "this" so multiple setXxx calls can be chained

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>