### PR TITLE
Unify screen capture code across backends

### DIFF
--- a/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DaydreamViewManager.java
+++ b/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DaydreamViewManager.java
@@ -104,10 +104,16 @@ class DaydreamViewManager extends GVRViewManager {
             sensoredSceneUpdated = updateSensoredScene();
         }
         if (eye == 0) {
+            captureCenterEye();
+            capture3DScreenShot();
+
             renderCamera(mMainScene, cameraRig.getLeftCamera(), mRenderBundle);
+            captureLeftEye();
         } else {
             renderCamera(mMainScene, cameraRig.getRightCamera(), mRenderBundle);
+            captureRightEye();
         }
+        captureFinish();
     }
 
     void setCameraRig(GVRCameraRig cameraRig) {

--- a/GVRf/Framework/framework/src/main/jni/view_manager_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/view_manager_jni.cpp
@@ -90,19 +90,19 @@ extern "C" {
                                 post_effect_render_texture_b);
     }
 
-    JNIEXPORT void JNICALL Java_org_gearvrf_GVRViewManager_readRenderResultNative(JNIEnv *env, jclass clazz, jlong jrender_texture,
-                                                                            jobject jreadback_buffer);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_GVRViewManager_readRenderResultNative(JNIEnv *env, jclass clazz,
+                                                           jobject jreadback_buffer);
 } // extern "C"
 
 
-JNIEXPORT void JNICALL Java_org_gearvrf_GVRViewManager_readRenderResultNative(JNIEnv * env, jclass clazz, jlong jrender_texture, jobject jreadback_buffer) {
-
-    RenderTexture *render_texture = reinterpret_cast<RenderTexture*>(jrender_texture);
+JNIEXPORT void JNICALL Java_org_gearvrf_GVRViewManager_readRenderResultNative(JNIEnv * env, jclass clazz, jobject jreadback_buffer) {
     uint8_t *readback_buffer = (uint8_t*) env->GetDirectBufferAddress(jreadback_buffer);
 
-    int width = render_texture->width();
-    int height = render_texture->height();
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, readback_buffer);
+    GLint viewport[4];
+    glGetIntegerv(GL_VIEWPORT, viewport);
+
+    glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA, GL_UNSIGNED_BYTE, readback_buffer);
 }
 
 }


### PR DESCRIPTION
- provides 4 apis all backends use to perform capturing
- changed the fbo size for daydream to be what the rest of the framework expects when default values are used; it was too big anyway; should eventually be derived from the requested configuration
- all implementation moved to the common framework
- tweaked readRenderResultNative so it is aware of the current viewport

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>