### PR TITLE
Fix build problem with NDK v14

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/jni/Android.mk
+++ b/GVRf/Framework/backend_oculus/src/main/jni/Android.mk
@@ -50,7 +50,6 @@ FILE_LIST := $(wildcard $(LOCAL_PATH)/monoscopic/*.cpp)
 LOCAL_SRC_FILES += $(FILE_LIST:$(LOCAL_PATH)/%=%)
 
 LOCAL_SHARED_LIBRARIES += vrapi
-LOCAL_STATIC_LIBRARIES += systemutils
 
 ## CPP flags are already defined in cflags.mk.
 #LOCAL_CPPFLAGS += -fexceptions -frtti -std=c++11 -D__GXX_EXPERIMENTAL_CXX0X__ -mhard-float -D_NDK_MATH_NO_SOFTFP=1


### PR DESCRIPTION
After switching to Oculus Mobile SDK 1.0.4 we stopped needing
the systemutils static lib; the previous NDK was silently
ignoring the missing dependency.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>