### PR TITLE
Add a bit of logging to the io library

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/Cursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/Cursor.java
@@ -57,10 +57,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Each {@link Cursor} object has a {@link CursorType} that defines the type of events generated.
  */
 public abstract class Cursor {
-    private static final String TAG = Cursor.class.getSimpleName();
+    private static final String TAG = "Cursor";
     protected static final float MAX_CURSOR_SCALE = 1000;
 
-    private GVRContext context;
     protected GVRSceneObject cursor;
     private String name;
     private final CursorType type;
@@ -68,8 +67,6 @@ public abstract class Cursor {
     private Position position;
     private String savedThemeId;
     private List<PriorityIoDeviceTuple> compatibleIoDevices;
-
-    private static final float SQRT_2 = (float) Math.sqrt(2);
 
     private static int uniqueCursorId = 0;
     private final int cursorId;
@@ -100,7 +97,6 @@ public abstract class Cursor {
     }
 
     Cursor(GVRContext context, CursorType type, CursorManager cursorManager) {
-        this.context = context;
         this.type = type;
         this.cursorId = uniqueCursorId++;
         cursorSceneObject = new CursorSceneObject(context, cursorId);
@@ -524,12 +520,15 @@ public abstract class Cursor {
      */
     public void setEnable(boolean value) {
         if (!enabled && value) {
+            Log.d(TAG, Integer.toHexString(hashCode()) + " enabled");
             enabled = true;
             cursorManager.assignIoDevicesToCursors();
         } else if (enabled && !value) {
             if (ioDevice == null) {
+                Log.d(TAG, Integer.toHexString(hashCode()) + " disabled; ioDevice == null");
                 enabled = false;
             } else {
+                Log.d(TAG, Integer.toHexString(hashCode()) + " disabled");
                 enabled = false;
                 Log.d(TAG, "Destroying Iodevice:" + ioDevice.getDeviceId());
                 destroyIoDevice(ioDevice);
@@ -652,6 +651,15 @@ public abstract class Cursor {
         if (cursorManager.isDepthOrderEnabled() &&
                 !controller.isEventHandledBySensorManager() && !sentEvent &&
                 (controller.getKeyEvent() != null || controller.getMotionEvents().size() > 0)) {
+
+            Log.d(TAG, Integer.toHexString(hashCode()) + " handling event"
+                    + "; isDepthOrderEnabled " + cursorManager.isDepthOrderEnabled()
+                    + "; isEventHandledBySensorManager " + controller.isEventHandledBySensorManager()
+                    + "; sentEvent " + sentEvent
+                    + "; getMotionEvents().size() " + controller.getMotionEvents().size()
+                    + "; getKeyEvent() " + controller.getKeyEvent()
+            );
+
             CursorEvent cursorEvent = CursorEvent.obtain();
             cursorEvent.setOver(false);
             cursorEvent.setColliding(false);

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/LaserCursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/LaserCursor.java
@@ -16,25 +16,19 @@
 
 package org.gearvrf.io.cursor3d;
 
-import android.view.KeyEvent;
-import android.view.MotionEvent;
-
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRCursorController;
 import org.gearvrf.GVRCursorController.ControllerEventListener;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.SensorEvent;
-import org.gearvrf.SensorEvent.EventGroup;
 import org.gearvrf.io.cursor3d.CursorAsset.Action;
 import org.gearvrf.utility.Log;
-
-import java.util.List;
 
 /**
  * Class that represents a laser type cursor.
  */
 class LaserCursor extends Cursor {
-    private static final String TAG = LaserCursor.class.getSimpleName();
+    private static final String TAG = "LaserCursor";
     private static final boolean COLLIDING = true;
 
     /**
@@ -44,6 +38,7 @@ class LaserCursor extends Cursor {
      */
     LaserCursor(GVRContext context, CursorManager manager) {
         super(context, CursorType.LASER, manager);
+        Log.d(TAG, Integer.toHexString(hashCode()) + " constructed");
     }
 
     @Override

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursor.java
@@ -41,6 +41,8 @@ class ObjectCursor extends Cursor {
     ObjectCursor(GVRContext context, CursorManager cursorManager) {
         super(context, CursorType.OBJECT, cursorManager);
         intersecting = new HashSet<GVRSceneObject>();
+
+        Log.d(TAG, Integer.toHexString(hashCode()) + " constructed");
     }
 
     @Override

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCursorController.java
@@ -48,7 +48,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * to add an external {@link GVRCursorController} to the framework.
  */
 public abstract class GVRCursorController {
-    private static final String TAG = GVRCursorController.class.getSimpleName();
+    private static final String TAG = "GVRCursorController";
     private static int uniqueControllerId = 0;
     private final int controllerId;
     private final GVRControllerType controllerType;
@@ -341,6 +341,7 @@ public abstract class GVRCursorController {
      *                    {@link GVRCursorController}.
      */
     protected void setMotionEvent(MotionEvent motionEvent) {
+        Log.d(TAG, "setting motion event; motionEvent " + (null != motionEvent));
         synchronized (eventLock) {
             this.motionEvent.add(motionEvent);
         }


### PR DESCRIPTION
debug-level logging to try track down an issue with an app where input stops working

for the next release will add a proguard rule to strip out all Log.d calls in release builds