### PR TITLE
[DockListener] separated addDockListener from the constructor

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -149,6 +149,7 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
 
     private void onConfigure(final String dataFilename) {
         mConfigurationManager = mDelegate.makeConfigurationManager(this);
+        mConfigurationManager.addDockListener(this);
         mConfigurationManager.configureForHeadset(GVRConfigurationManager.DEFAULT_HEADSET_MODEL);
         mDelegate.parseXmlSettings(getAssets(), dataFilename);
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRConfigurationManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRConfigurationManager.java
@@ -43,6 +43,9 @@ abstract class GVRConfigurationManager {
 
         mResetFovY = (0 == Float.compare(0, activity.getAppSettings().getEyeBufferParams().getFovY()));
 
+    }
+
+    protected void addDockListener(GVRActivity activity) {
         activity.addDockListener(new GVRActivity.DockListener() {
             @Override
             public void onDock() {
@@ -53,8 +56,8 @@ abstract class GVRConfigurationManager {
             public void onUndock() {
             }
         });
-    }
 
+    }
     private final Runnable mUsbCheckRunnable = new Runnable() {
         private final static int MAX_TRIES = 50;
         private int mCounter;


### PR DESCRIPTION
    - changed it so that constructor won't call it. Instead it's called separately.

Signed-off-by: Sean Yoon <sukhwan.y@samsung.com>