### PR TITLE
Fix the path to the so files

### DIFF
--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -157,7 +157,7 @@ task packageForPlugins(type: Zip) {
     from './src/main/libs/'
     include '*.jar'
 
-    from './src/main/libs/armeabi-v7a/'
+    from './build/intermediates/ndkBuild/debug/obj/local/armeabi-v7a/'
     include '*.so'
 }
 


### PR DESCRIPTION
The externalNativeBuild command no longer places the *.so files in
src/main/libs/

Use the build folder instead.

GearVRf-DCO-1.0-Signed-off-by: Rahul Rudradevan
r.rudradevan@samsung.com