### PR TITLE
framework: add an app theme that disables the so called preview window

### DIFF
--- a/GVRf/Framework/framework/src/main/res/values/styles.xml
+++ b/GVRf/Framework/framework/src/main/res/values/styles.xml
@@ -30,8 +30,10 @@
     </style>
 
     <!-- Application theme. -->
-    <style name="AppTheme" parent="AppBaseTheme">
-        <!-- All customizations that are NOT specific to a particular API-level can go here. -->
+    <style name="GVRfAppTheme" parent="AppBaseTheme">
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowBackground">@color/black</item>
     </style>
 
+    <color name="black">#000000</color>
 </resources>


### PR DESCRIPTION
- the white screen with a titlebar that flashes when launching gvr-immersivepedia will be gone; the app will not launch faster but the transition to it can be smoother in case you happen to launch it while wearing the headset
- windowBackground might not be necessary but just in case

Dependent pull request: https://github.com/gearvrf/GearVRf-Demos/pull/462