### PR TITLE
Add back the runPendingGL() call Texture::getId that I incorrectly removed

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
@@ -38,6 +38,10 @@ public:
             // must be recycled already. The caller will handle error.
             return 0;
         }
+
+        // Before returning the ID makes sure nothing is pending
+        runPendingGL();
+
         return gl_texture_->id();
     }
 


### PR DESCRIPTION
Reverts a one line change https://github.com/Samsung/GearVRf/pull/1173 made