### PR TITLE
framework: add do_not_package_for_plugins that disables building a zip file for the plugins

### DIFF
--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -170,7 +170,9 @@ tasks.whenTaskAdded { task ->
     } else if (task.name == 'bundleDebug') {
         task.finalizedBy(copyJarToBin)
     } else if (task.name == 'bundleRelease') {
-        task.finalizedBy(packageForPlugins)
+        if (!rootProject.hasProperty("do_not_package_for_plugins")) {
+            task.finalizedBy(packageForPlugins)
+        }
         task.finalizedBy(copyJarToBin)
     }
 }


### PR DESCRIPTION
Saves 2-3 seconds off every build

---

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>