### PR TITLE
Copy physics extension aar into GearVRf-Test libs folder

### DIFF
--- a/GVRf/Extensions/gvrf-physics/build.gradle
+++ b/GVRf/Extensions/gvrf-physics/build.gradle
@@ -106,4 +106,13 @@ assembleDebug {}.doLast{
         into gearvrfLibs
         include '*-debug.aar'
     }
+
+    def testsLibs = "../../../../GearVRf-Tests/gearvrf-libs/"
+    if (file(testsLibs).exists()) {
+        copy {
+            from 'build/outputs/aar'
+            into testsLibs
+            include '*-debug.aar'
+        }
+    }
 }


### PR DESCRIPTION
Send a copy of the generated gvr-physics aar to the gearvr-libs in the test folder 

GearVRf-DCO-1.0-Signed-off-by: JulianaFigueira juliana.f@samsung.com