### PR TITLE
Fix for the odd NullPointerException in GVRActivity.registerView

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -556,11 +556,11 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                /* The full screen should be updated
-                otherwise just the children's bounds may be refreshed. */
-                mRenderableViewGroup.setClipChildren(false);
-
-                mRenderableViewGroup.addView(view);
+                if (null != mRenderableViewGroup) {
+                    /* The full screen should be updated otherwise just the children's bounds may be refreshed. */
+                    mRenderableViewGroup.setClipChildren(false);
+                    mRenderableViewGroup.addView(view);
+                }
             }
         });
     }
@@ -574,7 +574,9 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                mRenderableViewGroup.removeView(view);
+                if (null != mRenderableViewGroup) {
+                    mRenderableViewGroup.removeView(view);
+                }
             }
         });
     }


### PR DESCRIPTION
```
05-01 14:07:10.201 22474 22474 E AndroidRuntime: FATAL EXCEPTION: main
05-01 14:07:10.201 22474 22474 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.ViewGroup.setClipChildren(boolean)' on a null object reference
05-01 14:07:10.201 22474 22474 E AndroidRuntime: 	at org.gearvrf.GVRActivity$2.run(GVRActivity.java:554)
05-01 14:07:10.201 22474 22474 E AndroidRuntime: 	at android.app.Activity.runOnUiThread(Activity.java:6035)
05-01 14:07:10.201 22474 22474 E AndroidRuntime: 	at org.gearvrf.GVRActivity.registerView(GVRActivity.java:549)
05-01 14:07:10.201 22474 22474 E AndroidRuntime: 	at org.gearvrf.scene_objects.view.GVRWebView.<init>(GVRWebView.java:36)
```

There is an app that may try to register a view after the activity has been destroyed.