### PR TITLE
Do not publish non-default variants in case the uploadArchives task has been specified

### DIFF
--- a/GVRf/Framework/backend_daydream/build.gradle
+++ b/GVRf/Framework/backend_daydream/build.gradle
@@ -12,6 +12,7 @@ repositories {
 }
 
 android {
+    publishNonDefault !gradle.getStartParameter().taskNames.contains('uploadArchives')
     compileSdkVersion 21
     buildToolsVersion '25.0.2'
 

--- a/GVRf/Framework/backend_oculus/build.gradle
+++ b/GVRf/Framework/backend_oculus/build.gradle
@@ -7,6 +7,7 @@ repositories {
 }
 
 android {
+    publishNonDefault !gradle.getStartParameter().taskNames.contains('uploadArchives')
     compileSdkVersion 24
     buildToolsVersion '25.0.2'
 

--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -7,6 +7,7 @@ repositories {
 }
 
 android {
+    publishNonDefault !gradle.getStartParameter().taskNames.contains('uploadArchives')
     compileSdkVersion 24
     buildToolsVersion '25.0.2'
 


### PR DESCRIPTION
The uploadArchives task uploads artifacts to the maven server and uploads -debug and -release variants of the aar if non default publishing is enabled; this is incompatible with the dependency
specifications we use.