### PR TITLE
Depth calculation in GVRBaseSensor using hitpoint

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/build.gradle
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/build.gradle
@@ -18,6 +18,9 @@ apply plugin: 'com.android.library'
 apply plugin: XmlValidator
 
 repositories {
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
     flatDir {
         dirs '../../../Framework/framework/src/main/libs/',
         '../../../Framework/framework/build/outputs/aar/'


### PR DESCRIPTION
This changes the depth calculation based on the hitpoint rather than the center of the scene object.
This gives a more accurate depth order for SensorEvents.