### PR TITLE
Update SensorEvents API to supply new picking information

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/LaserCursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/LaserCursor.java
@@ -19,6 +19,7 @@ package org.gearvrf.io.cursor3d;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRCursorController;
 import org.gearvrf.GVRCursorController.ControllerEventListener;
+import org.gearvrf.GVRPicker;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.SensorEvent;
 import org.gearvrf.io.cursor3d.CursorAsset.Action;
@@ -48,7 +49,8 @@ class LaserCursor extends Cursor {
         cursorEvent.setColliding(COLLIDING);
         cursorEvent.setActive(event.isActive());
         cursorEvent.setCursor(this);
-        GVRSceneObject object = event.getObject();
+        GVRPicker.GVRPickedObject pickedObject = event.getPickedObject();
+        GVRSceneObject object = pickedObject.getHitObject();
         SelectableGroup selectableGroup = (SelectableGroup) object.getComponent
                 (SelectableGroup.getComponentType());
 
@@ -61,7 +63,7 @@ class LaserCursor extends Cursor {
         }
 
         cursorEvent.setObject(object);
-        cursorEvent.setHitPoint(event.getHitX(), event.getHitY(), event.getHitZ());
+        cursorEvent.setHitPoint(pickedObject.getHitX(), pickedObject.getHitY(), pickedObject.getHitZ());
         cursorEvent.setCursorPosition(getPositionX(), getPositionY(), getPositionZ());
         cursorEvent.setCursorRotation(getRotationW(), getRotationX(), getRotationY(),
                 getRotationZ());

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursor.java
@@ -23,6 +23,7 @@ import android.view.MotionEvent;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRCursorController;
 import org.gearvrf.GVRCursorController.ControllerEventListener;
+import org.gearvrf.GVRPicker;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.SensorEvent;
 import org.gearvrf.io.cursor3d.CursorAsset.Action;
@@ -47,7 +48,8 @@ class ObjectCursor extends Cursor {
 
     @Override
     void dispatchSensorEvent(SensorEvent event) {
-        GVRSceneObject object = event.getObject();
+        GVRPicker.GVRPickedObject pickedObject = event.getPickedObject();
+        GVRSceneObject object = pickedObject.getHitObject();
 
         GVRCursorController controller = event.getCursorController();
         isControllerActive = event.isActive();
@@ -74,12 +76,12 @@ class ObjectCursor extends Cursor {
         }
 
         if (object != null && colliding) {
-            createAndSendCursorEvent(object, true, event.getHitX(), event.getHitY(),
-                    event.getHitZ(), true, event.isActive(),
+            createAndSendCursorEvent(object, true, pickedObject.getHitX(), pickedObject.getHitY(),
+                    pickedObject.getHitZ(), true, event.isActive(),
                     event.getCursorController().getKeyEvent(), controller.getMotionEvents());
         } else {
-            createAndSendCursorEvent(object, false, event.getHitX(), event.getHitY(),
-                    event.getHitZ(), event.isOver(), event.isActive(),
+            createAndSendCursorEvent(object, false, pickedObject.getHitX(), pickedObject.getHitY(),
+                    pickedObject.getHitZ(), event.isOver(), event.isActive(),
                     event.getCursorController().getKeyEvent(), controller.getMotionEvents());
         }
     }

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/BaseView.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/BaseView.java
@@ -29,6 +29,7 @@ import android.view.View;
 import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRBaseSensor;
 import org.gearvrf.GVRContext;
+import org.gearvrf.GVRPicker;
 import org.gearvrf.GVRScene;
 import org.gearvrf.ISensorEvents;
 import org.gearvrf.SensorEvent;
@@ -113,6 +114,7 @@ abstract class BaseView {
         @Override
         public void onSensorEvent(final SensorEvent event) {
             int id = event.getCursorController().getId();
+            GVRPicker.GVRPickedObject pickedObject = event.getPickedObject();
 
             if (id != settingsCursorId || !sensorEnabled) {
                 return;
@@ -126,10 +128,10 @@ abstract class BaseView {
                         sendSwipeEvent(keyEvent);
                         continue;
                     }
-                    sendMotionEvent(event.getHitX(), event.getHitY(), keyEvent.getAction());
+                    sendMotionEvent(pickedObject.getHitX(), pickedObject.getHitY(), keyEvent.getAction());
                 }
             } else {
-                sendMotionEvent(event.getHitX(), event.getHitY(), MotionEvent.ACTION_MOVE);
+                sendMotionEvent(pickedObject.getHitX(), pickedObject.getHitY(), MotionEvent.ACTION_MOVE);
             }
         }
     };

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBaseSensor.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBaseSensor.java
@@ -25,10 +25,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Create an instance of this class to receive {@link SensorEvent}s whenever an

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBaseSensor.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBaseSensor.java
@@ -27,6 +27,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -89,19 +90,17 @@ public class GVRBaseSensor {
         getControllerData(controller).setActive(active);
     }
 
-    void addSceneObject(GVRCursorController controller, GVRSceneObject object,
-            float hitX, float hitY, float hitZ) {
+    void addPickedObject(GVRCursorController controller, GVRPicker.GVRPickedObject pickedObject) {
         ControllerData data = getControllerData(controller);
-        Set<GVRSceneObject> prevHits = data.getPrevHits();
+        Map<GVRSceneObject, GVRPicker.GVRPickedObject> prevHits = data.getPrevHits();
         List<SensorEvent> newHits = data.getNewHits();
 
-        if (prevHits.contains(object)) {
-            prevHits.remove(object);
+        if (prevHits.containsKey(pickedObject.hitObject)) {
+            prevHits.remove(pickedObject.hitObject);
         }
 
         SensorEvent event = SensorEvent.obtain();
-        event.setObject(object);
-        event.setHitPoint(hitX, hitY, hitZ);
+        event.setPickedObject(pickedObject);
         event.setOver(true);
         newHits.add(event);
     }
@@ -110,18 +109,16 @@ public class GVRBaseSensor {
         final List<SensorEvent> events = new ArrayList<SensorEvent>();
 
         ControllerData data = getControllerData(controller);
-        Set<GVRSceneObject> prevHits = data.getPrevHits();
+        Map<GVRSceneObject, GVRPicker.GVRPickedObject> prevHits = data.getPrevHits();
         List<SensorEvent> newHits = data.getNewHits();
 
         // process the previous hit objects to set isOver to false.
         if (prevHits.isEmpty() == false) {
-            for (GVRSceneObject object : prevHits) {
+            for (GVRPicker.GVRPickedObject object : prevHits.values()) {
                 SensorEvent event = SensorEvent.obtain();
                 event.setActive(data.getActive());
                 event.setCursorController(controller);
-                event.setObject(object);
-                // clear the hit point
-                event.setHitPoint(EMPTY_HIT_POINT[0], EMPTY_HIT_POINT[1], EMPTY_HIT_POINT[2]);
+                event.setPickedObject(object);
                 event.setOver(false);
                 events.add(event);
             }
@@ -132,10 +129,11 @@ public class GVRBaseSensor {
 
         if (newHits.isEmpty() == false) {
             for (SensorEvent event : newHits) {
+                GVRPicker.GVRPickedObject pickedObject = event.getPickedObject();
                 event.setActive(data.getActive());
                 event.setCursorController(controller);
                 events.add(event);
-                prevHits.add(event.getObject());
+                prevHits.put(pickedObject.hitObject, pickedObject);
             }
             newHits.clear();
         }
@@ -243,12 +241,12 @@ public class GVRBaseSensor {
      * {@link GVRCursorController} on a given {@link GVRBaseSensor}.
      */
     private static class ControllerData {
-        private Set<GVRSceneObject> prevHits;
+        private Map<GVRSceneObject, GVRPicker.GVRPickedObject> prevHits;
         private List<SensorEvent> newHits;
         private boolean active;
 
         public ControllerData() {
-            prevHits = new HashSet<GVRSceneObject>();
+            prevHits = new HashMap<GVRSceneObject, GVRPicker.GVRPickedObject>();
             newHits = new ArrayList<SensorEvent>();
         }
 
@@ -256,7 +254,7 @@ public class GVRBaseSensor {
             this.active = active;
         }
 
-        public Set<GVRSceneObject> getPrevHits() {
+        public Map<GVRSceneObject, GVRPicker.GVRPickedObject> getPrevHits() {
             return prevHits;
         }
 
@@ -327,8 +325,9 @@ public class GVRBaseSensor {
 
         void updateDepthCache(List<SensorEvent> events) {
             for(SensorEvent sensorEvent: events) {
-                modelMatrix.set(sensorEvent.getObject().getTransform().getModelMatrix());
-                hitPoint.set(sensorEvent.getHitX(), sensorEvent.getHitY(), sensorEvent.getHitZ());
+                modelMatrix.set(sensorEvent.getPickedObject().getHitObject().getTransform().getModelMatrix());
+                GVRPicker.GVRPickedObject pickedObject = sensorEvent.getPickedObject();
+                hitPoint.set(pickedObject.getHitX(), pickedObject.getHitY(), pickedObject.getHitZ());
                 hitPoint.mulPosition(modelMatrix);
                 float depth = hitPoint.distance(0,0,0);
                 depthCache.put(sensorEvent, depth);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorEvent.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorEvent.java
@@ -33,7 +33,7 @@ public class SensorEvent {
     private static final String TAG = SensorEvent.class.getSimpleName();
     private boolean isActive;
     private boolean isOver;
-    private GVRSceneObject object;
+    private GVRPicker.GVRPickedObject pickedObject;
     private GVRCursorController controller;
     private EventGroup eventGroup;
 
@@ -102,10 +102,9 @@ public class SensorEvent {
     private static int recyclerUsed;
     private static SensorEvent recyclerTop;
     private SensorEvent next;
-    private Vector3f hitPoint;
 
     SensorEvent(){
-        hitPoint = new Vector3f();
+
     }
 
     /**
@@ -130,30 +129,19 @@ public class SensorEvent {
     }
 
     /**
-     * Set the coordinates of the intersection between the input ray and the
-     * affected object with the {@link GVRBaseSensor}.
-     *
-     * @param hitX X co-ordinate of the hit point
-     * @param hitY Y co-ordinate of the hit point
-     * @param hitZ Z co-ordinate of the hit point
-     */
-    void setHitPoint(float hitX, float hitY, float hitZ) {
-        hitPoint.set(hitX, hitY, hitZ);
-    }
-
-    /**
-     * The {@link GVRSceneObject} that triggered this {@link SensorEvent}.
+     * Set the picking information for the {@link GVRSceneObject} that
+     * triggered this {@link SensorEvent}.
      * 
-     * @param object
-     *            The affected object.
+     * @param pickedObject
+     *            The picking information of the affected {@link GVRSceneObject}.
      */
-    void setObject(GVRSceneObject object) {
-        this.object = object;
+    void setPickedObject(GVRPicker.GVRPickedObject pickedObject) {
+        this.pickedObject = pickedObject;
     }
 
     /**
      * This flag denotes that the {@link GVRCursorController} "is over" the
-     * affected object.
+     * affected pickedObject.
      * 
      * @param isOver
      *            The value of the "is over" flag.
@@ -163,18 +151,18 @@ public class SensorEvent {
     }
 
     /**
-     * Use this call to retrieve the affected object.
+     * Use this call to retrieve the picking information of the
+     * affected {@link GVRSceneObject}.
      * 
-     * @return The affected {@link GVRSceneObject} that caused this
-     *         {@link SensorEvent} to be triggered.
+     * @return The {@link GVRPicker.GVRPickedObject} corresponding to the {@link GVRSceneObject}
+     *         that caused this {@link SensorEvent} to be triggered.
      */
-    public GVRSceneObject getObject() {
-        return object;
+    public GVRPicker.GVRPickedObject getPickedObject() {
+        return pickedObject;
     }
 
     /**
      * Use this flag to detect if the input "is over" the {@link GVRSceneObject}
-     * .
      * 
      * @return <code>true</code> if the input is over the corresponding
      *         {@link GVRSceneObject}. The {@link ISensorEvents} delivers
@@ -184,58 +172,6 @@ public class SensorEvent {
      */
     public boolean isOver() {
         return isOver;
-    }
-
-    /**
-     * Get the X component of the hit point.
-     *
-     * The values returned by this call persist only for the duration of the
-     * {@link ISensorEvents#onSensorEvent(SensorEvent)} call. Make sure to make a copy of this
-     * value if you wish to use it past its lifetime.
-     *
-     * @return 'X' component of the hit point.
-     */
-    public float getHitX() {
-        return hitPoint.x;
-    }
-
-    /**
-     * Get the 'Y' component of the hit point.
-     *
-     * The values returned by this call persist only for the duration of the
-     * {@link ISensorEvents#onSensorEvent(SensorEvent)} call. Make sure to make a copy of this
-     * value if you wish to use it past its lifetime.
-     *
-     * @return 'Y' component of the hit point.
-     */
-    public float getHitY() {
-        return hitPoint.y;
-    }
-
-    /**
-     * Get the 'Z' component of the hit point.
-     * The values returned by this call persist only for the duration of the
-     * {@link ISensorEvents#onSensorEvent(SensorEvent)} call. Make sure to make a copy of this
-     * value if you wish to use it past its lifetime.
-     *
-     * @return 'Z' component of the hit point.
-     */
-    public float getHitZ() {
-        return hitPoint.z;
-    }
-
-    /**
-     * Returns the hit point of the input and the affected
-     * {@link GVRSceneObject}
-     *
-     * @return The coordinates where the input intersects with the
-     * {@link GVRSceneObject}.
-     * @deprecated Returns a new float array every call which may lead to
-     * frequent GC cycles. Use the more efficient call to {{@link #getHitX()}},
-     * {{@link #getHitY()}} and {{@link #getHitZ()}}.
-     */
-    public float[] getHitPoint() {
-        return new float[]{hitPoint.x, hitPoint.y, hitPoint.z};
     }
 
     /**

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/SensorManager.java
@@ -18,12 +18,10 @@ package org.gearvrf;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.gearvrf.GVRCursorController.ActiveState;
-import org.gearvrf.utility.Log;
 import org.joml.Vector3f;
 
 /**
@@ -121,15 +119,17 @@ class SensorManager {
 
         // Well at least we are not comparing against all scene objects.
         if (objectSensor != null && objectSensor.isEnabled() && object.isEnabled()
-                & object.hasMesh()) {
+                && object.hasMesh()) {
+            GVRPicker.GVRPickedObject pickedObject;
+            if(object.getCollider() != null)
+                pickedObject = GVRPicker.pickSceneObject(object, origin.x, origin.y, origin.z, ray.x, ray.y, ray.z);
+            else {
+                GVRPicker.pickSceneObjectAgainstBoundingBox(object, origin.x, origin.y, origin.z, ray.x, ray.y, ray.z, readbackBufferB);
+                pickedObject = new GVRPicker.GVRPickedObject(object, new float[]{readbackBuffer.get(0), readbackBuffer.get(1), readbackBuffer.get(2)});
+            }
 
-            boolean result = GVRPicker.pickSceneObjectAgainstBoundingBox(
-                    object, origin.x, origin.y, origin.z, ray.x, ray.y, ray.z, readbackBufferB);
-
-            if (result) {
-                objectSensor.addSceneObject(controller, object, readbackBuffer.get(0),
-                        readbackBuffer.get(1), readbackBuffer.get(2)
-                );
+            if (pickedObject != null) {
+                objectSensor.addPickedObject(controller, pickedObject);
 
                 // if we are doing an active search and we find one.
                 if (markActiveNodes) {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnchorImplementation.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnchorImplementation.java
@@ -500,7 +500,7 @@ public class AnchorImplementation {
                         // only go through once even if object is clicked a long time
                         uiObjectIsActive = !uiObjectIsActive;
                         if (uiObjectIsActive) {
-                            if (event.getHitX() > cubeUISize.x / 4.0f) {
+                            if (event.getPickedObject().getHitX() > cubeUISize.x / 4.0f) {
                                 // Delete the WebView page, control currently far right of web page
                                 gvrContext.unregisterDrawFrameListener(mOnDrawFrame);
                                 if (gvrTextScaleObject != null) {
@@ -522,10 +522,10 @@ public class AnchorImplementation {
                                 gvrWebView = null;
                                 webPagePlusUISceneObject = null;
                                 webPageActive = false;
-                            } else if (event.getHitX() > 0) {
+                            } else if (event.getPickedObject().getHitX() > 0) {
                                 // TODO: Rotate the web view, control currently right side of control bar
                                 webViewTranslation = false;
-                            } else if (event.getHitX() > -cubeUISize.x / 4.0f) {
+                            } else if (event.getPickedObject().getHitX() > -cubeUISize.x / 4.0f) {
                                 // Translate the web view, control currently left side of control bar
                                 TranslationControl(gvrWebViewSceneObjectFinal);
                             }   // end transltion web window, hit between 0 and .25,
@@ -538,16 +538,16 @@ public class AnchorImplementation {
                             if (mOnDrawFrame != null)
                                 // wrap up any lose ends closing the web page.
                                 gvrContext.unregisterDrawFrameListener(mOnDrawFrame);
-                            if (event.getHitX() > 0) {
+                            if (event.getPickedObject().getHitX() > 0) {
                                 // TODO: Stop Rotating the web page
-                            } else if (event.getHitX() > -cubeUISize.x / 4.0f) {
+                            } else if (event.getPickedObject().getHitX() > -cubeUISize.x / 4.0f) {
                                 // Stop translating the web page
                                 if (gvrTextTranslationObject != null) {
                                     gvrTextTranslationObject.setTextColor(textColorIsOver);
                                 }
                                 webViewTranslation = false;
                             }   // end transltion web window, hit between 0 and .25,
-                            else if (event.getHitX() < -cubeUISize.x / 4.0f) {
+                            else if (event.getPickedObject().getHitX() < -cubeUISize.x / 4.0f) {
                                 // Stop scaling the web page
                                 if (gvrTextScaleObject != null) {
                                     gvrTextScaleObject.setTextColor(textColorIsOver);
@@ -558,7 +558,7 @@ public class AnchorImplementation {
                     }
                 } else if (event.isOver() && !uiObjectIsActive) {
                     // highlight the icons to give visual cue to users
-                    if (event.getHitX() > cubeUISize.x / 4.0f) {
+                    if (event.getPickedObject().getHitX() > cubeUISize.x / 4.0f) {
                         if (gvrTextExitObject != null)
                             gvrTextExitObject.setTextColor(textColorIsOver);
                         if (gvrTextRotateObject != null)
@@ -569,7 +569,7 @@ public class AnchorImplementation {
                             gvrTextScaleObject.setTextColor(textColorDefault);
                         webViewTranslation = false;
                         webViewScale = false;
-                    } else if (event.getHitX() > 0) {
+                    } else if (event.getPickedObject().getHitX() > 0) {
                         if (gvrTextExitObject != null) gvrTextExitObject.setTextColor(textColorDefault);
                         if (gvrTextRotateObject != null) gvrTextRotateObject.setTextColor(textColorIsOver);
                         if (gvrTextTranslationObject != null) gvrTextTranslationObject.setTextColor(textColorDefault);
@@ -577,7 +577,7 @@ public class AnchorImplementation {
                         webViewTranslation = false;
                         webViewScale = false;
                     }  // end scaling web window, hit between 0 and .25,
-                    else if (event.getHitX() > -cubeUISize.x / 4.0f) {
+                    else if (event.getPickedObject().getHitX() > -cubeUISize.x / 4.0f) {
                         if (gvrTextExitObject != null) gvrTextExitObject.setTextColor(textColorDefault);
                         if (gvrTextRotateObject != null) gvrTextRotateObject.setTextColor(textColorDefault);
                         if (gvrTextTranslationObject != null) gvrTextTranslationObject.setTextColor(textColorIsOver);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
@@ -587,7 +587,7 @@ public class AnimationInteractivityManager {
                                                 .IS_ACTIVE))) {
                                     if (!isRunning) {
                                         isRunning = true;
-                                        interactiveObjectFinal.getSensor().setHitPoint(event.getHitPoint());
+                                        interactiveObjectFinal.getSensor().setHitPoint(event.getPickedObject().getHitLocation());
                                         gvrKeyFrameAnimationFinal.start(gvrContext.getAnimationEngine())
                                                 .setOnFinish(new GVROnFinish() {
                                                     @Override


### PR DESCRIPTION
This update modifies the SensorEvents API to

1.  Use an object's respective collider for picking, rather than defaulting to picking against a bounding box
2.  Supply GVRPickedObject in SensorEvent instances instead of only a float[3] HitLocation

The modification to use a SceneObject's collider reflects the fact that a developer chooses a collider according to how accurately they wish to raycast at an object. For less accurate, but also less expensive raycasting, a developer may attach a box or sphere collider. For an object with complex geometry (holes, curves, or oblong appearance), a mesh collider may be more appropriate.  Furthermore, a mesh collider can be attached to an object to supply more picking information (such as that introduced by #1232) , while still maintaining low cost picking (think about picking the texture coordinates of a quad, which only has two faces to process). 

Since all picking information is already passed around in the form of a GVRPickedObject, I believe it makes more sense to supply this in SensorEvents rather than only storing the HitLocation.  Also, I removed the storage of the GVRSceneObject since the picked GVRSceneObject is supplied in GVRPickedObject instances.