### PR TITLE
gvr-remote-scripting: fix the crash on "print(trex)"

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBone.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBone.java
@@ -1,12 +1,14 @@
 package org.gearvrf;
 
-import java.nio.FloatBuffer;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.gearvrf.jassimp.AiWrapperProvider;
 import org.gearvrf.utility.Log;
 import org.joml.Matrix4f;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A single bone of a mesh.<p>
@@ -111,7 +113,9 @@ public final class GVRBone extends GVRComponent implements PrettyPrint {
      * transform at the current time of the animation.
      */
     public Matrix4f getFinalTransformMatrix() {
-        return new Matrix4f(FloatBuffer.wrap(NativeBone.getFinalTransformMatrix(getNative())));
+        final FloatBuffer fb = ByteBuffer.allocateDirect(4*4*4).order(ByteOrder.nativeOrder()).asFloatBuffer();
+        NativeBone.getFinalTransformMatrix(getNative(), fb);
+        return new Matrix4f(fb);
     }
 
     /**
@@ -220,5 +224,5 @@ class NativeBone {
     static native void setOffsetMatrix(long object, float[] offsetMatrix);
     static native float[] getOffsetMatrix(long object);
     static native void setFinalTransformMatrix(long object, float[] offsetMatrix);
-    static native float[] getFinalTransformMatrix(long object);
+    static native void getFinalTransformMatrix(long object, FloatBuffer output);
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/bone_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/bone_jni.cpp
@@ -11,36 +11,36 @@
 
 namespace gvr {
 extern "C" {
-JNIEXPORT jlong JNICALL
-Java_org_gearvrf_NativeBone_ctor(JNIEnv * env, jobject obj);
+    JNIEXPORT jlong JNICALL
+    Java_org_gearvrf_NativeBone_ctor(JNIEnv * env, jobject obj);
 
-JNIEXPORT jlong JNICALL
-Java_org_gearvrf_NativeBone_getComponentType(JNIEnv * env, jobject clz);
+    JNIEXPORT jlong JNICALL
+    Java_org_gearvrf_NativeBone_getComponentType(JNIEnv * env, jobject clz);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeBone_setName(JNIEnv * env, jobject clz, jlong ptr,
-        jstring name);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeBone_setName(JNIEnv * env, jobject clz, jlong ptr,
+            jstring name);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeBone_setBoneWeights(JNIEnv * env, jobject clz, jlong ptr,
-        jlongArray jArrayBoneWeights);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeBone_setBoneWeights(JNIEnv * env, jobject clz, jlong ptr,
+            jlongArray jArrayBoneWeights);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeBone_setOffsetMatrix(JNIEnv * env, jobject clz, jlong ptr,
-        jfloatArray jOffsetMatrix);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeBone_setOffsetMatrix(JNIEnv * env, jobject clz, jlong ptr,
+            jfloatArray jOffsetMatrix);
 
-JNIEXPORT jfloatArray JNICALL
-Java_org_gearvrf_NativeBone_getOffsetMatrix(JNIEnv * env, jobject clz, jlong ptr);
+    JNIEXPORT jfloatArray JNICALL
+    Java_org_gearvrf_NativeBone_getOffsetMatrix(JNIEnv * env, jobject clz, jlong ptr);
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeBone_setFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr,
-        jfloatArray jOffsetMatrix);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeBone_setFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr,
+            jfloatArray jOffsetMatrix);
 
-JNIEXPORT jfloatArray JNICALL
-Java_org_gearvrf_NativeBone_getFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr);
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_NativeBone_getFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr, jobject jFloatBuffer);
 
 } // extern "C"
-;
+
 
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_NativeBone_ctor(JNIEnv * env, jobject clz) {
@@ -130,23 +130,17 @@ Java_org_gearvrf_NativeBone_setFinalTransformMatrix(JNIEnv * env, jobject clz, j
     env->ReleaseFloatArrayElements(jTransform, mat_arr, JNI_ABORT);
 }
 
-JNIEXPORT jfloatArray JNICALL
-Java_org_gearvrf_NativeBone_getFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr) {
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeBone_getFinalTransformMatrix(JNIEnv * env, jobject clz, jlong ptr, jobject buffer) {
     Bone* bone = reinterpret_cast<Bone*>(ptr);
     glm::mat4 matrix;
 
     if (bone) {
         matrix = bone->getFinalTransformMatrix();
     }
-    jsize size = sizeof(matrix) / sizeof(jfloat);
-    if (size != 16) {
-        LOGE("sizeof(matrix) / sizeof(jfloat) != 16");
-        throw "sizeof(matrix) / sizeof(jfloat) != 16";
-    }
-    jfloatArray jmatrix = env->NewFloatArray(size);
-    env->SetFloatArrayRegion(jmatrix, 0, size, glm::value_ptr(matrix));
 
-    return jmatrix;
+    float *ptrBuffer = static_cast<float*>(env->GetDirectBufferAddress(buffer));
+    std::memcpy(ptrBuffer, glm::value_ptr(matrix), sizeof matrix);
 }
 
 } // namespace gvr


### PR DESCRIPTION
Fix for the crashing GVRBone.getFinalTransformMatrix

- joml expects a direct buffer; if not you get a strange crash in libart due to invalid buffer access
- joml has an option to enable checks for this (joml.debug)

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>