### PR TITLE
Two culling calls when using monoscopic rendering mode.

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrMonoscopicViewManager.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrMonoscopicViewManager.java
@@ -142,7 +142,6 @@ class OvrMonoscopicViewManager extends OvrViewManager {
     private void drawEyes() {
         // Log.d(TAG, "drawEyes()");
         mMainScene.getMainCameraRig().updateRotation();
-        OvrMonoscopicRenderer.cull(mMainScene, mMainScene.getMainCameraRig().getCenterCamera(), mRenderBundle);
         OvrMonoscopicRenderer.renderCamera(mMainScene, mMainScene
                 .getMainCameraRig().getLeftCamera(), mViewportX, mViewportY,
                 mViewportWidth, mViewportHeight, mRenderBundle);


### PR DESCRIPTION
When using monoscopic rendering, "OVRMonoscopicViewManager" calls "beforeDrawEyes()" from "onDrawFrame()". Since this class extends from "OVRViewManager"  and it is not overriding this method , the "beforeDrawEyes()" of the "OVRViewManager" gets called, where culling takes place.  It appears as if the removed culling call in this commit is redundant because is actually causing a second cull pass to happen.