### PR TITLE
3DCursorLibrary: use the default implementation for the controller device removal

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorInputManager.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorInputManager.java
@@ -92,9 +92,7 @@ class CursorInputManager {
         public void onCursorControllerRemoved(GVRCursorController gvrCursorController) {
             // remove from list
             IoDevice removedIoDevice = null;
-            //TODO: Ignore the controller for now. Not yet implemented
-            if (gvrCursorController.getControllerType() == GVRControllerType.EXTERNAL ||
-                    gvrCursorController.getControllerType() == GVRControllerType.CONTROLLER) {
+            if (gvrCursorController.getControllerType() == GVRControllerType.EXTERNAL) {
                 return;
             }
             synchronized (lock) {


### PR DESCRIPTION
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>