### PR TITLE
backend_oculus: fix for CameraRig::reset not working when docked

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -203,7 +203,9 @@ void GVRActivity::onDrawFrame(jobject jViewManager) {
         const ovrQuatf& orientation = updatedTracking.HeadPose.Pose.Orientation;
         const glm::quat tmp(orientation.w, orientation.x, orientation.y, orientation.z);
         const glm::quat quat = glm::conjugate(glm::inverse(tmp));
-        cameraRig_->setRotation(quat);
+
+        cameraRig_->setRotationSensorData(0, quat.w, quat.x, quat.y, quat.z, 0, 0, 0);
+        cameraRig_->updateRotation();
     } else if (nullptr != cameraRig_) {
         cameraRig_->updateRotation();
     } else {


### PR DESCRIPTION
Apparently we lost somehow the fix we made in the past.
Fix for issue https://github.com/Samsung/GearVRf/issues/1271

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>