### PR TITLE
Vulkan: Refactored shadowmap code, amended

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRDirectLight.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRDirectLight.java
@@ -273,9 +273,13 @@ public class GVRDirectLight extends GVRLightBase
     public void onDrawFrame(float frameTime)
     {
         if (!isEnabled() || (getFloat("enabled") <= 0.0f) || (owner == null)) { return; }
+        float[] odir = getVec3("world_direction");
         boolean changed = false;
         Matrix4f worldmtx = owner.getTransform().getModelMatrix4f();
 
+        mOldDir.x = odir[0];
+        mOldDir.y = odir[1];
+        mOldDir.z = odir[2];
         mNewDir.x = 0.0f;
         mNewDir.y = 0.0f;
         mNewDir.z = -1.0f;

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRLightBase.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRLightBase.java
@@ -17,24 +17,6 @@ package org.gearvrf;
 
 import static org.gearvrf.utility.Assert.*;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.nio.Buffer;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.gearvrf.GVRSceneObject;
-import org.gearvrf.utility.ImageUtils;
-import org.gearvrf.utility.ResourceCache;
-import org.gearvrf.utility.Threads;
 import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;

--- a/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
@@ -21,7 +21,6 @@
 #include "scene.h"
 
 #include "engine/exporter/exporter.h"
-#include "objects/scene_object.h"
 #include "gl/gl_material.h"
 #include "objects/components/shadow_map.h"
 


### PR DESCRIPTION
Vulkan branch port of, Refactored shadowmap code, exposed render to texture #1099, amended
Remaining parts of a big commit:
    - Update mOldDir in GVRDirectLight.onDrawFrame()
    - Remove unused imports in GVRLightBase.java
    - Remove unused include in scene.cpp
This pull request shall be 'merged' and not 'rebased'
gvr-shadows did not work before, and does not work after this change.
