### PR TITLE
Correct GearCursorController origin

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GearCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GearCursorController.java
@@ -318,7 +318,7 @@ final class GearCursorController extends GVRCursorController {
             quaternionf.transform(FORWARD, result);
 
             pivot.getTransform().setPosition(position.x, position.y, position.z);
-            setOrigin(position.x, position.y, position.z);
+            setOrigin(position.x + result.x, position.y + result.y, position.z + result.z);
 
             int handleResult = handleButton(key, OVR_BUTTON_ENTER, prevButtonEnter, KeyEvent
                     .KEYCODE_ENTER);


### PR DESCRIPTION
Set GearCursorController's origin to scene object position, not pivot position. As a result, any picking information returned by SensorEvents will be relative to the scene objects attached to the GearCursorController. This is necessary for setting the correct ray depth in #1288.