### PR TITLE
X3D: use better minification filter for textures

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
@@ -1036,6 +1036,7 @@ public class X3Dobject {
                     gvrTextureParameters = new GVRTextureParameters(gvrContext);
                     gvrTextureParameters.setWrapSType(TextureWrapType.GL_REPEAT);
                     gvrTextureParameters.setWrapTType(TextureWrapType.GL_REPEAT);
+                    gvrTextureParameters.setMinFilterType(GVRTextureParameters.TextureFilterType.GL_LINEAR_MIPMAP_NEAREST);
 
                     String urlAttribute = attributes.getValue("url");
                     if (urlAttribute != null) {


### PR DESCRIPTION
It used to be GL_LINEAR.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>