### PR TITLE
Use compileSdkVersion 19 for the framework and the Oculus backend

### DIFF
--- a/GVRf/Framework/backend_oculus/build.gradle
+++ b/GVRf/Framework/backend_oculus/build.gradle
@@ -9,12 +9,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 19
     buildToolsVersion '24.0.3'
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 24
+        targetSdkVersion 21
 
         externalNativeBuild {
             ndkBuild {

--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -7,12 +7,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 19
     buildToolsVersion '24.0.3'
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 24
+        targetSdkVersion 21
 
         externalNativeBuild {
             ndkBuild {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRAssetLoader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRAssetLoader.java
@@ -1400,7 +1400,7 @@ public final class GVRAssetLoader {
             inputStream.close();
             assetRequest.onModelLoaded(mContext, root, fileName);
         }
-        catch (Exception ex)
+        catch (IOException ex)
         {
             assetRequest.onModelError(mContext, ex.getMessage(), fileName);
             throw ex;

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRConfigurationManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRConfigurationManager.java
@@ -27,6 +27,7 @@ import org.gearvrf.utility.DockEventReceiver;
 import org.gearvrf.utility.Threads;
 
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 
 abstract class GVRConfigurationManager {
@@ -39,7 +40,7 @@ abstract class GVRConfigurationManager {
     protected GVRConfigurationManager(GVRActivity activity) {
         mPtr = NativeConfigurationManager.ctor();
 
-        mActivity = new WeakReference<>(activity);
+        mActivity = new WeakReference<GVRActivity>(activity);
 
         mResetFovY = (0 == Float.compare(0, activity.getAppSettings().getEyeBufferParams().getFovY()));
 
@@ -183,7 +184,13 @@ abstract class GVRConfigurationManager {
         final HashMap<String, UsbDevice> deviceList = usbManager.getDeviceList();
         for (final UsbDevice device : deviceList.values()) {
             if (device.getVendorId() == vendorId && device.getProductId() == productId) {
-                return device.getSerialNumber();
+                try {
+                    Method m = UsbDevice.class.getMethod("getSerialNumber");
+                    return (String)m.invoke(device);
+                } catch (Exception e) {
+                    Log.e(TAG, "getSerialNumber not available; assuming headset model R322");
+                    return "R322";
+                }
             }
         }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRJassimpAdapter.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRJassimpAdapter.java
@@ -570,7 +570,7 @@ class GVRJassimpAdapter {
                 GVRAssetLoader.TextureRequest texRequest = new GVRAssetLoader.MaterialTextureRequest(assetRequest, mFileName + texFileName, gvrmtl, textureKey, texParams);
                 assetRequest.loadEmbeddedTexture(texRequest, tex, texParams);
             }
-            catch (NumberFormatException | IndexOutOfBoundsException ex)
+            catch (Exception ex)
             {
                 assetRequest.onModelError(mContext, ex.getMessage(), mFileName);
             }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRLODGroup.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRLODGroup.java
@@ -51,7 +51,7 @@ public final class GVRLODGroup extends GVRBehavior {
 
     private final Vector4f mCenter = new Vector4f();
     private final Vector4f mVector = new Vector4f();
-    private final LinkedList<Object[]> mRanges = new LinkedList<>();
+    private final LinkedList<Object[]> mRanges = new LinkedList<Object[]>();
 
     /**
      * Add a range to this LOD group. Specify the scene object that should be displayed in this


### PR DESCRIPTION
The app needs to have compileSdkVersion of **21** or remove the daydream backend to use 19.

Expecting further changes in other backends.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>