### PR TITLE
Fix for a UnknownFormatConversionException that leads to a crash

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
@@ -582,7 +582,7 @@ public class GVRPicker extends GVRBehavior {
        GVRCollider collider = GVRCollider.lookup(colliderPointer);
        if (collider == null)
        {
-           Log.d("Picker", "makeHit: cannot find collider for %p", colliderPointer);
+           Log.d(TAG, "makeHit: cannot find collider for %x", colliderPointer);
            return null;
        }
        return new GVRPicker.GVRPickedObject(collider, new float[] { hitx, hity, hitz }, distance);


### PR DESCRIPTION
A certain app that has been known to be kind of a stress test has been crashing recently due to ``java.util.UnknownFormatConversionException: Conversion: p``.

Doesn't look like there is a good case that justifies the lookup returning nullptr. The app can detach colliders from some thread and runs GVRPicker.pickObjects on the GL thread. While there is locking on the C++ side, part of the collider implementation is on the Java side. If it becomes a bigger problem we will have to look into making the operations atomic from Java's perspective.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>