### PR TITLE
Remove the getNextMainScene making the splash screen more transparent for end users

### DIFF
--- a/GVRf/Extensions/WidgetPlugin/widgetplugin/src/main/java/org/gearvrf/widgetplugin/GVRWidgetPlugin.java
+++ b/GVRf/Extensions/WidgetPlugin/widgetplugin/src/main/java/org/gearvrf/widgetplugin/GVRWidgetPlugin.java
@@ -166,7 +166,7 @@ public class GVRWidgetPlugin implements AndroidApplicationBase {
         @Override
         public void onEarlyInit(GVRContext context) {
             initWidget();
-        }  
+        }
     };
 
     public GVRWidgetPlugin(GVRActivity activity) {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContext.java
@@ -2302,30 +2302,6 @@ public abstract class GVRContext implements IEventReceiver {
     public abstract void setMainScene(GVRScene scene);
 
     /**
-     * Returns a {@link GVRScene} that you can populate before passing to
-     * {@link #setMainScene(GVRScene)}.
-     * 
-     * Implementation maintains a single element buffer, initialized to
-     * {@code null}. When this method is called, creates a new scene if the
-     * buffer is {@code null}, then returns the buffered scene. If this buffered
-     * scene is passed to {@link #setMainScene(GVRScene)}, the buffer is reset
-     * to {@code null}.
-     * 
-     * <p>
-     * One use of this is to build your scene graph while the splash screen is
-     * visible. If you have called {@linkplain #getNextMainScene()} (so that the
-     * next-main-scene buffer is non-{@code null} when the splash screen is
-     * closed) GVRF will automatically switch to the 'pending' main-scene; if
-     * the buffer is {@code null}, GVRF will simply remove the splash screen
-     * from the main scene object.
-     * 
-     * @since 1.6.4
-     */
-    public GVRScene getNextMainScene() {
-        return getNextMainScene(null);
-    }
-
-    /**
      * Start a debug server on the default TCP/IP port for the default number
      * of clients.
      */
@@ -2381,38 +2357,6 @@ public abstract class GVRContext implements IEventReceiver {
         mDebugServer.shutdown();
         mDebugServer = null;
     }
-
-    /**
-     * Returns a {@link GVRScene} that you can populate before passing to
-     * {@link #setMainScene(GVRScene)}.
-     * 
-     * Implementation maintains a single element buffer, initialized to
-     * {@code null}. When this method is called, creates a new scene if the
-     * buffer is {@code null}, then returns the buffered scene. If this buffered
-     * scene is passed to {@link #setMainScene(GVRScene)}, the buffer is reset
-     * to {@code null}.
-     * 
-     * <p>
-     * One use of this is to build your scene graph while the splash screen is
-     * visible. If you have called {@linkplain #getNextMainScene()} (so that the
-     * next-main-scene buffer is non-{@code null} when the splash screen is
-     * closed) GVRF will automatically switch to the 'pending' main-scene; if
-     * the buffer is {@code null}, GVRF will simply remove the splash screen
-     * from the main scene object.
-     * 
-     * @param onSwitchMainScene
-     *            Optional (may be {@code null}) {@code Runnable}, called when
-     *            this {@link GVRScene} becomes the new main scene, whether
-     *            {@linkplain #setMainScene(GVRScene) explicitly} or implicitly
-     *            (as, for example, when the splash screen closes). This
-     *            callback lets apps do things like start animations when their
-     *            scene becomes visible, instead of in
-     *            {@link GVRMain#onInit(GVRContext) onInit()} when the scene
-     *            objects may be hidden by the splash screen.
-     * 
-     * @since 1.6.4
-     */
-    public abstract GVRScene getNextMainScene(Runnable onSwitchMainScene);
 
     /**
      * Returns the {@link GVRInputManager}.

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -176,8 +176,8 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
      * This node is a common ancestor to all the objects
      * in the scene.
      * @return top level scene object.
-     * @see addSceneObject
-     * @see removeSceneObject
+     * @see #addSceneObject(GVRSceneObject)
+     * @see #removeSceneObject(GVRSceneObject)
      */
     public GVRSceneObject getRoot() {
         return mSceneRoot;
@@ -605,12 +605,24 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
                     && !sceneObject.getRenderData().isLightMapEnabled()) {
                 // TODO: Add support to enable and disable light map at run time.
                 continue;
-                    }
+            }
 
             sceneObject.getRenderData().getMaterial().setShaderType(shaderId);
             sceneObject.getRenderData().getMaterial().setTexture(key + "_texture", texture);
             sceneObject.getRenderData().getMaterial().setTextureAtlasInfo(key, atlasInfo);
         }
+    }
+
+    /**
+     * Sets the background color of the scene.
+     *
+     * If you don't set the background color, the default is an opaque black.
+     * Meaningful parameter values are from 0 to 1, inclusive: values
+     * {@literal < 0} are clamped to 0; values {@literal > 1} are clamped to 1.
+     */
+    public final void setBackgroundColor(float r, float g, float b, float a) {
+        getMainCameraRig().getLeftCamera().setBackgroundColor(r, g, b, a);
+        getMainCameraRig().getRightCamera().setBackgroundColor(r, g, b, a);
     }
 
     @Override
@@ -707,8 +719,6 @@ class NativeScene {
     static native void addSceneObject(long scene, long sceneObject);
    
     public static native void invalidateShadowMap(long scene);
-
-    static native void removeSceneObject(long scene, long sceneObject);
 
     static native void removeAllSceneObjects(long scene);
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptManager.java
@@ -266,7 +266,7 @@ public class GVRScriptManager {
 
                 @Override
                 public void onInit(GVRContext gvrContext) throws Throwable {
-                    mainScene = gvrContext.getNextMainScene();
+                    mainScene = gvrContext.getMainScene();
                 }
 
                 @Override


### PR DESCRIPTION
There will be one and only main scene from the user's perspective.

The use of the mainScene in the ViewManager has not been and still is not completely thread-safe. Instead of trying to fix that I rather completely remove the capability to change the main scene in the future.

Added a new method to the scene to set the background color. Deprecated the per-camera background color setter.

Demos update: https://github.com/gearvrf/GearVRf-Demos/pull/397