### PR TITLE
Vulkan port of GLSLESVersion

### DIFF
--- a/GVRf/Framework/framework/src/main/assets/_gvr.xml
+++ b/GVRf/Framework/framework/src/main/assets/_gvr.xml
@@ -28,6 +28,7 @@
         framebufferPixelsHigh="DEFAULT"
         framebufferPixelsWide="DEFAULT"
         showLoadingIcon="true"
+        useMultiview="false"
         useProtectedFramebuffer="false"
         useSrgbFramebuffer="false" >
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRColorBlendShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRColorBlendShader.java
@@ -33,7 +33,7 @@ public class GVRColorBlendShader extends GVRShaderTemplate
 {
     public GVRColorBlendShader(GVRContext ctx)
     {
-        super("float3 u_color float u_factor", "sampler2D u_texture", "float3 a_position float2 a_texcoord", 400);
+        super("float3 u_color float u_factor", "sampler2D u_texture", "float3 a_position float2 a_texcoord", GLSLESVersion.VULKAN);
         Context context = ctx.getContext();
         setSegment("FragmentTemplate", TextFile.readTextFile(context, R.raw.color_blend_frag));
         setSegment("VertexTemplate", TextFile.readTextFile(context, R.raw.color_blend_vert));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRColorShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRColorShader.java
@@ -30,7 +30,7 @@ public class GVRColorShader extends GVRShaderTemplate
 {
     public GVRColorShader(GVRContext gvrContext)
     {
-        super("float3 u_color", "", "float3 a_position", 400);
+        super("float3 u_color", "", "float3 a_position", GLSLESVersion.VULKAN);
         Context context = gvrContext.getContext();
         setSegment("FragmentTemplate", TextFile.readTextFile(context, R.raw.color_shader_frag));
         setSegment("VertexTemplate", TextFile.readTextFile(context, R.raw.color_shader_vert));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCubemapReflectionShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCubemapReflectionShader.java
@@ -72,7 +72,7 @@ public class GVRCubemapReflectionShader extends GVRShaderTemplate
 {
     public GVRCubemapReflectionShader(GVRContext gvrContext)
     {
-        super("float3 u_color float u_opacity", "samplerCube u_texture", "float3 a_position float3 a_normal", 400);
+        super("float3 u_color float u_opacity", "samplerCube u_texture", "float3 a_position float3 a_normal", GLSLESVersion.VULKAN);
         Context context = gvrContext.getContext();
         setSegment("FragmentTemplate", TextFile.readTextFile(context, R.raw.cubemap_reflection_frag));
         setSegment("VertexTemplate", TextFile.readTextFile(context, R.raw.cubemap_reflection_vert));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCubemapShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCubemapShader.java
@@ -69,7 +69,7 @@ public class GVRCubemapShader extends GVRShaderTemplate
 {
     public GVRCubemapShader(GVRContext gvrContext)
     {
-        super("float3 u_color float u_opacity", "samplerCube u_texture", "float3 a_position float2 a_texcoord", 400);
+        super("float3 u_color float u_opacity", "samplerCube u_texture", "float3 a_position float2 a_texcoord", GLSLESVersion.VULKAN);
         Context context = gvrContext.getContext();
         setSegment("FragmentTemplate", TextFile.readTextFile(context, R.raw.cubemap_frag));
         setSegment("VertexTemplate", TextFile.readTextFile(context, R.raw.cubemap_vert));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRDepthShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRDepthShader.java
@@ -30,7 +30,7 @@ public class GVRDepthShader extends GVRShaderTemplate
 
     public GVRDepthShader(GVRContext gvrcontext)
     {
-        super("", "", "float3 a_position float3 a_normal float4 a_bone_weights int4 a_bone_indices", 400);
+        super("", "", "float3 a_position float3 a_normal float4 a_bone_weights int4 a_bone_indices", GLSLESVersion.VULKAN);
         if (fragTemplate == null)
         {
             Context context = gvrcontext.getContext();

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRErrorShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRErrorShader.java
@@ -32,7 +32,7 @@ public class GVRErrorShader extends GVRShaderTemplate
 
     public GVRErrorShader(GVRContext ctx)
     {
-        super("", "", "float3 a_position",400);
+        super("", "", "float3 a_position",GLSLESVersion.VULKAN);
         setSegment("FragmentTemplate", fragmentShader);
         setSegment("VertexTemplate", TextFile.readTextFile(ctx.getContext(), R.raw.pos_ubo));
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRLightmapShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRLightmapShader.java
@@ -67,7 +67,7 @@ public class GVRLightmapShader extends GVRShaderTemplate
     {
         super("float2 u_lightmap_offset float2 u_lightmap_scale",
               "sampler2D u_main_texture, sampler2D u_lightmap_texture",
-              "float3 a_position float2 a_texcoord", 400);
+              "float3 a_position float2 a_texcoord", GLSLESVersion.VULKAN);
         setSegment("FragmentTemplate", fragmentShader);
         setSegment("VertexTemplate", vertexShader);
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVROESHorizontalStereoShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVROESHorizontalStereoShader.java
@@ -36,7 +36,7 @@ public class GVROESHorizontalStereoShader extends GVRShader
     {
         super("float3 u_color float u_opacity ",
                 "samplerExternalOES u_texture",
-                "float3 a_position float2 a_texcoord", 300);
+                "float3 a_position float2 a_texcoord", GLSLESVersion.V300);
         Context context = gvrContext.getContext();
         setSegment("VertexTemplate",  TextFile.readTextFile(context, R.raw.pos_tex_ubo));
         setSegment("FragmentTemplate", TextFile.readTextFile(context, R.raw.oes_horizontal_stereo_frag));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVROESShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVROESShader.java
@@ -35,7 +35,7 @@ public class GVROESShader extends GVRShader
     {
         super("float3 u_color float u_opacity ",
               "samplerExternalOES u_texture",
-              "float3 a_position float2 a_texcoord", 400);
+              "float3 a_position float2 a_texcoord", GLSLESVersion.VULKAN);
         Context context = gvrContext.getContext();
         setSegment("FragmentTemplate", TextFile.readTextFile(context, R.raw.ext_tex_frag));
         setSegment("VertexTemplate", TextFile.readTextFile(context, R.raw.pos_tex_ubo));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVROESVerticalStereoShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVROESVerticalStereoShader.java
@@ -36,7 +36,7 @@ public class GVROESVerticalStereoShader extends GVRShader
     {
         super("float3 u_color float u_opacity ",
               "samplerExternalOES u_texture",
-              "float3 a_position float2 a_texcoord", 300);
+              "float3 a_position float2 a_texcoord", GLSLESVersion.V300);
         Context context = gvrContext.getContext();
         setSegment("FragmentTemplate", TextFile.readTextFile(context, R.raw.oes_vertical_frag));
         setSegment("VertexTemplate", TextFile.readTextFile(context, R.raw.pos_tex_ubo));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPhongLayeredShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPhongLayeredShader.java
@@ -45,7 +45,7 @@ public class GVRPhongLayeredShader extends GVRShaderTemplate
                 "sampler2D ambientTexture1; sampler2D diffuseTexture1; sampler2D specularTexture1; sampler2D lightmapTexture1; sampler2D emissiveTexture1",
 
                 "float3 a_position float2 a_texcoord float3 a_normal float2 a_texcoord1 float2 a_texcoord2 float2 a_texcoord3 float4 a_bone_weights int4 a_bone_indices float4 a_tangent float4 a_bitangent",
-                400);
+                GLSLESVersion.VULKAN);
 
         if (fragTemplate == null)
         {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPhongShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPhongShader.java
@@ -43,7 +43,7 @@ import org.gearvrf.R;
             super("float4 ambient_color; float4 diffuse_color; float4 specular_color; float4 emissive_color; float3 u_color; float u_opacity; float specular_exponent; float line_width; float2 u_lightmap_offset; float2 u_lightmap_scale",
                    "sampler2D diffuseTexture; sampler2D ambientTexture; sampler2D specularTexture; sampler2D opacityTexture; sampler2D lightmapTexture; sampler2D normalTexture; sampler2D emissiveTexture",
                    "float3 a_position float2 a_texcoord float2 a_texcoord1 float2 a_texcoord2 float2 a_texcoord3 float3 a_normal float4 a_bone_weights int4 a_bone_indices float4 a_tangent float4 a_bitangent",
-                   400);
+                   GLSLESVersion.VULKAN);
 
            if (fragTemplate == null)
            {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShader.java
@@ -59,7 +59,7 @@ import android.util.Log;
  */
 public class GVRShader
 {
-    protected Integer mGLSLVersion = 100;
+    protected GLSLESVersion mGLSLVersion = GLSLESVersion.V100;
     protected boolean mHasVariants = false;
     protected boolean mUsesLights = false;
     protected boolean mUseTransformBuffer = false;  // true to use Transform UBO in GL
@@ -134,7 +134,7 @@ public class GVRShader
     }
 
     /**
-     * Construct a shader using GLSL version 300
+     * Construct a shader using specified GLSL version
      *
      * @param uniformDescriptor string describing uniform names and types
      *                          e.g. "float4 diffuse_color, float4 specular_color, float specular_exponent"
@@ -144,9 +144,9 @@ public class GVRShader
      *                          e.g. "float3 a_position, float2 a_texcoord"
      *            string describing uniform names and types
      * @param glslVersion
-     *            integer giving GLSL version (e.g. 300)
+     *            GLSL version (e.g. GLSLESVersion.V300)
      */
-    public GVRShader(String uniformDescriptor, String textureDescriptor, String vertexDescriptor, int glslVersion)
+    public GVRShader(String uniformDescriptor, String textureDescriptor, String vertexDescriptor, GLSLESVersion glslVersion)
     {
         mUniformDescriptor = uniformDescriptor;
         mVertexDescriptor = vertexDescriptor;
@@ -263,11 +263,8 @@ public class GVRShader
     {
         StringBuilder vertexShaderSource = new StringBuilder();
         StringBuilder fragmentShaderSource = new StringBuilder();
-        if (mGLSLVersion > 100)
-        {
-            vertexShaderSource.append("#version " + mGLSLVersion.toString() + "\n");
-            fragmentShaderSource.append("#version " + mGLSLVersion.toString() + " \n");
-        }
+        vertexShaderSource.append("#version " + mGLSLVersion.toString() + "\n");
+        fragmentShaderSource.append("#version " + mGLSLVersion.toString() + " \n");
         String vshader = replaceTransforms(getSegment("VertexTemplate"));
         String fshader = replaceTransforms(getSegment("FragmentTemplate"));
         if (material != null)
@@ -448,4 +445,21 @@ public class GVRShader
         }
     }
     public native boolean isVulkanInstance();
+
+    public enum GLSLESVersion {
+        V100("100 es"),
+        V300("300 es"),
+        V310("310 es"),
+        V320("320 es"),
+        VULKAN("400"); // HACK: OK with Vulkan; gl_shader.c will replace with "300 es"
+
+        private GLSLESVersion(String name) {
+            this.name = name;
+        }
+        private final String name;
+
+        public String toString() {
+            return name;
+        }
+    }
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderTemplate.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderTemplate.java
@@ -125,9 +125,9 @@ public class GVRShaderTemplate extends GVRShader
      * @param vertexDescriptor  string describing vertex attributes and types
      *                          e.g. "float3 a_position, float2 a_texcoord"
      * @param glslVersion
-     *            integer giving GLSL version (e.g. 300)
+     *            GLSL version (e.g. GLSLESVersion.V300)
      */
-    public GVRShaderTemplate(String uniformDescriptor, String textureDescriptor, String vertexDescriptor, int glslVersion)
+    public GVRShaderTemplate(String uniformDescriptor, String textureDescriptor, String vertexDescriptor, GLSLESVersion glslVersion)
     {
        super(uniformDescriptor, textureDescriptor, vertexDescriptor, glslVersion);
         mHasVariants = true;
@@ -337,10 +337,7 @@ public class GVRShaderTemplate extends GVRShader
         boolean useLights = (lightlist != null) && (lightlist.length > 0);
         String lightShaderSource = "";
 
-        if (mGLSLVersion > 100)
-        {
-            shaderSource.append("#version " + mGLSLVersion.toString() + "\n");
-        }
+        shaderSource.append("#version " + mGLSLVersion.toString() + "\n");
         if (definedNames.containsKey("LIGHTSOURCES") &&
             definedNames.get("LIGHTSOURCES") == 0)
         {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRTextureShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRTextureShader.java
@@ -39,7 +39,7 @@ public class GVRTextureShader extends GVRShaderTemplate
     {
         super("float4 ambient_color; float4 diffuse_color; float4 specular_color; float4 emissive_color; float3 u_color; float u_opacity; float specular_exponent; float line_width",
               "sampler2D u_texture; sampler2D diffuseTexture",
-              "float3 a_position; float2 a_texcoord; float3 a_normal", 400);
+              "float3 a_position; float2 a_texcoord; float3 a_normal", GLSLESVersion.VULKAN);
         if (fragTemplate == null) {
             Context context = gvrcontext.getContext();
             fragTemplate = TextFile.readTextFile(context, R.raw.fragment_template);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRUnlitFBOShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRUnlitFBOShader.java
@@ -34,7 +34,7 @@ public class GVRUnlitFBOShader extends GVRShaderTemplate
     public GVRUnlitFBOShader(GVRContext gvrContext)
     {
 
-        super("float3 u_color float u_opacity", "sampler2D u_texture", "float3 a_position float2 a_texcoord", 400);
+        super("float3 u_color float u_opacity", "sampler2D u_texture", "float3 a_position float2 a_texcoord", GLSLESVersion.VULKAN);
         Context context = gvrContext.getContext();
         setSegment("FragmentTemplate", TextFile.readTextFile(context,R.raw.unlit_tex_frag));
         setSegment("VertexTemplate",TextFile.readTextFile(context,R.raw.horz_flip_tex));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRUnlitHorizontalStereoShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRUnlitHorizontalStereoShader.java
@@ -34,7 +34,7 @@ public class GVRUnlitHorizontalStereoShader extends GVRShaderTemplate
 {
     public GVRUnlitHorizontalStereoShader(GVRContext gvrContext)
     {
-        super("float3 u_color float u_opacity ", "sampler2D u_texture", "float3 a_position float2 a_texcoord", 400);
+        super("float3 u_color float u_opacity ", "sampler2D u_texture", "float3 a_position float2 a_texcoord", GLSLESVersion.VULKAN);
         Context context = gvrContext.getContext();
         setSegment("FragmentTemplate", TextFile.readTextFile(context,R.raw.unlit_horizontal_frag));
         setSegment("VertexTemplate",TextFile.readTextFile(context,R.raw.pos_tex_ubo));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRUnlitVerticalStereoShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRUnlitVerticalStereoShader.java
@@ -35,7 +35,7 @@ public class GVRUnlitVerticalStereoShader extends GVRShaderTemplate
 {
     public GVRUnlitVerticalStereoShader(GVRContext gvrContext)
     {
-        super("float3 u_color float u_opacity ", "sampler2D u_texture", "float3 a_position float2 a_texcoord", 400);
+        super("float3 u_color float u_opacity ", "sampler2D u_texture", "float3 a_position float2 a_texcoord", GLSLESVersion.VULKAN);
         Context context = gvrContext.getContext();
         setSegment("FragmentTemplate", TextFile.readTextFile(context,R.raw.unlit_vertical_frag));
         setSegment("VertexTemplate",TextFile.readTextFile(context,R.raw.pos_tex_ubo));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRVerticalFlipShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRVerticalFlipShader.java
@@ -36,7 +36,7 @@ public class GVRVerticalFlipShader extends GVRShader
 {
     public GVRVerticalFlipShader(GVRContext ctx)
     {
-        super("float3 u_color float u_factor", "sampler2D u_texture", "float3 a_position float2 a_texcoord", 400);
+        super("float3 u_color float u_factor", "sampler2D u_texture", "float3 a_position float2 a_texcoord", GLSLESVersion.VULKAN);
         Context context = ctx.getContext();
         setSegment("VertexTemplate", TextFile.readTextFile(context, R.raw.vert_flip_tex));
         setSegment("FragmentTemplate", TextFile.readTextFile(context, R.raw.color_blend_frag));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/accessibility/GVRAccessibilityPostEffectShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/accessibility/GVRAccessibilityPostEffectShader.java
@@ -24,7 +24,7 @@ public class GVRAccessibilityPostEffectShader  extends GVRShaderTemplate {
     static String vertexSource;
 
     public GVRAccessibilityPostEffectShader(GVRContext context) {
-        super("", "sampler2D u_texture", "float3 a_position float2 a_texcoord",300);
+        super("", "sampler2D u_texture", "float3 a_position float2 a_texcoord",GLSLESVersion.V300);
         if (vertexSource == null)
         {
             vertexSource = TextFile.readTextFile(context.getContext(), R.raw.inverted_colors_vertex);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/debug/GVRConsole.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/debug/GVRConsole.java
@@ -69,7 +69,7 @@ public class GVRConsole extends GVRShaderData
 
         public ConsoleShader(GVRContext ctx)
         {
-            super("", "sampler2D u_texture sampler2D u_overlay", "float3 a_position float2 a_texcoord",300);
+            super("", "sampler2D u_texture sampler2D u_overlay", "float3 a_position float2 a_texcoord",GLSLESVersion.V300);
             if (vertexShader == null)
             {
                 vertexShader = TextFile.readTextFile(ctx.getContext(), R.raw.posteffect_quad);


### PR DESCRIPTION
    Vulkan port of GLSLESVersion
    
    Port of:
    Fix problem with some of the demos that have custom shaders that are using GLSL ES version 100. #1147
    
    - add useMultiView to _gvr.xml
    - add GLSLESVersion enum
          creatively redone as compared to Master. Uses strings (for example "300 es") instead of integers.
          Has an explicit Vulkan enum with value "400" . This is a hack because:
            for OpenGL ES, we will detect this version and rewrite the shader, removing layout directives. Replace version with "300 es"
            for Vulkan, shaderc compiler is perfectly OK with "#version 400" and we don't need to touch the shader source
    - always use #version directive, even for version "100" where this directive is optional

This PR shall be 'merged'