### PR TITLE
GVRScene: Make getRoot package private.

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCameraRig.java
@@ -105,6 +105,7 @@ public class GVRCameraRig extends GVRComponent implements PrettyPrint {
         getOwnerObject().attachCameraRig(this);
 
         headTransformObject = new GVRSceneObject(gvrContext);
+        headTransformObject.setName("_gvrf_head_transform");
         addHeadTransformObject();
 
         leftCameraObject = new GVRSceneObject(gvrContext);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -79,6 +79,7 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
         }
 
         mSceneRoot = new GVRSceneObject(gvrContext);
+        mSceneRoot.setName("_gvrf_java_root");
         NativeScene.addSceneObject(getNative(), mSceneRoot.getNative());
         GVRCamera leftCamera = new GVRPerspectiveCamera(gvrContext);
         leftCamera.setRenderMask(GVRRenderMaskBit.Left);
@@ -97,6 +98,11 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
         cameraRig.attachLeftCamera(leftCamera);
         cameraRig.attachRightCamera(rightCamera);
         cameraRig.attachCenterCamera(centerCamera);
+
+        cameraRig.getOwnerObject().setName("_gvrf_camera_rig");
+        leftCamera.getOwnerObject().setName("_gvrf_left_camera");
+        rightCamera.getOwnerObject().setName("_gvrf_right_camera");
+        centerCamera.getOwnerObject().setName("_gvrf_center_camera");
 
         addSceneObject(cameraRig.getOwnerObject());
 
@@ -179,7 +185,7 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
      * @see #addSceneObject(GVRSceneObject)
      * @see #removeSceneObject(GVRSceneObject)
      */
-    public GVRSceneObject getRoot() {
+    GVRSceneObject getRoot() {
         return mSceneRoot;
     }
     

--- a/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
@@ -36,6 +36,7 @@ Scene::Scene() :
     if (main_scene() == NULL) {
         set_main_scene(this);
     }
+    scene_root_.set_name("_gvrf_native_root");
 }
 
 Scene::~Scene() {


### PR DESCRIPTION
Exposing it is confusing since it is unclear what users may do with it.

Also add names for various objects to make debugging slightly easier.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>