### PR TITLE
Add surface normals to picking information

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
@@ -632,7 +632,7 @@ public class GVRPicker extends GVRBehavior {
      */
     static GVRPickedObject makeHit(long colliderPointer, float distance, float hitx, float hity, float hitz,
                                    int faceIndex, float barycentricx, float barycentricy, float barycentricz,
-                                   float texu, float texv)
+                                   float texu, float texv, float normalx, float normaly, float normalz)
     {
         GVRCollider collider = GVRCollider.lookup(colliderPointer);
         if (collider == null)
@@ -641,8 +641,8 @@ public class GVRPicker extends GVRBehavior {
             return null;
         }
         return new GVRPicker.GVRPickedObject(collider, new float[] { hitx, hity, hitz }, distance, faceIndex,
-                new float[] {barycentricx, barycentricy, barycentricz},
-                new float[]{ texu, texv });
+                new float[] {barycentricx, barycentricy, barycentricz}, new float[]{ texu, texv },
+                new float[]{normalx, normaly, normalz});
     }
 
     /**
@@ -686,6 +686,7 @@ public class GVRPicker extends GVRBehavior {
         public final int faceIndex;
         public final float[] barycentricCoords;
         public final float[] textureCoords;
+        public final float[] normalCoords;
 
         /**
          * Creates a new instance of {@link GVRPickedObject}.
@@ -712,7 +713,7 @@ public class GVRPicker extends GVRBehavior {
          * @see GVRCollider
          */
         public GVRPickedObject(GVRCollider hitCollider, float[] hitLocation, float hitDistance, int faceIndex,
-                               float[] barycentricCoords, float[] textureCoords) {
+                               float[] barycentricCoords, float[] textureCoords, float[] normalCoords) {
             hitObject = hitCollider.getOwnerObject();
             this.hitDistance = hitDistance;
             this.hitCollider = hitCollider;
@@ -720,6 +721,7 @@ public class GVRPicker extends GVRBehavior {
             this.faceIndex = faceIndex;
             this.barycentricCoords = barycentricCoords;
             this.textureCoords = textureCoords;
+            this.normalCoords = normalCoords;
         }
 
         public GVRPickedObject(GVRSceneObject hitObject, float[] hitLocation) {
@@ -730,6 +732,7 @@ public class GVRPicker extends GVRBehavior {
             this.faceIndex = -1;
             this.barycentricCoords = new float[]{-1.0f, -1.0f, -1.0f};
             this.textureCoords = new float[]{-1.0f, -1.0f};
+            this.normalCoords = new float[]{0.0f, 0.0f, 0.0f};
         }
 
         /**
@@ -831,6 +834,29 @@ public class GVRPicker extends GVRBehavior {
 
         /** The v coordinate of the texture hit location */
         public float getTextureV(){ return textureCoords[1]; }
+
+        /**
+         * The normalized surface normal of the hit location on the mesh (in world coordinates)
+         * All coordinates will be 0.0f if the coordinates haven't been calculated
+         */
+        public float[] getNormalCoords() {
+            return normalCoords;
+        }
+
+        /** The x coordinate of the surface normal */
+        public float getNormalX() {
+            return normalCoords[0];
+        }
+
+        /** The y coordinate of the surface normal */
+        public float getNormalY() {
+            return normalCoords[1];
+        }
+
+        /** The z coordinate of the surface normal*/
+        public float getNormalZ() {
+            return normalCoords[2];
+        }
     }
 
     static final ReentrantLock sFindObjectsLock = new ReentrantLock();

--- a/GVRf/Framework/framework/src/main/jni/engine/picker/picker_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/picker/picker_jni.cpp
@@ -76,7 +76,7 @@ Java_org_gearvrf_NativePicker_pickObjects(JNIEnv * env,
     Scene* scene = reinterpret_cast<Scene*>(jscene);
     jclass pickerClass = env->FindClass("org/gearvrf/GVRPicker");
     jclass hitClass = env->FindClass("org/gearvrf/GVRPicker$GVRPickedObject");
-    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFFIFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFFIFFFFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
     std::vector<ColliderData> colliders;
     Transform* t = reinterpret_cast<Transform*>(jtransform);
 
@@ -97,7 +97,8 @@ Java_org_gearvrf_NativePicker_pickObjects(JNIEnv * env,
                                                         data.HitPosition.x, data.HitPosition.y, data.HitPosition.z,
                                                         data.FaceIndex,
                                                         data.BarycentricCoordinates.x, data.BarycentricCoordinates.y, data.BarycentricCoordinates.z,
-                                                        data.TextureCoordinates.x, data.TextureCoordinates.y);
+                                                        data.TextureCoordinates.x, data.TextureCoordinates.y,
+                                                        data.NormalCoordinates.x, data.NormalCoordinates.y, data.NormalCoordinates.z);
         if (hitObject != 0)
         {
             env->SetObjectArrayElement(pickList, i++, hitObject);
@@ -122,7 +123,7 @@ Java_org_gearvrf_NativePicker_pickSceneObject(JNIEnv * env,
 
     jclass pickerClass = env->FindClass("org/gearvrf/GVRPicker");
     jclass hitClass = env->FindClass("org/gearvrf/GVRPicker$GVRPickedObject");
-    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFFIFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFFIFFFFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
 
     jlong pointerCollider = reinterpret_cast<jlong>(data.ColliderHit);
 
@@ -130,7 +131,8 @@ Java_org_gearvrf_NativePicker_pickSceneObject(JNIEnv * env,
                                                     data.HitPosition.x, data.HitPosition.y, data.HitPosition.z,
                                                     data.FaceIndex,
                                                     data.BarycentricCoordinates.x, data.BarycentricCoordinates.y, data.BarycentricCoordinates.z,
-                                                    data.TextureCoordinates.x, data.TextureCoordinates.y);
+                                                    data.TextureCoordinates.x, data.TextureCoordinates.y,
+                                                    data.NormalCoordinates.x, data.NormalCoordinates.y, data.NormalCoordinates.z);
 
     env->DeleteLocalRef(pickerClass);
     env->DeleteLocalRef(hitClass);
@@ -169,7 +171,7 @@ Java_org_gearvrf_NativePicker_pickVisible(JNIEnv * env,
     Scene* scene = reinterpret_cast<Scene*>(jscene);
     jclass pickerClass = env->FindClass("org/gearvrf/GVRPicker");
     jclass hitClass = env->FindClass("org/gearvrf/GVRPicker$GVRPickedObject");
-    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFFIFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFFIFFFFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
     std::vector<ColliderData> colliders;
     Transform* t = scene->main_camera_rig()->getHeadTransform();
 
@@ -187,7 +189,8 @@ Java_org_gearvrf_NativePicker_pickVisible(JNIEnv * env,
                                                         data.HitPosition.x, data.HitPosition.y, data.HitPosition.z,
                                                         data.FaceIndex,
                                                         data.BarycentricCoordinates.x, data.BarycentricCoordinates.y, data.BarycentricCoordinates.z,
-                                                        data.TextureCoordinates.x, data.TextureCoordinates.y);
+                                                        data.TextureCoordinates.x, data.TextureCoordinates.y,
+                                                        data.NormalCoordinates.x, data.NormalCoordinates.y, data.NormalCoordinates.z);
         if (hitObject != 0)
         {
             env->SetObjectArrayElement(pickList, i++, hitObject);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
@@ -48,6 +48,7 @@ public:
     int             FaceIndex;
     glm::vec3       BarycentricCoordinates;
     glm::vec2       TextureCoordinates;
+    glm::vec3       NormalCoordinates;
 };
 
 /*
@@ -109,7 +110,8 @@ inline ColliderData::ColliderData(Collider* collider) :
         Distance((std::numeric_limits<float>::infinity())),
         FaceIndex(-1),
         BarycentricCoordinates(-1.0f),
-        TextureCoordinates(-1.0f)
+        TextureCoordinates(-1.0f),
+        NormalCoordinates(0.0f)
 {
     if (collider != NULL)
     {
@@ -129,7 +131,8 @@ inline ColliderData::ColliderData() :
         Distance(std::numeric_limits<float>::infinity()),
         FaceIndex(-1),
         BarycentricCoordinates(-1.0f),
-        TextureCoordinates(-1.0f)
+        TextureCoordinates(-1.0f),
+        NormalCoordinates(0.0f)
 {
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.cpp
@@ -152,7 +152,8 @@ static void calcBarycentric(const glm::vec3 &p, const glm::vec3 &a, const glm::v
 /**
  * Sets the Barycentric coordinates corresponding to the HitPoint on the mesh
  * @param mesh          the Mesh of the object that was collided with
- * @param colliderData  the ColliderData holding the HitPoint which will also store the Barycentric coordinates
+ * @param colliderData  the ColliderData holding the HitPoint which will also store the Barycentric
+ * coordinates
  */
 static void populateBarycentricCoords(const Mesh& mesh, ColliderData& colliderData) {
     const std::vector<glm::vec3> &vertices = mesh.vertices();
@@ -165,11 +166,13 @@ static void populateBarycentricCoords(const Mesh& mesh, ColliderData& colliderDa
 }
 
 /**
- * Sets the Barycentric and UV coordinates corresponding to the HitPoint on the mesh
+ * Sets the Barycentric coordinates, UV coordinates, and normal corresponding to the HitPoint on the
+ * mesh
  * @param mesh          the Mesh of the object that was collided with
  * @param colliderData  the ColliderData holding the HitPoint which will also store the UV coordinates
+ *                      and the surface normal
  */
-static void populateTexCoords(const Mesh& mesh, ColliderData& colliderData) {
+static void populateSurfaceCoords(const Mesh &mesh, ColliderData &colliderData) {
     populateBarycentricCoords(mesh, colliderData);
     try{
         const std::vector<glm::vec2> &texCoords = mesh.getVec2Vector("a_texcoord"); //may not exist
@@ -177,9 +180,16 @@ static void populateTexCoords(const Mesh& mesh, ColliderData& colliderData) {
         glm::vec2 u2(texCoords[mesh.triangles()[colliderData.FaceIndex * 3 + 1]]);
         glm::vec2 u3(texCoords[mesh.triangles()[colliderData.FaceIndex * 3 + 2]]);
 
+        glm::vec3 n1(mesh.normals()[mesh.triangles()[colliderData.FaceIndex * 3]]);
+        glm::vec3 n2(mesh.normals()[mesh.triangles()[colliderData.FaceIndex * 3 + 1]]);
+        glm::vec3 n3(mesh.normals()[mesh.triangles()[colliderData.FaceIndex * 3 + 2]]);
+
         colliderData.TextureCoordinates =   u1 * colliderData.BarycentricCoordinates.x
                                             + u2 * colliderData.BarycentricCoordinates.y
                                             + u3 * colliderData.BarycentricCoordinates.z;
+        colliderData.NormalCoordinates =    n1 * colliderData.BarycentricCoordinates.x
+                                            + n2 * colliderData.BarycentricCoordinates.y
+                                            + n3 * colliderData.BarycentricCoordinates.z;
     }
     catch (const std::string& warning){
         LOGW("%s", warning.c_str());
@@ -220,7 +230,7 @@ ColliderData MeshCollider::isHit(const Mesh& mesh, const glm::vec3& rayStart, co
             }
         }
         if(pickCoordinates){
-            populateTexCoords(mesh, data);
+            populateSurfaceCoords(mesh, data);
         }
 
     }


### PR DESCRIPTION
A small PR to add surface normals to picking information. Note that the normals are calculated in model coordinates just as the hit coordinates are. 