### PR TITLE
autogenerate layout for Bones uniforms 

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderManager.java
@@ -83,6 +83,25 @@ public class GVRShaderManager extends GVRHybridObject
     }
 
     /**
+     * Make a string with the shader layout for a uniform block
+     * with a given descriptor. The format of the descriptor is
+     * the same as for a @{link GVRShaderData} - a string of
+     * types and names of each field.
+     * <p>
+     * This function will return a Vulkan shader layout if the
+     * Vulkan renderer is being used. Otherwise, it returns
+     * an OpenGL layout.
+     * @param descriptor string with types and names of each field
+     * @param blockName  name of uniform block
+     * @param useUBO     true to output uniform buffer layout, false for push constants
+     * @return string with shader declaration
+     */
+    static String makeLayout(String descriptor, String blockName, boolean useUBO)
+    {
+        return NativeShaderManager.makeLayout(descriptor, blockName, useUBO);
+    }
+
+    /**
      * Maps the shader template class to the instance of the template.
      * Only one shader template of each class is necessary since
      * shaders are global.
@@ -98,4 +117,5 @@ class NativeShaderManager {
                                 String vertexShader, String fragmentShader);
     static native void bindCalcMatrix(long shaderManager, int nativeShader, Class<? extends GVRShader> javaShaderClass);
     static native int getShader(long shaderManager, String signature);
+    static native String makeLayout(String descriptor, String blockName, boolean useUBO);
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderTemplate.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderTemplate.java
@@ -377,8 +377,7 @@ public class GVRShaderTemplate extends GVRShader
         combinedSource = combinedSource.replace("@ShaderName", getClass().getSimpleName());
         combinedSource = combinedSource.replace("@LIGHTSOURCES", lightShaderSource);
         combinedSource = combinedSource.replace("@MATERIAL_UNIFORMS", material.makeShaderLayout());
-        combinedSource = replaceBones(combinedSource);
-
+        combinedSource = combinedSource.replace("@BONES_UNIFORMS", GVRShaderManager.makeLayout(sBonesDescriptor, "Bones_ubo", true));
         if (type.equals("Vertex"))
         {
             String texcoordSource = assignTexcoords(material);

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
@@ -64,9 +64,13 @@ namespace gvr
     }
 
     UniformBlock *GLRenderer::createUniformBlock(const char* desc, int binding,
-                                                 const char* name)
+                                                 const char* name, int maxelems)
     {
-        return new GLUniformBlock(desc, binding, name);
+        if (maxelems <= 1)
+        {
+            return new GLUniformBlock(desc, binding, name);
+        }
+        return new GLUniformBlock(desc, binding, name, maxelems);
     }
 
     Image *GLRenderer::createImage(int type, int format)
@@ -158,7 +162,7 @@ namespace gvr
         else
             desc = " mat4 u_view; mat4 u_mvp; mat4 u_mv; mat4 u_mv_it; mat4 u_model; mat4 u_view_i; float u_right;";
         transform_ubo_ = reinterpret_cast<GLUniformBlock*>
-                            (createUniformBlock(desc, TRANSFORM_UBO_INDEX, "Transform_ubo"));
+                            (createUniformBlock(desc, TRANSFORM_UBO_INDEX, "Transform_ubo", 0));
         transform_ubo_->useGPUBuffer(false);
     }
 

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.h
@@ -92,24 +92,24 @@ public:
     void makeShadowMaps(Scene* scene, ShaderManager* shader_manager);
 
     // Specific to GL
-     void renderCamera(Scene* scene, Camera* camera, int framebufferId,
+    void renderCamera(Scene* scene, Camera* camera, int framebufferId,
             int viewportX, int viewportY, int viewportWidth, int viewportHeight,
             ShaderManager* shader_manager,
             PostEffectShaderManager* post_effect_shader_manager,
             RenderTexture* post_effect_render_texture_a,
             RenderTexture* post_effect_render_texture_b);
 
-     void renderCamera(Scene* scene, Camera* camera,
+    void renderCamera(Scene* scene, Camera* camera,
             RenderTexture* render_texture, ShaderManager* shader_manager,
             PostEffectShaderManager* post_effect_shader_manager,
             RenderTexture* post_effect_render_texture_a,
             RenderTexture* post_effect_render_texture_b);
 
-     void set_face_culling(int cull_face);
+    void set_face_culling(int cull_face);
     virtual RenderPass* createRenderPass();
     virtual ShaderData* createMaterial(const char* uniform_desc, const char* texture_desc);
     virtual RenderData* createRenderData();
-    virtual UniformBlock* createUniformBlock(const char* desc, int binding, const char* name);
+    virtual UniformBlock* createUniformBlock(const char* desc, int binding, const char* name, int maxelems);
     virtual Image* createImage(int type, int format);
     virtual Texture* createTexture(int target = GL_TEXTURE_2D);
     virtual RenderTexture* createRenderTexture(int width, int height, int sample_count, int layers);

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
@@ -120,7 +120,7 @@ public:
      }
      virtual ShaderData* createMaterial(const char* uniform_desc, const char* texture_desc) = 0;
      virtual RenderData* createRenderData() = 0;
-     virtual UniformBlock* createUniformBlock(const char* desc, int, const char* name) = 0;
+     virtual UniformBlock* createUniformBlock(const char* desc, int, const char* name, int) = 0;
      virtual Image* createImage(int type, int format) = 0;
         virtual RenderPass* createRenderPass() = 0;
      virtual Texture* createTexture(int target = GL_TEXTURE_2D) = 0;

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/vulkan_renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/vulkan_renderer.cpp
@@ -46,8 +46,12 @@ namespace gvr {
     RenderPass* VulkanRenderer::createRenderPass(){
         return new VulkanRenderPass();
     }
-    UniformBlock* VulkanRenderer::createUniformBlock(const char* desc, int binding, const char* name)
+    UniformBlock* VulkanRenderer::createUniformBlock(const char* desc, int binding, const char* name, int maxelems)
     {
+        if (maxelems <= 1)
+        {
+            return new VulkanUniformBlock(desc, binding, name);
+        }
         return new VulkanUniformBlock(desc, binding, name);
     }
 

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/vulkan_renderer.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/vulkan_renderer.h
@@ -119,7 +119,7 @@ public:
     virtual ShaderData* createMaterial(const char* uniform_desc, const char* texture_desc);
     virtual RenderData* createRenderData();
     virtual RenderPass* createRenderPass();
-    virtual UniformBlock* createUniformBlock(const char* desc, int binding, const char* name);
+    virtual UniformBlock* createUniformBlock(const char* desc, int binding, const char* name, int maxelems);
     Image* createImage(int type, int format);
     virtual Texture* createTexture(int target = GL_TEXTURE_2D);
     virtual RenderTexture* createRenderTexture(int width, int height, int sample_count,

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_shader.cpp
@@ -283,10 +283,16 @@ std::string GLShader::makeLayout(const DataDescriptor& desc, const char* blockNa
     std::ostringstream stream;
     if (useGPUBuffer)
     {
-        stream << "\nlayout (std140) uniform " << blockName << " {" << std::endl;
+        stream << "\nlayout (std140) uniform " << blockName << std::endl << "{" << std::endl;
         desc.forEachEntry([&stream](const DataDescriptor::DataEntry& entry) mutable
         {
-            stream << "   " << entry.Type << " " << entry.Name << ";" << std::endl;
+            int nelems = entry.Count;
+            stream << "   " << entry.Type << " " << entry.Name;
+            if (nelems > 1)
+            {
+                stream << "[" << nelems << "]";
+            }
+            stream << ";" << std::endl;
         });
         stream << "};" << std::endl;
     }
@@ -296,7 +302,13 @@ std::string GLShader::makeLayout(const DataDescriptor& desc, const char* blockNa
         {
             if (entry.IsSet)
             {
-                stream << "uniform " << entry.Type << " " << entry.Name << ";" << std::endl;
+                int nelems = entry.Count;
+                stream << "uniform " << entry.Type << " " << entry.Name;
+                if (nelems > 1)
+                {
+                    stream << "[" << nelems << "]";
+                }
+                stream << ";" << std::endl;
             }
         });
     }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_uniform_block.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_uniform_block.cpp
@@ -16,10 +16,16 @@
 #include "gl/gl_shader.h"
 
 namespace gvr {
-    GLUniformBlock::GLUniformBlock(const char* descriptor, int bindingPoint, const char* blockName) :
-            UniformBlock(descriptor, bindingPoint, blockName),
-            GLOffset(0),
-            GLBuffer(0)
+    GLUniformBlock::GLUniformBlock(const char* descriptor, int bindingPoint, const char* blockName)
+      : UniformBlock(descriptor, bindingPoint, blockName),
+        GLOffset(0),
+        GLBuffer(0)
+    { }
+
+    GLUniformBlock::GLUniformBlock(const char* descriptor, int bindingPoint, const char* blockName, int maxelems)
+      : UniformBlock(descriptor, bindingPoint, blockName, maxelems),
+        GLOffset(0),
+        GLBuffer(0)
     { }
 
     GLUniformBlock::~GLUniformBlock()
@@ -39,7 +45,7 @@ namespace gvr {
             {
                 glGenBuffers(1, &GLBuffer);
                 glBindBuffer(GL_UNIFORM_BUFFER, GLBuffer);
-                glBufferData(GL_UNIFORM_BUFFER, getTotalSize(), NULL, GL_DYNAMIC_DRAW);
+                glBufferData(GL_UNIFORM_BUFFER, mElemSize * mMaxElems, NULL, GL_DYNAMIC_DRAW);
                 mIsDirty = true;
             }
             if (mIsDirty)

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_uniform_block.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_uniform_block.cpp
@@ -51,7 +51,7 @@ namespace gvr {
             if (mIsDirty)
             {
                 glBindBufferBase(GL_UNIFORM_BUFFER, mBindingPoint, GLBuffer);
-                glBufferSubData(GL_UNIFORM_BUFFER, GLOffset, getTotalSize(), getData());
+                glBufferSubData(GL_UNIFORM_BUFFER, GLOffset, mElemSize * mNumElems, getData());
                 mIsDirty = false;
                 if (Shader::LOG_SHADER)
                     LOGV("UniformBlock::updateGPU %s size %d\n", getBlockName(), getTotalSize());

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_uniform_block.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_uniform_block.h
@@ -20,7 +20,8 @@
 
 #include "objects/uniform_block.h"
 
-namespace gvr {
+namespace gvr
+{
 
 /**
  * Manages a Uniform Block containing data parameters to pass to
@@ -29,35 +30,37 @@ namespace gvr {
  * The UniformBlock may be updated by the application. If it has changed,
  * GearVRf resends the entire data block to OpenGL.
  */
-class GLUniformBlock : public UniformBlock
-{
-public:
-    GLUniformBlock(const char* descriptor, int bindingPoint, const char* blockName);
-    virtual ~GLUniformBlock();
+    class GLUniformBlock : public UniformBlock
+    {
+    public:
+        GLUniformBlock(const char *descriptor, int bindingPoint, const char *blockName);
+        GLUniformBlock(const char *descriptor, int bindingPoint, const char *blockName, int maxelems);
 
-    /**
-     * Copy the data from CPU into the OpenGL uniform buffer.
-     */
-    virtual bool updateGPU(Renderer*);
+        virtual ~GLUniformBlock();
 
-    /*
-     * Bind the uniform buffer to the OpenGL shader
-     */
-    virtual bool bindBuffer(Shader*, Renderer*);
+        /**
+         * Copy the data from CPU into the OpenGL uniform buffer.
+         */
+        virtual bool updateGPU(Renderer *);
 
-    virtual std::string makeShaderLayout();
+        /*
+         * Bind the uniform buffer to the OpenGL shader
+         */
+        virtual bool bindBuffer(Shader *, Renderer *);
 
-    /**
-     * Dump the contents of the shader uniforms to the log.
-     * @param programID OpenGL program ID for shader
-     * @param blockIndex OpenGL binding point
-     */
-    static void dump(GLuint programID, int blockIndex);
+        virtual std::string makeShaderLayout();
 
-protected:
-    GLuint      GLBuffer;
-    GLuint      GLOffset;
-};
+        /**
+         * Dump the contents of the shader uniforms to the log.
+         * @param programID OpenGL program ID for shader
+         * @param blockIndex OpenGL binding point
+         */
+        static void dump(GLuint programID, int blockIndex);
+
+    protected:
+        GLuint GLBuffer;
+        GLuint GLOffset;
+    };
 
 }
 #endif

--- a/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.cpp
@@ -94,9 +94,9 @@ namespace gvr
             {
                 ++p;                    // indicates unused field
             }
-            while (std::isalnum(*p) || (*p == '_'))
+            while (std::isalnum(*p) || (*p == '_') || (*p == '[') || (*p == ']'))
             {
-                ++p;                    // names are alphanumeric, _ allowed
+                ++p;                    // names are alphanumeric, _ allowed, [] for arrays
             }
             name_size = p - name_start;
             if (name_size == 0)
@@ -110,22 +110,15 @@ namespace gvr
         }
     }
 
-    const char* DataDescriptor::addName(const char* name, DataEntry& entry)
+    const char* DataDescriptor::addName(const char* name, int len, DataEntry& entry)
     {
-        int len = strlen(name);
-        int n = mLayout.size();
-
         if (len > 62)
         {
             len = 62;
-            strncpy(entry.Name, name, len);
-            entry.Name[62] = 0;
             LOGE("DataDescriptor: %s too long, truncated to %s", name, entry.Name);
         }
-        else
-        {
-            strcpy(entry.Name, name);
-        }
+        strncpy(entry.Name, name, len);
+        entry.Name[len] = 0;
         entry.NameLength = (char) len;
         return entry.Name;
     }
@@ -153,27 +146,30 @@ namespace gvr
             int array_size = 1;
             const char* p = name;
             const char* bracket = strchr(name, '[');
+            size_t namelen = strlen(name);
 
             if (name == NULL)
             {
                 LOGE("UniformBlock: SYNTAX ERROR: expecting uniform name\n");
                 return;
             }
-            if (bracket)
+            if (bracket)                // parse array size in brackets
             {
+                namelen = bracket - name;
+                array_size = 0;
                 p += (bracket - name) + 1;
                 while (std::isdigit(*p))
                 {
-                    array_size = array_size * 10 + (*p - '0');
+                    int v = *p - '0';
+                    array_size = array_size * 10 + v;
                     ++p;
                 }
-                ++p;
             }
             DataEntry entry;
             short byteSize = calcSize(type);
 
-            entry.Type = makeShaderType(type, byteSize, array_size);
-            byteSize *= array_size;
+            entry.Type = makeShaderType(type, byteSize);
+            byteSize *= array_size;     // multiply by number of array elements
             entry.IsSet = false;
             entry.Count = array_size;
             entry.NotUsed = false;
@@ -183,12 +179,12 @@ namespace gvr
             entry.Offset = mTotalSize;
             entry.Size = byteSize;
 
-            if (*name == '!')
+            if (*name == '!')           // ! indicates entry not used by shader
             {
                 entry.NotUsed = true;
                 ++name;
             }
-            addName(name, entry);
+            addName(name, namelen, entry);
             mLayout.push_back(entry);
             LOGV("DataDescriptor: %s offset=%d size=%d\n", name, entry.Offset, entry.Size);
             mTotalSize = entry.Offset + entry.Size;
@@ -199,7 +195,7 @@ namespace gvr
         }
     }
 
-    std::string DataDescriptor::makeShaderType(const char* type, int byteSize, int arraySize)
+    std::string DataDescriptor::makeShaderType(const char* type, int byteSize)
     {
         std::ostringstream stream;
 
@@ -221,10 +217,6 @@ namespace gvr
         else
         {
             stream << type;
-        }
-        if (arraySize > 1)
-        {
-            stream << "[" << arraySize << "]";
         }
         return stream.str();
     }

--- a/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.h
@@ -139,7 +139,7 @@ public:
      */
     bool isDirty() const { return mIsDirty; }
     virtual void markDirty() { mIsDirty = true; }
-    virtual std::string makeShaderType(const char* type, int byteSize, int arraySize);
+    virtual std::string makeShaderType(const char* type, int byteSize);
 
     /**
      * Calculate the byte size of the given type.
@@ -154,7 +154,7 @@ protected:
      */
     virtual void parseDescriptor();
 
-    const char* addName(const char* name, DataEntry& entry);
+    const char* addName(const char* name, int len, DataEntry& entry);
     int findName(const char* name) const;
 
     mutable bool mIsDirty;          // true if data in block has changed since last render

--- a/GVRf/Framework/framework/src/main/jni/objects/mesh.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/mesh.h
@@ -93,16 +93,7 @@ namespace gvr {
 
         void setBones(std::vector<Bone*>&& bones)
         {
-            const void* vertexData = vertexBoneData_.boneData.data();
-            int numVerts = vertexBoneData_.boneData.size();
             vertexBoneData_.setBones(std::move(bones));
-            if ((bones.size() > 0) && (numVerts > 0))
-            {
-                mVertices->setFloatVec("a_bone_weights", static_cast<const float*>(vertexData) + 4,
-                                       8 * numVerts, 8);
-                mVertices->setIntVec("a_bone_indices", static_cast<const int*>(vertexData),
-                                     8 * numVerts, 8);
-            }
         }
 
         VertexBoneData &getVertexBoneData()

--- a/GVRf/Framework/framework/src/main/jni/objects/mesh.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/mesh.h
@@ -93,7 +93,16 @@ namespace gvr {
 
         void setBones(std::vector<Bone*>&& bones)
         {
+            const void* vertexData = vertexBoneData_.boneData.data();
+            int numVerts = vertexBoneData_.boneData.size();
             vertexBoneData_.setBones(std::move(bones));
+            if ((bones.size() > 0) && (numVerts > 0))
+            {
+                mVertices->setFloatVec("a_bone_weights", static_cast<const float*>(vertexData) + 4,
+                                       8 * numVerts, 8);
+                mVertices->setIntVec("a_bone_indices", static_cast<const int*>(vertexData),
+                                     8 * numVerts, 8);
+            }
         }
 
         VertexBoneData &getVertexBoneData()

--- a/GVRf/Framework/framework/src/main/jni/objects/uniform_block.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/uniform_block.cpp
@@ -371,6 +371,7 @@ namespace gvr
             if (dest)
             {
                 memcpy(dest, srcData, mElemSize * numElems);
+                markDirty();
                 return true;
             }
         }

--- a/GVRf/Framework/framework/src/main/jni/objects/uniform_block.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/uniform_block.cpp
@@ -25,11 +25,15 @@ namespace gvr
             mBlockName(blockName),
             mOwnData(false),
             mUseBuffer(true),
+            mNumElems(0),
+            mMaxElems(1),
             mBindingPoint(bindingPoint),
             mUniformData(NULL)
     {
         if (mTotalSize > 0)
         {
+            mElemSize = mTotalSize;
+            mNumElems = 1;
             mTotalSize = (mTotalSize + 15) & ~0x0F;
             mUniformData = new char[mTotalSize];
             memset(mUniformData, 0, mTotalSize);
@@ -41,7 +45,6 @@ namespace gvr
             LOGE("UniformBlock: ERROR: no uniform block allocated\n");
         }
     }
-
 
     bool UniformBlock::setInt(const char* name, int val)
     {
@@ -323,6 +326,82 @@ namespace gvr
             os << ';' << std::endl;
         });
         return os.str();
+    }
+
+    UniformBlock::UniformBlock(const char *descriptor, int bindingPoint, const char *blockName, int maxElems)
+    :   DataDescriptor(descriptor),
+        mBlockName(blockName),
+        mOwnData(false),
+        mUseBuffer(true),
+        mBindingPoint(bindingPoint),
+        mUniformData(NULL)
+    {
+        mElemSize = mTotalSize;
+        mMaxElems = maxElems;
+        if (blockName)
+        {
+            mBlockName = blockName;
+        }
+        if ((mElemSize > 0) && (maxElems > 0))
+        {
+            mMaxElems = mNumElems = maxElems;
+            mTotalSize = mElemSize * maxElems;
+            mUniformData = new char[mTotalSize];
+            mOwnData = true;
+        }
+    }
+
+    bool UniformBlock::setNumElems(int numElems)
+    {
+        if ((numElems < 0) || (numElems > mMaxElems))
+        {
+            return false;
+        }
+        mNumElems = numElems;
+        mTotalSize = mNumElems * mElemSize;
+        return true;
+    }
+
+
+    bool UniformBlock::setRange(int elemIndex, const void* srcData, int numElems)
+    {
+        if ((elemIndex + numElems) <= mMaxElems)
+        {
+            char* dest = (char*) getDataAt(elemIndex);
+            if (dest)
+            {
+                memcpy(dest, srcData, mElemSize * numElems);
+                return true;
+            }
+        }
+        LOGE("UniformBlock::setRange ERROR %d out of range, maximum is %d", elemIndex + numElems, mMaxElems);
+        return false;
+    }
+
+    bool UniformBlock::setAt(int elemIndex, UniformBlock& srcBlock)
+    {
+        if ((elemIndex >= 0) &&
+            (elemIndex < mMaxElems) &&
+            (srcBlock.getTotalSize() == mElemSize))
+        {
+            const char* src = (const char*) srcBlock.getData();
+            memcpy(mUniformData + mElemSize * elemIndex, src, mElemSize);
+            return true;
+        }
+        LOGE("UniformBlock::setAt ERROR %d out of range, maximum is %d", elemIndex, mMaxElems);
+        return false;
+    }
+
+    const char* UniformBlock::getDataAt(int elemIndex)
+    {
+        if (mUniformData &&
+            (elemIndex >= 0) &&
+            (elemIndex < mMaxElems))
+        {
+            return mUniformData + (mElemSize * elemIndex);
+        }
+        LOGE("UniformBlock::getDataAt ERROR %d out of range, maximum is %d", elemIndex, mMaxElems);
+        return NULL;
     }
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/uniform_block.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/uniform_block.h
@@ -29,10 +29,13 @@
 #define BONES_UBO_INDEX     2
 #define SAMPLER_UBO_INDEX   3
 
-namespace gvr {
-class SceneObject;
-class Shader;
-class Renderer;
+namespace gvr
+{
+    class SceneObject;
+
+    class Shader;
+
+    class Renderer;
 
 /**
  * Manages a Uniform Block containing data parameters to pass to
@@ -51,303 +54,328 @@ class Renderer;
  * @see GLUniformBlock
  * @see VulkanUniformBlock
  */
-class UniformBlock : public DataDescriptor
-{
-public:
-    UniformBlock(const char* descriptor, int binding_point, const char* blockName);
-
-    /**
-     * Gets the OpenGL binding point for this uniform block.
-     * @return GL binding point or -1 if not set
-     */
-    int getBindingPoint() const
+    class UniformBlock : public DataDescriptor
     {
-        return mBindingPoint;
-    }
+    public:
+        UniformBlock(const char *descriptor, int binding_point, const char *blockName);
+        UniformBlock(const char *descriptor, int binding_point, const char *blockName, int maxElems);
 
-    /**
-     * Enables or disabled the use of a GPU uniform buffer.
-      */
-    void useGPUBuffer(bool flag)    { mUseBuffer = flag; }
-
-    /**
-     * Determines if a GPU buffer is used for this uniform block
-     * or if it uses immediate mode to update the GPU.
-     * @return true if GPU buffer used, else false
-     */
-    bool usesGPUBuffer() const      { return mUseBuffer; }
-
-     /**
-     * Get the name of the uniform block.
-     * This name should be set by the caller to be the same
-     * as the name used for the block in the shader.
-     * @returns uniform block name or NULL if not set.
-     * @see #setBlockName
-     */
-    const char* getBlockName() const { return mBlockName.c_str(); }
-
-    /**
-     * Set the value of an integer uniform.
-     * If the named uniform is not an "int" in the descriptor
-     * this function will fail and log an error.
-     * @param name name of uniform to set.
-     * @param val integer value to set.
-     * @returns true if successfully set, false on error.
-     * @see getInt
-     */
-    virtual bool setInt(const char*, int val);
-
-    /**
-     * Set the value of a floating point uniform.
-     * If the named uniform is not a "float" in the descriptor
-     * this function will fail and log an error.
-     * @param name name of uniform to set.
-     * @param val float value to set.
-     * @returns true if successfully set, false on error.
-     * @see getFloat
-     */
-    virtual bool setFloat(const char*, float val);
-
-    /**
-     * Set the value of an integer vector uniform.
-     * If the named uniform is not an int vector in the descriptor
-     * of the proper size this function will fail and log an error.
-     * @param name name of uniform to set.
-     * @param val pointer to integer vector.
-     * @param n number of integers in the vector.
-     * @returns true if successfully set, false on error.
-     * @see getIntVec
-     */
-    virtual bool setIntVec(const char* name, const int* val, int n);
-
-    /**
-     * Set the value of a floating point vector uniform.
-     * If the named uniform is not a float vector in the descriptor
-     * of the proper size this function will fail and log an error.
-     * @param name name of uniform to set.
-     * @param val pointer to float vector.
-     * @param n number of floats in the vector.
-     * @returns true if successfully set, false on error.
-     * @see getVec
-     */
-    virtual bool setFloatVec(const char* name, const float* val, int n);
-
-    /**
-     * Set the value of a 2D vector uniform.
-     * If the named uniform is not a "float2" in the descriptor
-     * this function will fail and log an error.
-     * @param name name of uniform to set.
-     * @param val 2D vector value to set.
-     * @returns true if successfully set, false on error.
-     * @see setVec
-     * @see getVec
-     * @see getVec2
-     */
-    virtual bool setVec2(const char* name, const glm::vec2& val);
-
-    /**
-     * Set the value of a 3D vector uniform.
-     * If the named uniform is not a "float3" in the descriptor
-     * this function will fail and log an error.
-     * @param name name of uniform to set.
-     * @param val 3D vector value to set.
-     * @returns true if successfully set, false on error.
-     * @see setVec
-     * @see getVec
-     * @see getVec3
-     */
-    virtual bool setVec3(const char* name, const glm::vec3& val);
-
-    /**
-     * Set the value of a 4D vector uniform.
-     * If the named uniform is not a "float4" in the descriptor
-     * this function will fail and log an error.
-     * @param name name of uniform to set.
-     * @param val 4D vector value to set.
-     * @returns true if successfully set, false on error.
-     * @see getVec
-     * @see setVec
-     * @see getVec4
-     */
-    virtual bool setVec4(const char* name, const glm::vec4& val);
-
-    /**
-     * Set the value of a 4x4 matrix uniform.
-     * If the named uniform is not a "mat4" in the descriptor
-     * this function will fail and log an error.
-     * @param name name of uniform to set.
-     * @param val 4x4 matrix value to set.
-     * @see setMat4
-     * @see setVec
-     * @see getVec
-     */
-    virtual bool setMat4(const char* name,  const glm::mat4& val);
-
-    /**
-     * Get the value of a 2D vector uniform.
-     * If the named uniform is not a 2D vector this function
-     * will return null.
-     * @param name name of uniform to get.
-     * @returns pointer to 2D vector or NULL if uniform not found.
-     * @see setVec2
-     * @see setVec
-     * @see getVec
-     */
-    virtual const glm::vec2* getVec2(const char* name) const;
-
-    /**
-     * Get the value of a 3D vector uniform.
-     * If the named uniform is not a 3D vector this function
-     * will return null.
-     * @param name name of uniform to get.
-     * @returns pointer to 3D vector or NULL if uniform not found.
-     * @see getVec
-     * @see setVec3
-     * @see setVec
-     */
-    virtual const glm::vec3* getVec3(const char* name) const;
-
-    /**
-     * Get the value of a 4D vector uniform.
-     * If the named uniform is not a 4D vector this function
-     * will return null.
-     * @param name name of uniform to get.
-     * @returns pointer to 4D vector or NULL if uniform not found.
-     * @see getVec
-     * @see setVec4
-     * @see setVec
-     */
-    virtual const glm::vec4* getVec4(const char* name) const;
-
-    /**
-     * Get the value of a 4x4 matrix uniform.
-     * If the named uniform is not a 4x4 matrix this function
-     * will return false.
-     * @param name name of uniform to get.
-     * @returns true if matrix found, false if not.
-     * @see getVec
-     * @see setMat4
-     * @see setVec
-     */
-    virtual bool getMat4(const char*, glm::mat4& val) const;
-
-    /**
-     * Get the value of a floating po2int uniform.
-     * If the named uniform is not a "float" in the descriptor
-     * this function returns 0 and logs an error.
-     * @param name name of uniform to get.
-     * @param v where to store float value.
-     * @returns true if value found, else false.
-     * @see setVec
-     * @see getVec
-     * @see setFloat
-     */
-    virtual bool getFloat(const char* name, float& v) const;
-
-    /**
-     * Get the value of an integer uniform.
-     * If the named uniform is not "inat" in the descriptor
-     * this function returns 0 and logs an error.
-     * @param name name of uniform to get.
-     * @param v where to store integer value.
-     * @returns true if value found, else false.
-     * @see setVec
-     * @see getVec
-     * @see setInt
-     */
-    virtual bool getInt(const char* name, int& v) const;
-
-    /**
-     * Get the value of a float vector uniform.
-     * If the named uniform is not a float vector
-     * of the proper size this function will return null.
-     * @param name name of uniform to get.
-     * @param val pointer to float array to get value.
-     * @param n number of floats in the array.
-     * @return true if vector retrieved, false if not found or size is wrong.
-     * @see setVec
-     */
-    virtual bool getFloatVec(const char* name, float* val, int n) const;
-
-    /**
-     * Get the value of an integer vector uniform.
-     * If the named uniform is not an int vector
-     * of the proper size this function will return null.
-     * @param name name of uniform to get.
-     * @param val pointer to float array to get value.
-     * @param n number of ints in the array.
-     * @return true if vector retrieved, false if not found or size is wrong.
-     * @see setVec
-     */
-    virtual bool getIntVec(const char* name, int* val, int n) const;
-
-    /**
-     * Copy the data from the CPU into the GPU.
-     * If useGPUBuffer is enabled, the data is copied into a uniform
-     * buffer in the GPU. Otherwise immediate mode is used to
-     * copy the data to the graphics driver.
-     */
-    virtual bool updateGPU(Renderer*) = 0;
-
-    /**
-     * Bind the uniform block to a shader
-     */
-    virtual bool bindBuffer(Shader*, Renderer*) = 0;
-
-    virtual ~UniformBlock()
-    {
-        if ((mUniformData != NULL) && mOwnData)
+        /**
+         * Gets the OpenGL binding point for this uniform block.
+         * @return GL binding point or -1 if not set
+         */
+        int getBindingPoint() const
         {
-            delete [] mUniformData;
+            return mBindingPoint;
         }
-        mUniformData = NULL;
-    }
 
-    /**
-     * Returns a string with the names and offsets
-     * of all the uniforms in the block.
-     * @return string describing the uniform block.
-     */
-    std::string toString();
-
-    /**
-     * Get a pointer to the entire uniform data area.
-     * @returns -> uniform block data if it exists, else NULL
-     */
-    const void* getData() { return mUniformData; }
-
-    virtual std::string makeShaderLayout();
-
-protected:
-
-    /**
-     * Constructs the data block containing the values
-     * for all the uniform variables in the descriptor.
-     */
-    void  makeData()
-    {
-        if (mUniformData == NULL)
+        /**
+         * Enables or disabled the use of a GPU uniform buffer.
+          */
+        void useGPUBuffer(bool flag)
         {
-            mUniformData = new char[mTotalSize];
-            mOwnData = true;
+            mUseBuffer = flag;
         }
-    }
 
-    /**
-     * Get a pointer to the value for the named uniform.
-     * @param name name of uniform to get.
-     * @param bytesize number of bytes uniform occupies
-     * @return pointer to start of uniform value or NULL if not found.
-     */
-    char* getData(const char* name, int& bytesize);
-    const char* getData(const char* name, int& bytesize) const;
+        /**
+         * Determines if a GPU buffer is used for this uniform block
+         * or if it uses immediate mode to update the GPU.
+         * @return true if GPU buffer used, else false
+         */
+        bool usesGPUBuffer() const
+        {
+            return mUseBuffer;
+        }
 
-    int          mBindingPoint;      // shader binding point
-    unsigned int mOwnData : 1;      // true if this uniform block owns its data
-    unsigned int mUseBuffer : 1;    // true if this uniform block uses a GPU buffer
-    std::string  mBlockName;         // name of the block in the shader
-    char*        mUniformData;       // -> data block with uniform values
-};
+        /**
+        * Get the name of the uniform block.
+        * This name should be set by the caller to be the same
+        * as the name used for the block in the shader.
+        * @returns uniform block name or NULL if not set.
+        * @see #setBlockName
+        */
+        const char *getBlockName() const
+        {
+            return mBlockName.c_str();
+        }
 
+        /**
+         * Set the value of an integer uniform.
+         * If the named uniform is not an "int" in the descriptor
+         * this function will fail and log an error.
+         * @param name name of uniform to set.
+         * @param val integer value to set.
+         * @returns true if successfully set, false on error.
+         * @see getInt
+         */
+        virtual bool setInt(const char *, int val);
+
+        /**
+         * Set the value of a floating point uniform.
+         * If the named uniform is not a "float" in the descriptor
+         * this function will fail and log an error.
+         * @param name name of uniform to set.
+         * @param val float value to set.
+         * @returns true if successfully set, false on error.
+         * @see getFloat
+         */
+        virtual bool setFloat(const char *, float val);
+
+        /**
+         * Set the value of an integer vector uniform.
+         * If the named uniform is not an int vector in the descriptor
+         * of the proper size this function will fail and log an error.
+         * @param name name of uniform to set.
+         * @param val pointer to integer vector.
+         * @param n number of integers in the vector.
+         * @returns true if successfully set, false on error.
+         * @see getIntVec
+         */
+        virtual bool setIntVec(const char *name, const int *val, int n);
+
+        /**
+         * Set the value of a floating point vector uniform.
+         * If the named uniform is not a float vector in the descriptor
+         * of the proper size this function will fail and log an error.
+         * @param name name of uniform to set.
+         * @param val pointer to float vector.
+         * @param n number of floats in the vector.
+         * @returns true if successfully set, false on error.
+         * @see getVec
+         */
+        virtual bool setFloatVec(const char *name, const float *val, int n);
+
+        /**
+         * Set the value of a 2D vector uniform.
+         * If the named uniform is not a "float2" in the descriptor
+         * this function will fail and log an error.
+         * @param name name of uniform to set.
+         * @param val 2D vector value to set.
+         * @returns true if successfully set, false on error.
+         * @see setVec
+         * @see getVec
+         * @see getVec2
+         */
+        virtual bool setVec2(const char *name, const glm::vec2 &val);
+
+        /**
+         * Set the value of a 3D vector uniform.
+         * If the named uniform is not a "float3" in the descriptor
+         * this function will fail and log an error.
+         * @param name name of uniform to set.
+         * @param val 3D vector value to set.
+         * @returns true if successfully set, false on error.
+         * @see setVec
+         * @see getVec
+         * @see getVec3
+         */
+        virtual bool setVec3(const char *name, const glm::vec3 &val);
+
+        /**
+         * Set the value of a 4D vector uniform.
+         * If the named uniform is not a "float4" in the descriptor
+         * this function will fail and log an error.
+         * @param name name of uniform to set.
+         * @param val 4D vector value to set.
+         * @returns true if successfully set, false on error.
+         * @see getVec
+         * @see setVec
+         * @see getVec4
+         */
+        virtual bool setVec4(const char *name, const glm::vec4 &val);
+
+        /**
+         * Set the value of a 4x4 matrix uniform.
+         * If the named uniform is not a "mat4" in the descriptor
+         * this function will fail and log an error.
+         * @param name name of uniform to set.
+         * @param val 4x4 matrix value to set.
+         * @see setMat4
+         * @see setVec
+         * @see getVec
+         */
+        virtual bool setMat4(const char *name, const glm::mat4 &val);
+
+        /**
+         * Get the value of a 2D vector uniform.
+         * If the named uniform is not a 2D vector this function
+         * will return null.
+         * @param name name of uniform to get.
+         * @returns pointer to 2D vector or NULL if uniform not found.
+         * @see setVec2
+         * @see setVec
+         * @see getVec
+         */
+        virtual const glm::vec2 *getVec2(const char *name) const;
+
+        /**
+         * Get the value of a 3D vector uniform.
+         * If the named uniform is not a 3D vector this function
+         * will return null.
+         * @param name name of uniform to get.
+         * @returns pointer to 3D vector or NULL if uniform not found.
+         * @see getVec
+         * @see setVec3
+         * @see setVec
+         */
+        virtual const glm::vec3 *getVec3(const char *name) const;
+
+        /**
+         * Get the value of a 4D vector uniform.
+         * If the named uniform is not a 4D vector this function
+         * will return null.
+         * @param name name of uniform to get.
+         * @returns pointer to 4D vector or NULL if uniform not found.
+         * @see getVec
+         * @see setVec4
+         * @see setVec
+         */
+        virtual const glm::vec4 *getVec4(const char *name) const;
+
+        /**
+         * Get the value of a 4x4 matrix uniform.
+         * If the named uniform is not a 4x4 matrix this function
+         * will return false.
+         * @param name name of uniform to get.
+         * @returns true if matrix found, false if not.
+         * @see getVec
+         * @see setMat4
+         * @see setVec
+         */
+        virtual bool getMat4(const char *, glm::mat4 &val) const;
+
+        /**
+         * Get the value of a floating po2int uniform.
+         * If the named uniform is not a "float" in the descriptor
+         * this function returns 0 and logs an error.
+         * @param name name of uniform to get.
+         * @param v where to store float value.
+         * @returns true if value found, else false.
+         * @see setVec
+         * @see getVec
+         * @see setFloat
+         */
+        virtual bool getFloat(const char *name, float &v) const;
+
+        /**
+         * Get the value of an integer uniform.
+         * If the named uniform is not "inat" in the descriptor
+         * this function returns 0 and logs an error.
+         * @param name name of uniform to get.
+         * @param v where to store integer value.
+         * @returns true if value found, else false.
+         * @see setVec
+         * @see getVec
+         * @see setInt
+         */
+        virtual bool getInt(const char *name, int &v) const;
+
+        /**
+         * Get the value of a float vector uniform.
+         * If the named uniform is not a float vector
+         * of the proper size this function will return null.
+         * @param name name of uniform to get.
+         * @param val pointer to float array to get value.
+         * @param n number of floats in the array.
+         * @return true if vector retrieved, false if not found or size is wrong.
+         * @see setVec
+         */
+        virtual bool getFloatVec(const char *name, float *val, int n) const;
+
+        /**
+         * Get the value of an integer vector uniform.
+         * If the named uniform is not an int vector
+         * of the proper size this function will return null.
+         * @param name name of uniform to get.
+         * @param val pointer to float array to get value.
+         * @param n number of ints in the array.
+         * @return true if vector retrieved, false if not found or size is wrong.
+         * @see setVec
+         */
+        virtual bool getIntVec(const char *name, int *val, int n) const;
+
+        /**
+         * Copy the data from the CPU into the GPU.
+         * If useGPUBuffer is enabled, the data is copied into a uniform
+         * buffer in the GPU. Otherwise immediate mode is used to
+         * copy the data to the graphics driver.
+         */
+        virtual bool updateGPU(Renderer *) = 0;
+
+        /**
+         * Bind the uniform block to a shader
+         */
+        virtual bool bindBuffer(Shader *, Renderer *) = 0;
+
+        virtual ~UniformBlock()
+        {
+            if ((mUniformData != NULL) && mOwnData)
+            {
+                delete[] mUniformData;
+            }
+            mUniformData = NULL;
+        }
+
+        /**
+         * Returns a string with the names and offsets
+         * of all the uniforms in the block.
+         * @return string describing the uniform block.
+         */
+        std::string toString();
+
+        /**
+         * Get a pointer to the entire uniform data area.
+         * @returns -> uniform block data if it exists, else NULL
+         */
+        const void *getData()
+        {
+            return mUniformData;
+        }
+
+        int getNumElems() const;
+        int getMaxElems() const;
+        int getElemSize() const;
+        bool setNumElems(int numElems);
+
+        virtual std::string makeShaderLayout();
+        const char* getDataAt(int elemIndex);
+        bool setAt(int elemIndex, UniformBlock& srcBlock);
+        bool setRange(int elemIndex, const void* srcData, int numElems);
+
+    protected:
+        UniformBlock(const char *descriptor);
+
+        /**
+         * Constructs the data block containing the values
+         * for all the uniform variables in the descriptor.
+         */
+        void makeData()
+        {
+            if (mUniformData == NULL)
+            {
+                mUniformData = new char[mTotalSize];
+                mOwnData = true;
+            }
+        }
+
+        /**
+         * Get a pointer to the value for the named uniform.
+         * @param name name of uniform to get.
+         * @param bytesize number of bytes uniform occupies
+         * @return pointer to start of uniform value or NULL if not found.
+         */
+        char* getData(const char *name, int &bytesize);
+
+        const char* getData(const char *name, int &bytesize) const;
+
+        int mBindingPoint;           // shader binding point
+        unsigned int mOwnData : 1;   // true if this uniform block owns its data
+        unsigned int mUseBuffer : 1; // true if this uniform block uses a GPU buffer
+        std::string mBlockName;      // name of the block in the shader
+        char *mUniformData;          // -> data block with uniform values
+        int mElemSize;
+        int mMaxElems;
+        int mNumElems;
+    };
 }
 #endif

--- a/GVRf/Framework/framework/src/main/jni/objects/vertex_bone_data.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/vertex_bone_data.cpp
@@ -82,6 +82,17 @@ void VertexBoneData::normalizeWeights() {
             }
         }
     }
+    VertexBuffer* vbuf = mesh->getVertexBuffer();
+    const void* vertexData = boneData.data();
+    int numVerts = boneData.size();
+    if ((bones.size() > 0) && (numVerts > 0))
+    {
+        vbuf->setFloatVec("a_bone_weights", static_cast<const float*>(vertexData) + 4,
+                               8 * numVerts, 8);
+        vbuf->setIntVec("a_bone_indices", static_cast<const int*>(vertexData),
+                             8 * numVerts, 8);
+    }
+
 }
 
 } // namespace gvr

--- a/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer.cpp
@@ -459,6 +459,7 @@ namespace gvr {
         const DataEntry* attr = find(attrName);
         const float*    data = reinterpret_cast<float*>(mVertexData);
         int             stride = getVertexSize();
+        int             ofs;
 
         if ((attr == NULL) || !attr->IsSet)
         {
@@ -470,9 +471,10 @@ namespace gvr {
             LOGD("VertexBuffer: cannot find attribute %s", attrName);
             return false;
         }
+        ofs = attr->Offset / sizeof(float);
         for (int i = 0; i < mVertexCount; ++i)
         {
-            func(i, data + attr->Offset);
+            func(i, data + ofs);
             data += stride;
         }
         return true;
@@ -490,6 +492,37 @@ namespace gvr {
             {
                 float f = *v++;
                 os << std::fixed << f << " ";
+            }
+            LOGV("%s", os.str().c_str());
+        });
+    }
+
+    void VertexBuffer::dump(const char* attrName) const
+    {
+        int vsize = getVertexSize();
+        const DataEntry* attr = find(attrName);
+
+        forAllVertices(attrName, [attr](int iter, const float* vertex)
+        {
+            std::ostringstream os;
+            os.precision(3);
+            int asize = attr->Size / sizeof(float);
+            if (attr->IsInt)
+            {
+                const int* iv = (const int*) vertex;
+                for (int i = 0; i < asize; ++i)
+                {
+                    os << *iv++ << " ";
+                }
+            }
+            else
+            {
+                const float* v = vertex;
+                for (int i = 0; i < asize; ++i)
+                {
+                    float f = *v++;
+                    os << std::fixed << f << " ";
+                }
             }
             LOGV("%s", os.str().c_str());
         });

--- a/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer.cpp
@@ -55,7 +55,7 @@ namespace gvr {
                 return;
 
             DataEntry entry;
-            entry.Type = makeShaderType(type, byteSize, 1);
+            entry.Type = makeShaderType(type, byteSize);
             entry.IsSet = false;
             entry.Count = 1;
             entry.NotUsed = false;
@@ -70,7 +70,7 @@ namespace gvr {
                 entry.NotUsed = true;
                 ++name;
             }
-            addName(name, entry);
+            addName(name, strlen(name), entry);
             mLayout.push_back(entry);
             LOGV("VertexBuffer: %s index=%d offset=%d size=%d %d entries\n",
                  entry.Name, entry.Index, entry.Offset, entry.Size, mLayout.size());

--- a/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer.h
@@ -137,6 +137,7 @@ namespace gvr {
         virtual bool    updateGPU(Renderer*, IndexBuffer*, Shader*) = 0;
         virtual void    bindToShader(Shader* shader, IndexBuffer* ibuf) = 0;
         void            dump() const;
+        void            dump(const char* attrName) const;
 
     protected:
         virtual void    parseDescriptor();

--- a/GVRf/Framework/framework/src/main/jni/shaders/shader_manager_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/shader_manager_jni.cpp
@@ -19,6 +19,7 @@
 
 #include <engine/renderer/renderer.h>
 #include <vulkan/vulkan_shader.h>
+#include <gl/gl_shader.h>
 #include "shader_manager.h"
 #include "shader.h"
 #include "util/gvr_jni.h"
@@ -117,9 +118,10 @@ JNIEXPORT jstring JNICALL
 Java_org_gearvrf_NativeShaderManager_makeLayout(JNIEnv* env, jobject obj,
                                                 jstring jdescriptor, jstring jblockName, jboolean useGPUBuffer)
 {
-    const char* desc = env->GetStringUTFChars(jdescriptor, 0);
+    const char* sdesc = env->GetStringUTFChars(jdescriptor, 0);
     const char* block = env->GetStringUTFChars(jblockName, 0);
     Renderer* renderer = Renderer::getInstance();
+    DataDescriptor desc(sdesc);
     if (renderer->isVulkanInstance())
     {
         const std::string& layout = VulkanShader::makeLayout(desc, block, useGPUBuffer);
@@ -127,7 +129,7 @@ Java_org_gearvrf_NativeShaderManager_makeLayout(JNIEnv* env, jobject obj,
     }
     else
     {
-        const std::string& layout = VulkanShader::makeLayout(desc, block, useGPUBuffer);
+        const std::string& layout = GLShader::makeLayout(desc, block, useGPUBuffer);
         return env->NewStringUTF(layout.c_str());
     }
 }

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_shader.cpp
@@ -176,7 +176,15 @@ VulkanShader::~VulkanShader() { }
         desc.forEachEntry([&stream](const DataDescriptor::DataEntry& entry) mutable
         {
             if(entry.IsSet)
-                stream << "   " << entry.Type << " " << entry.Name << ";" << std::endl;
+            {
+                int nelems = entry.Count;
+                stream << "   " << entry.Type << " " << entry.Name;
+                if (nelems > 1)
+                {
+                    stream << "[" << nelems << "]";
+                }
+                stream << ";" << std::endl;
+            }
         });
         stream << "};" << std::endl;
         return stream.str();

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_uniform_block.cpp
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_uniform_block.cpp
@@ -19,8 +19,14 @@
 
 namespace gvr {
 
-    VulkanUniformBlock::VulkanUniformBlock(const char* descriptor, int bindingPoint,const char* blockName)
+    VulkanUniformBlock::VulkanUniformBlock(const char* descriptor, int bindingPoint, const char* blockName)
             : UniformBlock(descriptor, bindingPoint, blockName), vk_descriptor(nullptr)
+    {
+        vk_descriptor = new VulkanDescriptor();
+    }
+
+    VulkanUniformBlock::VulkanUniformBlock(const char* descriptor, int bindingPoint, const char* blockName, int maxelems)
+            : UniformBlock(descriptor, bindingPoint, blockName, maxelems), vk_descriptor(nullptr)
     {
         vk_descriptor = new VulkanDescriptor();
     }

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_uniform_block.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_uniform_block.h
@@ -54,6 +54,7 @@ namespace gvr {
     {
     public:
         VulkanUniformBlock(const char* descriptor, int bindingPoint,const char* blockName);
+        VulkanUniformBlock(const char* descriptor, int bindingPoint,const char* blockName, int maxelems);
         bool bindBuffer(Shader*, Renderer*) {}
         virtual bool updateGPU(Renderer*);
         virtual std::string makeShaderLayout();


### PR DESCRIPTION
Fixed bug in DataDescriptor::parseDescriptor parsing arrays
exposed GVRShaderManager.makeLayout to Java to generate Bones_ubo layout
copy vertex indices & weights in Mesh::setBones

GearVRF DCO signed off by: Nola Donato nola.donato@samsung.com