### PR TITLE
Features and fixes for physics

### DIFF
--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRRigidBody.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRRigidBody.java
@@ -15,6 +15,7 @@
 
 package org.gearvrf.physics;
 
+import org.gearvrf.GVRCollider;
 import org.gearvrf.GVRComponent;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRSceneObject;
@@ -33,6 +34,10 @@ import org.gearvrf.GVRSceneObject;
  * and the mass value of the rigid body before attach it to its owner.
  */
 public class GVRRigidBody extends GVRComponent {
+    public static final int DYNAMIC  = 0;
+    public static final int STATIC = 1;
+    public static final int KINEMATIC = 2;
+
     static {
         System.loadLibrary("gvrf-physics");
     }
@@ -114,6 +119,36 @@ public class GVRRigidBody extends GVRComponent {
     }
 
     /**
+     * Establishes how this rigid body will behave in the simulation.
+     *
+     * @param type type of simulation desired for the rigid body:
+     * <table>
+     * <tr><td>DYNAMIC</td><td>Collides with other objects, moved by simulation</td></tr>
+     * <tr><td>STATIC</td><td>Collides with other objects, does not move</td></tr>
+     * <tr><td>KINEMATIC</td><td>Collides with other objects, moved by application</td></tr>
+     * </table>
+     */
+    public void setSimulationType(int type)
+    {
+        Native3DRigidBody.setSimulationType(getNative(), type);
+    }
+
+    /**
+     * Queries how this rigid body will behave in the simulation.
+     *
+     * @return type of simulation desired for the rigid body
+     * <table>
+     * <tr><td>DYNAMIC</td><td>Collides with other objects, moved by simulation</td></tr>
+     * <tr><td>STATIC</td><td>Collides with other objects, does not move</td></tr>
+     * <tr><td>KINEMATIC</td><td>Collides with other objects, moved by application</td></tr>
+     * </table>
+     */
+    public int getSimulationType()
+    {
+       return Native3DRigidBody.getSimulationType(getNative());
+    }
+
+    /**
      * Returns the mass of the body.
      *
      * @return The mass of the body.
@@ -129,138 +164,6 @@ public class GVRRigidBody extends GVRComponent {
      */
     public void setMass(float mass) {
         Native3DRigidBody.setMass(getNative(), mass);
-    }
-
-    /**
-     * Get the X component of the transform's position.
-     *
-     * @return 'X' component of the transform's position.
-     */
-    public float getCenterX() {
-        return Native3DRigidBody.getCenterX(getNative());
-    }
-
-    /**
-     * Get the 'Y' component of the transform's position.
-     *
-     * @return 'Y' component of the transform's position.
-     */
-    public float getCenterY() {
-        return Native3DRigidBody.getCenterY(getNative());
-    }
-
-    /**
-     * Get the 'Z' component of the transform's position.
-     *
-     * @return 'Z' component of the transform's position.
-     */
-    public float getCenterZ() {
-        return Native3DRigidBody.getCenterZ(getNative());
-    }
-
-    /**
-     * Set absolute position.
-     * <p>
-     * Use {@link #setCenter(float, float, float)} to <em>move</em> the object.
-     *
-     * @param x 'X' component of the absolute position.
-     * @param y 'Y' component of the absolute position.
-     * @param z 'Z' component of the absolute position.
-     */
-    public void setCenter(float x, float y, float z) {
-        Native3DRigidBody.setCenter(getNative(), x, y, z);
-    }
-
-    /**
-     * Get the quaternion 'W' component.
-     *
-     * @return 'W' component of the transform's rotation, treated as a
-     * quaternion.
-     */
-    public float getRotationW() {
-        return Native3DRigidBody.getRotationW(getNative());
-    }
-
-    /**
-     * Get the quaternion 'X' component.
-     *
-     * @return 'X' component of the transform's rotation, treated as a
-     * quaternion.
-     */
-    public float getRotationX() {
-        return Native3DRigidBody.getRotationX(getNative());
-    }
-
-    /**
-     * Get the quaternion 'Y' component.
-     *
-     * @return 'Y' component of the transform's rotation, treated as a
-     * quaternion.
-     */
-    public float getRotationY() {
-        return Native3DRigidBody.getRotationY(getNative());
-    }
-
-    /**
-     * Get the quaternion 'Z' component.
-     *
-     * @return 'Z' component of the transform's rotation, treated as a
-     * quaternion.
-     */
-    public float getRotationZ() {
-        return Native3DRigidBody.getRotationZ(getNative());
-    }
-
-    /**
-     * Set rotation, as a quaternion.
-     * <p>
-     * Sets the transform's current rotation in quaternion terms.
-     *
-     * @param w 'W' component of the quaternion.
-     * @param x 'X' component of the quaternion.
-     * @param y 'Y' component of the quaternion.
-     * @param z 'Z' component of the quaternion.
-     */
-    public void setRotation(float w, float x, float y, float z) {
-        Native3DRigidBody.setRotation(getNative(), w, x, y, z);
-    }
-
-    /**
-     * Get the 'X' scale
-     *
-     * @return The transform's current scaling on the 'X' axis.
-     */
-    public float getScaleX() {
-        return Native3DRigidBody.getScaleX(getNative());
-    }
-
-    /**
-     * Get the 'Y' scale
-     *
-     * @return The transform's current scaling on the 'Y' axis.
-     */
-    public float getScaleY() {
-        return Native3DRigidBody.getScaleY(getNative());
-    }
-
-    /**
-     * Get the 'Z' scale
-     *
-     * @return The transform's current scaling on the 'Z' axis.
-     */
-    public float getScaleZ() {
-        return Native3DRigidBody.getScaleZ(getNative());
-    }
-
-    /**
-     * Set [X, Y, Z] current scale
-     *
-     * @param x Scaling factor on the 'X' axis.
-     * @param y Scaling factor on the 'Y' axis.
-     * @param z Scaling factor on the 'Z' axis.
-     */
-    public void setScale(float x, float y, float z) {
-        Native3DRigidBody.setScale(getNative(), x, y, z);
     }
 
     /**
@@ -507,20 +410,25 @@ public class GVRRigidBody extends GVRComponent {
 
     @Override
     public void onAttach(GVRSceneObject newOwner) {
-        super.onAttach(newOwner);
-
         if (newOwner.getCollider() == null) {
-            throw new RuntimeException("GVRRigidBody depends of a Collider attached to it's SceneObject");
+            throw new UnsupportedOperationException("You must have a collider attached to the scene object before attaching the rigid body");
         }
-
-        doPhysicsAttach(newOwner);
+        if ((newOwner.getRenderData() == null) ||
+            (newOwner.getRenderData().getMesh() == null)) {
+            throw new UnsupportedOperationException("You must have a mesh attached to the scene object before attaching the rigid body");
+        }
+        super.onAttach(newOwner);
+        if (isEnabled()) {
+            addToWorld(getWorld(newOwner));
+        }
     }
 
     @Override
     public void onDetach(GVRSceneObject oldOwner) {
         super.onDetach(oldOwner);
-
-        doPhysicsDetach(oldOwner);
+        if (isEnabled()) {
+            removeFromWorld(getWorld(oldOwner));
+        }
     }
 
     @Override
@@ -551,21 +459,6 @@ public class GVRRigidBody extends GVRComponent {
         removeFromWorld(getWorld());
     }
 
-    private void doPhysicsAttach(GVRSceneObject newOwner) {
-        Native3DRigidBody.onAttach(getNative());
-
-        if (isEnabled()) {
-            addToWorld(getWorld(newOwner));
-        }
-    }
-
-    private void doPhysicsDetach(GVRSceneObject oldOwner) {
-        if (isEnabled()) {
-            removeFromWorld(getWorld(oldOwner));
-        }
-
-        Native3DRigidBody.onDetach(getNative());
-    }
 
     private void addToWorld(GVRWorld world) {
         if (world != null) {
@@ -592,36 +485,6 @@ class Native3DRigidBody {
     static native void applyCentralForce(long jrigid_body, float x, float y, float z);
 
     static native void applyTorque(long jrigid_body, float x, float y, float z);
-
-    static native void onAttach(long jrigid_body);
-
-    static native void onDetach(long jrigid_body);
-
-    static native float getCenterX(long jrigid_body);
-
-    static native float getCenterY(long jrigid_body);
-
-    static native float getCenterZ(long jrigid_body);
-
-    static native void setCenter(long jrigid_body, float x, float y, float z);
-
-    static native float getRotationW(long jrigid_body);
-
-    static native float getRotationX(long jrigid_body);
-
-    static native float getRotationY(long jrigid_body);
-
-    static native float getRotationZ(long jrigid_body);
-
-    static native void setRotation(long jrigid_body, float w, float x, float y, float z);
-
-    static native float getScaleX(long jrigid_body);
-
-    static native float getScaleY(long jrigid_body);
-
-    static native float getScaleZ(long jrigid_body);
-
-    static native void setScale(long jrigid_body, float x, float y, float z);
 
     static native void setGravity(long jrigid_body, float x, float y, float z);
 
@@ -666,4 +529,8 @@ class Native3DRigidBody {
     static native float getCcdMotionThreshold(long jrigid_body);
 
     static native float getContactProcessingThreshold(long jrigid_body);
+
+    static native int getSimulationType(long jrigid_body);
+
+    static native void setSimulationType(long jrigid_body, int jtype);
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
@@ -121,8 +121,8 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
         if (mIsProcessing) {
             return;
         }
+        mIsProcessing = true;
         NativePhysics3DWorld.step(getNative(), mFrameTime);
-
         generateCollisionEvents();
         mFrameTime = 0.0f;
         mIsProcessing = false;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/bullet/bullet_rigidbody.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/bullet/bullet_rigidbody.cpp
@@ -53,13 +53,17 @@ void BulletRigidBody::setSimulationType(PhysicsRigidBody::SimulationType type)
         break;
 
         case SimulationType::STATIC:
-        mRigidBody->setCollisionFlags(mRigidBody->getCollisionFlags() & ~btCollisionObject::CollisionFlags::CF_KINEMATIC_OBJECT);
-        mRigidBody->setActivationState(DISABLE_DEACTIVATION);
+        mRigidBody->setCollisionFlags(mRigidBody->getCollisionFlags() |
+                                      btCollisionObject::CollisionFlags::CF_STATIC_OBJECT &
+                                      ~btCollisionObject::CollisionFlags::CF_KINEMATIC_OBJECT);
+        mRigidBody->setActivationState(ISLAND_SLEEPING);
         break;
 
         case SimulationType::KINEMATIC:
-        mRigidBody->setCollisionFlags(mRigidBody->getCollisionFlags() & ~btCollisionObject::CollisionFlags::CF_STATIC_OBJECT);
-        mRigidBody->setActivationState(DISABLE_DEACTIVATION);
+        mRigidBody->setCollisionFlags(mRigidBody->getCollisionFlags() |
+                                       btCollisionObject::CollisionFlags::CF_KINEMATIC_OBJECT &
+                                       ~btCollisionObject::CollisionFlags::CF_STATIC_OBJECT);
+        mRigidBody->setActivationState(ISLAND_SLEEPING);
         break;
     }
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/bullet/bullet_rigidbody.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/bullet/bullet_rigidbody.h
@@ -22,6 +22,7 @@
 #include <LinearMath/btMotionState.h>
 
 namespace gvr {
+class SceneObject;
 
 class BulletRigidBody : public Physics3DRigidBody, btMotionState {
  public:
@@ -32,6 +33,9 @@ class BulletRigidBody : public Physics3DRigidBody, btMotionState {
     btRigidBody *getRigidBody() const {
         return mRigidBody;
     }
+
+    virtual void setSimulationType(SimulationType type);
+    virtual SimulationType getSimulationType() const;
 
     void setMass(float mass) {
         mConstructionInfo.m_mass = btScalar(mass);
@@ -54,10 +58,6 @@ class BulletRigidBody : public Physics3DRigidBody, btMotionState {
     void applyCentralForce(float x, float y, float z);
 
     void applyTorque(float x, float y, float z);
-
-    void onAttach();
-
-    void onDetach();
 
     float center_x() const;
 
@@ -133,6 +133,8 @@ class BulletRigidBody : public Physics3DRigidBody, btMotionState {
 
     const float getCcdSweptSphereRadius() const;
 
+    virtual void set_owner_object(SceneObject* obj);
+
  private:
     void initialize();
 
@@ -140,11 +142,14 @@ class BulletRigidBody : public Physics3DRigidBody, btMotionState {
 
     void updateColisionShapeLocalScaling();
 
- private:
+    void onAttach(SceneObject* owner);
+
+private:
     btRigidBody *mRigidBody;
     btRigidBody::btRigidBodyConstructionInfo mConstructionInfo;
     btTransform m_centerOfMassOffset;
     btVector3 mScale;
+    SimulationType mSimType;
 };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/bullet/bullet_world.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/bullet/bullet_world.h
@@ -47,6 +47,14 @@ class BulletWorld : public Physics3DWorld {
 
     void listCollisions(std::list <ContactPoint> &contactPoints);
 
+    void setGravity(float x, float y, float z);
+
+    void setGravity(glm::vec3 gravity);
+
+    glm::vec3 getGravity();
+
+    static std::mutex& getLock() { return sLock; }
+
  private:
     void initialize();
 
@@ -59,10 +67,10 @@ class BulletWorld : public Physics3DWorld {
     btCollisionDispatcher *mDispatcher;
     btSequentialImpulseConstraintSolver *mSolver;
     btBroadphaseInterface *mOverlappingPairCache;
-
     btNearCallback *gTmpFilter;
     int gNearCallbackCount = 0;
     void *gUserData = 0;
+    static std::mutex sLock;
 };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics3d/physics_3drigidbody_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics3d/physics_3drigidbody_jni.cpp
@@ -14,7 +14,8 @@
  */
 
 #include "../bullet/bullet_rigidbody.h"
-
+#include "../bullet/bullet_world.h"
+#include <mutex>
 #include "glm/gtc/type_ptr.hpp"
 #include "util/gvr_jni.h"
 
@@ -26,6 +27,13 @@ extern "C" {
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DRigidBody_getComponentType(JNIEnv * env, jobject obj);
 
+    JNIEXPORT jint JNICALL
+    Java_org_gearvrf_physics_Native3DRigidBody_getSimulationType(JNIEnv * env, jobject obj,
+             jlong jrigid_body);
+
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_physics_Native3DRigidBody_setSimulationType(JNIEnv * env, jobject obj,
+             jlong jrigid_body, jint jtype);
     JNIEXPORT jfloat JNICALL
     Java_org_gearvrf_physics_Native3DRigidBody_getMass(JNIEnv * env, jobject obj,
             jlong jrigid_body);
@@ -40,66 +48,6 @@ extern "C" {
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_physics_Native3DRigidBody_applyTorque(JNIEnv * env, jobject obj,
-            jlong jrigid_body, jfloat x, jfloat y, jfloat z);
-
-    JNIEXPORT void JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_onAttach(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT void JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_onDetach(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getCenterX(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getCenterY(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getCenterZ(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT void JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_setCenter(JNIEnv * env, jobject obj,
-            jlong jrigid_body, jfloat x, jfloat y, jfloat z);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getRotationW(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getRotationX(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getRotationY(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getRotationZ(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT void   JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_setRotation(JNIEnv * env, jobject obj,
-            jlong jrigid_body, jfloat w, jfloat x, jfloat y, jfloat z);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getScaleX(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getScaleY(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT jfloat JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_getScaleZ(JNIEnv * env, jobject obj,
-            jlong jrigid_body);
-
-    JNIEXPORT void   JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_setScale(JNIEnv * env, jobject obj,
             jlong jrigid_body, jfloat x, jfloat y, jfloat z);
 
     JNIEXPORT void   JNICALL
@@ -201,6 +149,23 @@ Java_org_gearvrf_physics_Native3DRigidBody_getComponentType(JNIEnv * env, jobjec
     return BulletRigidBody::getComponentType();
 }
 
+JNIEXPORT jint JNICALL
+Java_org_gearvrf_physics_Native3DRigidBody_getSimulationType(JNIEnv * env, jobject obj,
+          jlong jrigid_body)
+{
+    PhysicsRigidBody* rigid_body = reinterpret_cast<PhysicsRigidBody*>(jrigid_body);
+    return rigid_body->getSimulationType();
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_physics_Native3DRigidBody_setSimulationType(JNIEnv * env, jobject obj,
+         jlong jrigid_body, jint jtype)
+{
+    PhysicsRigidBody* rigid_body = reinterpret_cast<PhysicsRigidBody*>(jrigid_body);
+    PhysicsRigidBody::SimulationType type = (PhysicsRigidBody::SimulationType) (int) (jtype);
+    rigid_body->setSimulationType(type);
+}
+
 JNIEXPORT jfloat JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_getMass(JNIEnv * env, jobject obj,
         jlong jrigid_body) {
@@ -220,6 +185,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setMass(JNIEnv * env, jobject obj,
 JNIEXPORT void JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_applyCentralForce(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat x, jfloat y, jfloat z) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody *rigid_body = reinterpret_cast<BulletRigidBody *>(jrigid_body);
 
     rigid_body->applyCentralForce(x, y, z);
@@ -233,129 +199,10 @@ Java_org_gearvrf_physics_Native3DRigidBody_applyTorque(JNIEnv * env, jobject obj
     rigid_body->applyTorque(x, y, z);
 }
 
-JNIEXPORT void JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_onAttach(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    rigid_body->onAttach();
-}
-
-JNIEXPORT void JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_onDetach(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    rigid_body->onDetach();
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getCenterX(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->center_x();
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getCenterY(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->center_y();
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getCenterZ(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->center_z();
-}
-
-JNIEXPORT void JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_setCenter(JNIEnv * env, jobject obj,
-        jlong jrigid_body, jfloat x, jfloat y, jfloat z) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    rigid_body->set_center(x, y, z);
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getRotationW(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->rotation_w();
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getRotationX(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->rotation_x();
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getRotationY(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->rotation_y();
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getRotationZ(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->rotation_z();
-}
-
-JNIEXPORT void JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_setRotation(JNIEnv * env, jobject obj,
-        jlong jrigid_body, jfloat w, jfloat x, jfloat y, jfloat z) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    rigid_body->set_rotation(w, x, y, z);
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getScaleX(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->scale_x();
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getScaleY(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->scale_y();
-}
-
-JNIEXPORT jfloat JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_getScaleZ(JNIEnv * env, jobject obj,
-        jlong jrigid_body) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    return rigid_body->scale_z();
-}
-
-JNIEXPORT void JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_setScale(JNIEnv * env, jobject obj,
-        jlong jrigid_body, jfloat x, jfloat y, jfloat z) {
-    BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
-
-    rigid_body->set_scale(x, y, z);
-}
-
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setGravity(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat x, jfloat y, jfloat z) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setGravity(x, y, z);
@@ -364,6 +211,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setGravity(JNIEnv * env, jobject obj,
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setDamping(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat linear, jfloat angular) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setDamping(linear, angular);
@@ -372,6 +220,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setDamping(JNIEnv * env, jobject obj,
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setLinearVelocity(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat x, jfloat y, jfloat z) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setLinearVelocity(x, y, z);
@@ -380,6 +229,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setLinearVelocity(JNIEnv * env, jobje
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setAngularVelocity(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat x, jfloat y, jfloat z) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setAngularVelocity(x, y, z);
@@ -388,6 +238,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setAngularVelocity(JNIEnv * env, jobj
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setAngularFactor(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat x, jfloat y, jfloat z) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setAngularFactor(x, y, z);
@@ -396,6 +247,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setAngularFactor(JNIEnv * env, jobjec
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setLinearFactor(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat x, jfloat y, jfloat z) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setLinearFactor(x, y, z);
@@ -404,6 +256,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setLinearFactor(JNIEnv * env, jobject
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setFriction(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat n) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setFriction(n);
@@ -412,6 +265,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setFriction(JNIEnv * env, jobject obj
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setRestitution(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat n) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setRestitution(n);
@@ -420,6 +274,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setRestitution(JNIEnv * env, jobject 
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setSleepingThresholds(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat linear, jfloat angular) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setSleepingThresholds(linear, angular);
@@ -428,6 +283,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setSleepingThresholds(JNIEnv * env, j
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setCcdMotionThreshold(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat n) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setCcdMotionThreshold(n);
@@ -436,6 +292,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setCcdMotionThreshold(JNIEnv * env, j
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setContactProcessingThreshold(JNIEnv * env, jobject obj,
         jlong jrigid_body, jfloat n) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setContactProcessingThreshold(n);
@@ -444,6 +301,7 @@ Java_org_gearvrf_physics_Native3DRigidBody_setContactProcessingThreshold(JNIEnv 
 JNIEXPORT void   JNICALL
 Java_org_gearvrf_physics_Native3DRigidBody_setIgnoreCollisionCheck(JNIEnv * env, jobject obj,
         jlong jrigid_body, jobject collisionObj, jboolean ignore) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
     rigid_body->setIgnoreCollisionCheck(reinterpret_cast<BulletRigidBody*>(jrigid_body), ignore);

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics3d/physics_3dworld_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics3d/physics_3dworld_jni.cpp
@@ -50,6 +50,14 @@ extern "C" {
     JNIEXPORT jobjectArray JNICALL
     Java_org_gearvrf_physics_NativePhysics3DWorld_listCollisions(JNIEnv * env, jobject obj,
                                                                     jlong jworld);
+
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_physics_NativePhysics3DWorld_setGravity(JNIEnv* env, jobject obj,
+            jlong jworld, float gx, float gy, float gz);
+
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_physics_NativePhysics3DWorld_getGravity(JNIEnv* env, jobject obj,
+            jlong jworld, jfloatArray jgravity);
 }
 
 JNIEXPORT jlong JNICALL
@@ -65,6 +73,7 @@ Java_org_gearvrf_physics_NativePhysics3DWorld_getComponentType(JNIEnv * env, job
 JNIEXPORT void JNICALL
 Java_org_gearvrf_physics_NativePhysics3DWorld_addRigidBody(JNIEnv * env, jobject obj,
         jlong jworld, jlong jrigid_body) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletWorld *world = reinterpret_cast<BulletWorld*>(jworld);
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
@@ -74,6 +83,7 @@ Java_org_gearvrf_physics_NativePhysics3DWorld_addRigidBody(JNIEnv * env, jobject
 JNIEXPORT void JNICALL
 Java_org_gearvrf_physics_NativePhysics3DWorld_addRigidBodyWithMask(JNIEnv * env, jobject obj,
         jlong jworld, jlong jrigid_body, jlong collisionType, jlong collidesWith) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletWorld *world = reinterpret_cast<BulletWorld*>(jworld);
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
@@ -83,6 +93,7 @@ Java_org_gearvrf_physics_NativePhysics3DWorld_addRigidBodyWithMask(JNIEnv * env,
 JNIEXPORT void JNICALL
 Java_org_gearvrf_physics_NativePhysics3DWorld_removeRigidBody(JNIEnv * env, jobject obj,
         jlong jworld, jlong jrigid_body) {
+    std::lock_guard<std::mutex> lock(BulletWorld::getLock());
     BulletWorld *world = reinterpret_cast<BulletWorld*>(jworld);
     BulletRigidBody* rigid_body = reinterpret_cast<BulletRigidBody*>(jrigid_body);
 
@@ -132,4 +143,21 @@ Java_org_gearvrf_physics_NativePhysics3DWorld_listCollisions(JNIEnv * env, jobje
     return jNewList;
 }
 
+JNIEXPORT void JNICALL
+Java_org_gearvrf_physics_NativePhysics3DWorld_setGravity(JNIEnv* env, jobject obj,
+        jlong jworld, float gx, float gy, float gz)
+{
+    BulletWorld* world = reinterpret_cast <BulletWorld*> (jworld);
+    world->setGravity(gx, gy, gz);
+}
+
+JNIEXPORT void JNICALL
+Java_org_gearvrf_physics_NativePhysics3DWorld_getGravity(JNIEnv* env, jobject obj,
+        jlong jworld, jfloatArray jgravity)
+{
+    BulletWorld* world = reinterpret_cast <BulletWorld*> (jworld);
+    glm::vec3 gravity = world->getGravity();
+    float temp[3] = { gravity.x, gravity.y, gravity.z };
+    env->SetFloatArrayRegion(jgravity, 0, 3, temp);
+}
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics_rigidbody.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics/physics_rigidbody.h
@@ -28,12 +28,21 @@ namespace gvr {
 
 class PhysicsRigidBody : public Component {
  public:
-    PhysicsRigidBody() : Component(PhysicsRigidBody::getComponentType()) {}
+	enum SimulationType
+	{
+		DYNAMIC = 0,
+		KINEMATIC = 1,
+		STATIC = 2
+	};
+
+	PhysicsRigidBody() : Component(PhysicsRigidBody::getComponentType()) {}
 
 	static long long getComponentType() {
 	        return COMPONENT_TYPE_PHYSICS_RIGID_BODY;
 	}
 
+	virtual void setSimulationType(SimulationType t) = 0;
+	virtual SimulationType getSimulationType() const = 0;
 	virtual float getMass() = 0;
 	virtual void setMass(float mass) = 0;
     virtual void setCenterOfMass(const Transform* t) = 0;
@@ -41,22 +50,6 @@ class PhysicsRigidBody : public Component {
     virtual void getTranslation(float &x, float &y, float &z) = 0;
     virtual void applyCentralForce(float x, float y, float z) = 0;
     virtual void applyTorque(float x, float y, float z) = 0;
-    virtual void onAttach() = 0;
-    virtual void onDetach() = 0;
-
-	virtual float center_x() const  = 0;
-	virtual float center_y() const  = 0;
-	virtual float center_z() const  = 0;
-	virtual void  set_center(float x, float y, float z) = 0;
-	virtual float rotation_w() const  = 0;
-	virtual float rotation_x() const  = 0;
-	virtual float rotation_y() const  = 0;
-	virtual float rotation_z() const  = 0;
-	virtual void  set_rotation(float w, float x, float y, float z) = 0;
-	virtual float scale_x()  const = 0;
-	virtual float scale_y() const  = 0;
-	virtual float scale_z() const  = 0;
-	virtual void  set_scale(float x, float y, float z) = 0;
 
 	virtual void setGravity(float x, float y, float z)  = 0;
 	virtual void setDamping(float linear, float angular)  = 0;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
@@ -23,6 +23,8 @@
 
 #include <memory>
 
+#include "objects/scene_object.h"
+#include "render_data.h"
 #include "collider.h"
 
 namespace gvr {
@@ -40,7 +42,18 @@ public:
     }
 
     Mesh* mesh() const {
-        return mesh_;
+        if (mesh_) {
+            return mesh_;
+        }
+        SceneObject* owner = owner_object();
+        if (owner == nullptr) {
+            return nullptr;
+        }
+        RenderData* rdata = owner->render_data();
+        if (rdata == nullptr) {
+            return nullptr;
+        }
+        return rdata->mesh();
     }
 
     void set_mesh(Mesh* mesh) {

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data.cpp
@@ -36,9 +36,14 @@ const RenderPass* RenderData::pass(int pass) const {
 }
 
 void RenderData::set_mesh(Mesh* mesh) {
-    mesh_ = mesh;
-    mesh->add_dirty_flag(dirty_flag_);
-    *dirty_flag_ = true;
+    if (mesh != nullptr) {
+        mesh_ = mesh;
+        mesh->add_dirty_flag(dirty_flag_);
+        *dirty_flag_ = true;
+    }
+    else {
+        LOGE("RenderData::set_mesh mesh cannot be NULL");
+    }
 }
 
 void RenderData::setDirty(bool dirty){


### PR DESCRIPTION
1. RenderData::set_mesh now checks for null to avoid crash
2. MeshCollider::mesh() returns the mesh from an associated RenderData if the mesh was not specified (it used to return NULL). The physics extension assumes the new behavior.
3. Added GVRWorld.setGravity to allow app to change global gravity settings
4. Lock around updates to physics rigid bodies in C++ to prevent crashes. This is a global lock - not a per rigid-body lock. We may need to revisit this issue in the future to support more granular locking.
3. Added GVRRigidBody.setSimulationType to support dynamic, kinematic and static objects. THIS FEATURE IS NOT WORKING YET!
4. Removed confusing APIs in GVRRigidBody to set position and center. The correct way to move and orient the rigid body is by changing the transformation of the scene object which owns it. These APIs should not be exposed to the user.
5. Do not permit re-entering NativePhysics3DWorld.step by the draw frame listener, Instead wait until the next frame to run physics. This fixes some thread safety issues.

These changes fix some of the crashes in the gvr-simplephysics sample.

GearVRF DCO signed off by: Nola Donato nola.donato@samsung.com