### PR TITLE
framework: stop the fw thread from onDestroy

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContext.java
@@ -723,17 +723,6 @@ public abstract class GVRContext implements IEventReceiver {
         mHandler.post(runnable);
     }
 
-    @Override
-    public void finalize() throws Throwable {
-        try {
-            if (null != mHandlerThread) {
-                mHandlerThread.getLooper().quitSafely();
-            }
-        } finally {
-            super.finalize();
-        }
-    }
-
     /**
      * Show a toast-like message for 3 seconds
      *
@@ -819,6 +808,12 @@ public abstract class GVRContext implements IEventReceiver {
         GVRReference reference;
         while (null != (reference = (GVRReference)mReferenceQueue.poll())) {
             reference.close();
+        }
+    }
+
+    void onDestroy() {
+        if (null != mHandlerThread) {
+            mHandlerThread.getLooper().quitSafely();
         }
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -76,6 +76,7 @@ abstract class GVRViewManager extends GVRContext {
         mFrameListeners.clear();
         mRunnables.clear();
         mRunnablesPostRender.clear();
+        super.onDestroy();
     }
 
     public GVREventManager getEventManager() {


### PR DESCRIPTION
leaking a GVRContext is too easy and common so just stop it from onDestroy

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>