### PR TITLE
Back key handling fix: let backends decide to just exit on pressing

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -394,12 +394,13 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
                 if (!isPaused()) {
                     if (duration < 250) {
                         if (!mGVRMain.onBackPress()) {
-                            mDelegate.onBackPress();
+                            if (mDelegate.onBackPress()) {
+                                return true;
+                            }
                         }
                     }
                 }
             }
-            return true;
         } else {
             switch (event.getKeyCode()) {
                 case KeyEvent.KEYCODE_VOLUME_UP:


### PR DESCRIPTION
Oculus still works the same.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>