### PR TITLE
Force NDK_DEBUG to 1 for all builds in case the framework and the demos

### DIFF
--- a/GVRf/Framework/backend_oculus/build.gradle
+++ b/GVRf/Framework/backend_oculus/build.gradle
@@ -18,6 +18,9 @@ android {
 
         externalNativeBuild {
             ndkBuild {
+                if(rootProject.hasProperty("buildGvrfAndDemos")) {
+                    arguments.add("NDK_DEBUG=1")
+                }
                 arguments = ["-j" + Runtime.runtime.availableProcessors()]
                 arguments += ['OVR_MOBILE_SDK=' + rootProject.property("OVR_MOBILE_SDK")]
                 arguments += ['PROJECT_ROOT='+rootProject.projectDir]

--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -17,6 +17,9 @@ android {
         externalNativeBuild {
             ndkBuild {
                 arguments = ["-j" + Runtime.runtime.availableProcessors()]
+                if(rootProject.hasProperty("buildGvrfAndDemos")) {
+                    arguments.add("NDK_DEBUG=1")
+                }
                 if (rootProject.hasProperty("ARM64")) {
                     arguments += ['ARM64=true']
                 }


### PR DESCRIPTION
are configured to be built together.

Add "buildGvrfAndDemos=true" to your gradle.properties to enable building
the framework, backends and the demos together. And also to be able to
debug.

Looks like gradle packages the release .so in the apk no matter what..
And also builds the release target even though nobody asks for it.

Accompanying Demos pull request: https://github.com/gearvrf/GearVRf-Demos/pull/393

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>