### PR TITLE
Fix for cases where the Oculus backend may end up rendering to a portrait-oriented surface

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
@@ -145,6 +145,29 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
     public void onSetScript() {
         mSurfaceView = new GLSurfaceView(mActivity);
 
+        final DisplayMetrics metrics = new DisplayMetrics();
+        mActivity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        final VrAppSettings appSettings = mActivity.getAppSettings();
+        int defaultWidthPixels = Math.max(metrics.widthPixels, metrics.heightPixels);
+        int defaultHeightPixels = Math.min(metrics.widthPixels, metrics.heightPixels);
+        final int frameBufferWidth = appSettings.getFramebufferPixelsWide();
+        final int frameBufferHeight = appSettings.getFramebufferPixelsHigh();
+        final SurfaceHolder holder = mSurfaceView.getHolder();
+        holder.setFormat(PixelFormat.TRANSLUCENT);
+
+        if ((-1 != frameBufferHeight) && (-1 != frameBufferWidth)) {
+            if ((defaultWidthPixels != frameBufferWidth) && (defaultHeightPixels != frameBufferHeight)) {
+                Log.v(TAG, "--- window configuration ---");
+                Log.v(TAG, "--- width: %d", frameBufferWidth);
+                Log.v(TAG, "--- height: %d", frameBufferHeight);
+                //a different resolution of the native window requested
+                defaultWidthPixels = frameBufferWidth;
+                defaultHeightPixels = frameBufferHeight;
+                Log.v(TAG, "----------------------------");
+            }
+        }
+        holder.setFixedSize(defaultWidthPixels, defaultHeightPixels);
+
         mSurfaceView.setPreserveEGLContextOnPause(true);
         mSurfaceView.setEGLContextClientVersion(3);
         mSurfaceView.setEGLContextFactory(mContextFactory);
@@ -154,27 +177,6 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
         mSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
 
         mActivity.setContentView(mSurfaceView);
-
-        final DisplayMetrics metrics = new DisplayMetrics();
-        mActivity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
-        final VrAppSettings appSettings = mActivity.getAppSettings();
-        final int screenWidthPixels = Math.max(metrics.widthPixels, metrics.heightPixels);
-        final int screenHeightPixels = Math.min(metrics.widthPixels, metrics.heightPixels);
-        final int frameBufferWidth = appSettings.getFramebufferPixelsWide();
-        final int frameBufferHeight = appSettings.getFramebufferPixelsHigh();
-        final SurfaceHolder holder = mSurfaceView.getHolder();
-        holder.setFormat(PixelFormat.TRANSLUCENT);
-
-        if ((-1 != frameBufferHeight) && (-1 != frameBufferWidth)) {
-            if ((screenWidthPixels != frameBufferWidth) && (screenHeightPixels != frameBufferHeight)) {
-                Log.v(TAG, "--- window configuration ---");
-                Log.v(TAG, "--- width: %d", frameBufferWidth);
-                Log.v(TAG, "--- height: %d", frameBufferHeight);
-                //a different resolution of the native window requested
-                holder.setFixedSize((int) frameBufferWidth, (int) frameBufferHeight);
-                Log.v(TAG, "----------------------------");
-            }
-        }
     }
 
     private final EGLContextFactory mContextFactory = new EGLContextFactory() {

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
@@ -15,19 +15,6 @@
 
 package org.gearvrf;
 
-import java.util.Arrays;
-import java.util.concurrent.CountDownLatch;
-
-import javax.microedition.khronos.egl.EGL10;
-import javax.microedition.khronos.egl.EGLConfig;
-import javax.microedition.khronos.egl.EGLContext;
-import javax.microedition.khronos.egl.EGLDisplay;
-import javax.microedition.khronos.egl.EGLSurface;
-import javax.microedition.khronos.opengles.GL10;
-
-import org.gearvrf.utility.Log;
-import org.gearvrf.utility.VrAppSettings;
-
 import android.content.pm.PackageManager;
 import android.graphics.PixelFormat;
 import android.opengl.EGL14;
@@ -41,6 +28,19 @@ import android.util.DisplayMetrics;
 import android.view.Choreographer;
 import android.view.Choreographer.FrameCallback;
 import android.view.SurfaceHolder;
+
+import org.gearvrf.utility.Log;
+import org.gearvrf.utility.VrAppSettings;
+
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+
+import javax.microedition.khronos.egl.EGL10;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.egl.EGLContext;
+import javax.microedition.khronos.egl.EGLDisplay;
+import javax.microedition.khronos.egl.EGLSurface;
+import javax.microedition.khronos.opengles.GL10;
 
 /**
  * Keep Oculus-specifics here
@@ -118,7 +118,6 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
             mVrApiInitialized = true;
         }
 
-        startChoreographerThreadIfNotStarted();
         if (null != mSurfaceView) {
             mSurfaceView.onResume();
         }
@@ -181,7 +180,7 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
     private final EGLContextFactory mContextFactory = new EGLContextFactory() {
         @Override
         public void destroyContext(final EGL10 egl, final EGLDisplay display, final EGLContext context) {
-            Log.v(TAG, "EGLContextFactory.destroyContext");
+            Log.v(TAG, "EGLContextFactory.destroyContext 0x%X", context.hashCode());
             egl.eglDestroyContext(display, context);
         }
 
@@ -199,6 +198,7 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
                 throw new IllegalStateException("eglCreateContext failed; egl error 0x"
                         + Integer.toHexString(egl.eglGetError()));
             }
+            Log.v(TAG, "EGLContextFactory.createContext 0x%X", context.hashCode());
             return context;
         }
     };
@@ -206,8 +206,10 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
     private final EGLWindowSurfaceFactory mWindowSurfaceFactory = new EGLWindowSurfaceFactory() {
         @Override
         public void destroySurface(final EGL10 egl, final EGLDisplay display, final EGLSurface surface) {
-            Log.v(TAG, "EGLWindowSurfaceFactory.destroySurface " + Integer.toHexString(surface.hashCode()));
-            egl.eglDestroySurface(display, surface);
+            Log.v(TAG, "EGLWindowSurfaceFactory.destroySurface 0x%X, mPixelBuffer 0x%X", surface.hashCode(), mPixelBuffer.hashCode());
+            boolean result = egl.eglDestroySurface(display, mPixelBuffer);
+            Log.v(TAG, "EGLWindowSurfaceFactory.destroySurface successful %b, egl error 0x%x", result, egl.eglGetError());
+            mPixelBuffer = null;
         }
 
         @Override
@@ -223,7 +225,7 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
                 throw new IllegalStateException("Pixel buffer surface not created; egl error 0x"
                         + Integer.toHexString(egl.eglGetError()));
             }
-            Log.v(TAG, "EGLWindowSurfaceFactory.createWindowSurface : " + Integer.toHexString(mPixelBuffer.hashCode()));
+            Log.v(TAG, "EGLWindowSurfaceFactory.eglCreatePbufferSurface 0x%X", mPixelBuffer.hashCode());
             return mPixelBuffer;
         }
     };
@@ -326,6 +328,7 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
             mChoreographerThread.quitSafely();
             try {
                 mChoreographerThread.join();
+                Log.i(TAG, "stopChoreographerThread done");
             } catch (final Exception ignored) {
             } finally {
                 mChoreographerThread = null;
@@ -334,11 +337,18 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
     }
 
     private void destroySurfaceForTimeWarp() {
+        final EGL10 egl = (EGL10) EGLContext.getEGL();
+        final EGLDisplay display = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
+        final EGLContext context = egl.eglGetCurrentContext();
+
+        if (!egl.eglMakeCurrent(display, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_SURFACE, context)) {
+            Log.v(TAG, "destroySurfaceForTimeWarp makeCurrent NO_SURFACE failed, egl error 0x%x", egl.eglGetError());
+        }
+
         if (null != mMainSurface) {
-            Log.v(TAG, "destroying mMainSurface: 0x%x", mMainSurface.hashCode());
-            final EGL10 egl = (EGL10) EGLContext.getEGL();
-            final EGLDisplay display = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
-            egl.eglDestroySurface(display, mMainSurface);
+            boolean result = egl.eglDestroySurface(display, mMainSurface);
+            Log.v(TAG, "destroySurfaceForTimeWarp destroyed mMainSurface: 0x%x, successful %b, egl error 0x%x",
+                    mMainSurface.hashCode(), result, egl.eglGetError());
             mMainSurface = null;
         }
     }
@@ -359,10 +369,13 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
         public void onSurfaceChanged(final GL10 gl, final int width, final int height) {
             Log.i(TAG, "onSurfaceChanged; %d x %d", width, height);
 
-            if (null != mMainSurface) {
-                Log.v(TAG, "short-circuiting onSurfaceChanged");
+            if (width < height) {
+                Log.v(TAG, "short-circuiting onSurfaceChanged; surface in portrait");
                 return;
             }
+
+            nativeLeaveVrMode(mPtr);
+            destroySurfaceForTimeWarp();
 
             final EGL10 egl = (EGL10) EGLContext.getEGL();
             final EGLDisplay display = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
@@ -396,12 +409,12 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
 
             // this is the display surface timewarp will hijack
             mMainSurface = egl.eglCreateWindowSurface(display, mConfig, mSurfaceView.getHolder(), configAttribs);
-            Log.v(TAG, "mMainSurface: 0x%x", mMainSurface.hashCode());
-
             if (mMainSurface == EGL10.EGL_NO_SURFACE) {
                 throw new IllegalStateException(
                         "eglCreateWindowSurface() failed: 0x" + Integer.toHexString(egl.eglGetError()));
             }
+
+            Log.v(TAG, "mMainSurface: 0x%x", mMainSurface.hashCode());
             if (!egl.eglMakeCurrent(display, mMainSurface, mMainSurface, context)) {
                 throw new IllegalStateException(
                         "eglMakeCurrent() failed: 0x " + Integer.toHexString(egl.eglGetError()));
@@ -442,9 +455,7 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
 
     private static native int nativeUninitializeVrApi(long ptr);
 
-    private static final int VRAPI_INITIALIZE_SUCCESS = 0;
     private static final int VRAPI_INITIALIZE_UNKNOWN_ERROR = -1;
-    private static final int VRAPI_INITIALIZE_PERMISSIONS_ERROR = -2;
 
     private static final String TAG = "OvrVrapiActivityHandler";
 }


### PR DESCRIPTION
- fixes leaked egl surfaces
- gradle: publishNonDefault to ensure apps use the correct build variant
of the libraries (not always release like it is by default)

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>