### PR TITLE
Remove the buildGvrfAndDemos option

### DIFF
--- a/GVRf/Framework/backend_oculus/build.gradle
+++ b/GVRf/Framework/backend_oculus/build.gradle
@@ -21,9 +21,6 @@ android {
                 arguments += ['PROJECT_ROOT=' + rootProject.projectDir]
                 arguments += ['PROJECT_DIR=' + projectDir.absolutePath]
                 arguments += ['BUILDTYPE=Release']      // for oculus
-                if (rootProject.hasProperty("buildGvrfAndDemos")) {
-                    arguments += ["NDK_DEBUG=1"]
-                }
                 if (rootProject.hasProperty("ARM64")) {
                     arguments += ['ARM64=true']
                 }

--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -17,9 +17,6 @@ android {
         externalNativeBuild {
             ndkBuild {
                 arguments = ["-j" + Runtime.runtime.availableProcessors()]
-                if (rootProject.hasProperty("buildGvrfAndDemos")) {
-                    arguments.add("NDK_DEBUG=1")
-                }
                 if (rootProject.hasProperty("ARM64")) {
                     arguments += ['ARM64=true']
                 }


### PR DESCRIPTION
to build a demo together with the fw just add the demo module to
the extra_settings.gradle file; it will use the framework projects
instead of the aars

Goes together with https://github.com/gearvrf/GearVRf-Demos/pull/446

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>