### PR TITLE
3DCursorLibrary: eliminate a singleton causing the input to not work on some S8s

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorInputManager.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorInputManager.java
@@ -28,14 +28,13 @@ import java.util.List;
 
 class CursorInputManager {
     private static final String TAG = CursorInputManager.class.getSimpleName();
-    private static CursorInputManager inputManager;
     private GVRInputManager gvrInputManager;
     private List<IoDeviceListener> ioDeviceListeners;
     private List<IoDevice> availableIoDevices;
     private List<IoDevice> unavailableIoDevices;
     private static final Object lock = new Object();
 
-    private CursorInputManager(GVRContext context) {
+    CursorInputManager(GVRContext context) {
         gvrInputManager = context.getInputManager();
         availableIoDevices = new ArrayList<IoDevice>();
         unavailableIoDevices = new ArrayList<IoDevice>();
@@ -45,15 +44,6 @@ class CursorInputManager {
             IoDevice ioDevice = IoDeviceLoader.getIoDevice(gvrController);
             addIoDevice(ioDevice);
         }
-    }
-
-    //TODO fix the odd singleton pattern
-    static CursorInputManager getInstance(GVRContext context) {
-        if (inputManager == null) {
-            inputManager = new CursorInputManager(context);
-            return inputManager;
-        }
-        return inputManager;
     }
 
     List<IoDevice> getAvailableIoDevices() {

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorManager.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/CursorManager.java
@@ -146,7 +146,7 @@ public final class CursorManager {
         }
         this.scene = scene;
         this.context = context;
-        this.inputManager = CursorInputManager.getInstance(context);
+        this.inputManager = new CursorInputManager(context);
         activationListeners = new ArrayList<CursorActivationListener>();
         globalSettings = GlobalSettings.getInstance();
         themes = new HashMap<String, CursorTheme>();


### PR DESCRIPTION
On Tom's S8 two activities could get created in a quick succession on launching Erik's app. The second activity adds cursor controller listeners to the wrong instances of the cursor controllers due to the caching by the singleton.

I could reproduce the problem by first locking the screen then launching the app from the launcher. Was happening for me 50% of times.

I think it is possible to end up with two cursors (gaze+mouse) but that would be a different problem. The input would work though.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>