### PR TITLE
Modify picker_jni to use different makeHit functions for different colliders

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/LaserCursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/LaserCursor.java
@@ -63,7 +63,7 @@ class LaserCursor extends Cursor {
         }
 
         cursorEvent.setObject(object);
-        cursorEvent.setHitPoint(pickedObject.getHitX(), pickedObject.getHitY(), pickedObject.getHitZ());
+        cursorEvent.setHitPoint(pickedObject.hitLocation[0], pickedObject.hitLocation[1], pickedObject.hitLocation[2]);
         cursorEvent.setCursorPosition(getPositionX(), getPositionY(), getPositionZ());
         cursorEvent.setCursorRotation(getRotationW(), getRotationX(), getRotationY(),
                 getRotationZ());

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursor.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/ObjectCursor.java
@@ -76,12 +76,12 @@ class ObjectCursor extends Cursor {
         }
 
         if (object != null && colliding) {
-            createAndSendCursorEvent(object, true, pickedObject.getHitX(), pickedObject.getHitY(),
-                    pickedObject.getHitZ(), true, event.isActive(),
+            createAndSendCursorEvent(object, true, pickedObject.hitLocation[0], pickedObject.hitLocation[1],
+                    pickedObject.hitLocation[2], true, event.isActive(),
                     event.getCursorController().getKeyEvent(), controller.getMotionEvents());
         } else {
-            createAndSendCursorEvent(object, false, pickedObject.getHitX(), pickedObject.getHitY(),
-                    pickedObject.getHitZ(), event.isOver(), event.isActive(),
+            createAndSendCursorEvent(object, false, pickedObject.hitLocation[0], pickedObject.hitLocation[1],
+                    pickedObject.hitLocation[2], event.isOver(), event.isActive(),
                     event.getCursorController().getKeyEvent(), controller.getMotionEvents());
         }
     }

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/BaseView.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/BaseView.java
@@ -128,10 +128,10 @@ abstract class BaseView {
                         sendSwipeEvent(keyEvent);
                         continue;
                     }
-                    sendMotionEvent(pickedObject.getHitX(), pickedObject.getHitY(), keyEvent.getAction());
+                    sendMotionEvent(pickedObject.hitLocation[0], pickedObject.hitLocation[1], keyEvent.getAction());
                 }
             } else {
-                sendMotionEvent(pickedObject.getHitX(), pickedObject.getHitY(), MotionEvent.ACTION_MOVE);
+                sendMotionEvent(pickedObject.hitLocation[0], pickedObject.hitLocation[1], MotionEvent.ACTION_MOVE);
             }
         }
     };

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBaseSensor.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBaseSensor.java
@@ -323,9 +323,10 @@ public class GVRBaseSensor {
 
         void updateDepthCache(List<SensorEvent> events) {
             for(SensorEvent sensorEvent: events) {
+                float[] hitLocation = sensorEvent.getPickedObject().getHitLocation();
                 modelMatrix.set(sensorEvent.getPickedObject().getHitObject().getTransform().getModelMatrix());
                 GVRPicker.GVRPickedObject pickedObject = sensorEvent.getPickedObject();
-                hitPoint.set(pickedObject.getHitX(), pickedObject.getHitY(), pickedObject.getHitZ());
+                hitPoint.set(hitLocation[0], hitLocation[1], hitLocation[2]);
                 hitPoint.mulPosition(modelMatrix);
                 float depth = hitPoint.distance(0,0,0);
                 depthCache.put(sensorEvent, depth);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRPicker.java
@@ -540,11 +540,24 @@ public class GVRPicker extends GVRBehavior {
         return Arrays.asList(pickObjects(scene, ox, oy, oz, dx, dy, dz));
     }
 
-
     /**
      * Internal utility to help JNI add hit objects to the pick list.
      */
-    static GVRPickedObject makeHit(long colliderPointer, float distance, float hitx, float hity, float hitz,
+    static GVRPickedObject makeHit(long colliderPointer, float distance, float hitx, float hity, float hitz)
+    {
+        GVRCollider collider = GVRCollider.lookup(colliderPointer);
+        if (collider == null)
+        {
+            Log.d(TAG, "makeHit: cannot find collider for %x", colliderPointer);
+            return null;
+        }
+        return new GVRPicker.GVRPickedObject(collider, new float[] { hitx, hity, hitz }, distance);
+    }
+    /**
+     * Internal utility to help JNI add hit objects to the pick list. Specifically for MeshColliders with picking
+     * for UV, Barycentric, and normal coordinates enabled
+     */
+    static GVRPickedObject makeHitMesh(long colliderPointer, float distance, float hitx, float hity, float hitz,
                                    int faceIndex, float barycentricx, float barycentricy, float barycentricz,
                                    float texu, float texv, float normalx, float normaly, float normalz)
     {
@@ -558,7 +571,7 @@ public class GVRPicker extends GVRBehavior {
                 new float[] {barycentricx, barycentricy, barycentricz}, new float[]{ texu, texv },
                 new float[]{normalx, normaly, normalz});
     }
-
+    
     /**
      * Tests the {@link GVRSceneObject}s contained within scene against the
      * camera rig's lookat vector.
@@ -637,15 +650,26 @@ public class GVRPicker extends GVRBehavior {
             this.normalCoords = normalCoords;
         }
 
+        public GVRPickedObject(GVRCollider hitCollider, float[] hitLocation, float hitDistance) {
+            hitObject = hitCollider.getOwnerObject();
+            this.hitDistance = hitDistance;
+            this.hitCollider = hitCollider;
+            this.hitLocation = hitLocation;
+            this.faceIndex = -1;
+            this.barycentricCoords = null;
+            this.textureCoords = null;
+            this.normalCoords = null;
+        }
+
         public GVRPickedObject(GVRSceneObject hitObject, float[] hitLocation) {
             this.hitObject = hitObject;
             this.hitLocation = hitLocation;
             this.hitDistance = -1;
             this.hitCollider = null;
             this.faceIndex = -1;
-            this.barycentricCoords = new float[]{-1.0f, -1.0f, -1.0f};
-            this.textureCoords = new float[]{-1.0f, -1.0f};
-            this.normalCoords = new float[]{0.0f, 0.0f, 0.0f};
+            this.barycentricCoords = null;
+            this.textureCoords = null;
+            this.normalCoords = null;
         }
 
         /**
@@ -685,21 +709,6 @@ public class GVRPicker extends GVRBehavior {
             return hitDistance;
         }
 
-        /** The x coordinate of the hit location */
-        public float getHitX() {
-            return hitLocation[0];
-        }
-
-        /** The y coordinate of the hit location */
-        public float getHitY() {
-            return hitLocation[1];
-        }
-
-        /** The z coordinate of the hit location */
-        public float getHitZ() {
-            return hitLocation[2];
-        }
-
 
         /**
          * The barycentric coordinates of the hit location on the collided face
@@ -711,62 +720,35 @@ public class GVRPicker extends GVRBehavior {
 
         /**
          * The barycentric coordinates of the hit location on the collided face
-         * All coordinates will be -1.0f if the coordinates haven't been calculated
+         * Returns null if the coordinates haven't been calculated.
          */
         public float[] getBarycentricCoords() {
-            return Arrays.copyOf(barycentricCoords, barycentricCoords.length);
-        }
-
-        /** The x coordinate of the barycentric hit location */
-        public float getBarycentrictX() {
-            return barycentricCoords[0];
-        }
-
-        /** The y coordinate of the barycentric hit location */
-        public float getBarycentricY() {
-            return barycentricCoords[1];
-        }
-
-        /** The z coordinate of the barycentric hit location */
-        public float getBarycentricZ() {
-            return barycentricCoords[2];
+            if(barycentricCoords != null)
+                return Arrays.copyOf(barycentricCoords, barycentricCoords.length);
+            else
+                return null;
         }
 
         /**
          * The UV texture coordinates of the hit location on the mesh
-         * All coordinates will be -1.0f if the coordinates haven't been calculated
+         * Returns null if the coordinates haven't been calculated.
          */
         public float[] getTextureCoords() {
-            return Arrays.copyOf(textureCoords, textureCoords.length);
+            if(textureCoords != null)
+                return Arrays.copyOf(textureCoords, textureCoords.length);
+            else
+                return null;
         }
-
-        /** The u coordinate of the texture hit location */
-        public float getTextureU(){ return textureCoords[0]; }
-
-        /** The v coordinate of the texture hit location */
-        public float getTextureV(){ return textureCoords[1]; }
 
         /**
-         * The normalized surface normal of the hit location on the mesh (in world coordinates)
-         * All coordinates will be 0.0f if the coordinates haven't been calculated
+         * The normalized surface normal of the hit location on the mesh (in local coordinates).
+         * Returns null if the coordinates haven't been calculated.
          */
         public float[] getNormalCoords() {
-            return normalCoords;
-        }
-
-        /** The x coordinate of the surface normal */
-        public float getNormalX() {
-            return normalCoords[0];
-        }
-
-        /** The y coordinate of the surface normal */
-        public float getNormalY() {
-            return normalCoords[1];
-        }
-
-        /** The z coordinate of the surface normal*/
-        public float getNormalZ() {
-            return normalCoords[2];
+            if(normalCoords != null)
+                return Arrays.copyOf(normalCoords, normalCoords.length);
+            else
+                return null;
         }
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRGUISceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRGUISceneObject.java
@@ -161,8 +161,9 @@ public class GVRGUISceneObject extends GVRViewSceneObject {
                             + ((motionEvent.getY() - savedMotionEventY) * SCALE);
                 } else {
                     GVRPicker.GVRPickedObject pickedObject = event.getPickedObject();
-                    pointerCoords.x = pickedObject.getTextureU() * frameWidth;
-                    pointerCoords.y = pickedObject.getTextureV() * frameHeight;
+                    float[] texCoords = pickedObject.getTextureCoords();
+                    pointerCoords.x = texCoords[0] * frameWidth;
+                    pointerCoords.y = texCoords[1] * frameHeight;
 
 
                     if (motionEvent.getAction() == KeyEvent.ACTION_DOWN) {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnchorImplementation.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnchorImplementation.java
@@ -494,13 +494,15 @@ public class AnchorImplementation {
 
             @Override
             public void onSensorEvent(SensorEvent event) {
+                float[] hitLocation = event.getPickedObject().getHitLocation();
+                float hitX = hitLocation[0];
                 if (event.isActive()) {
                     clickDown = !clickDown;
                     if (clickDown) {
                         // only go through once even if object is clicked a long time
                         uiObjectIsActive = !uiObjectIsActive;
                         if (uiObjectIsActive) {
-                            if (event.getPickedObject().getHitX() > cubeUISize.x / 4.0f) {
+                            if (hitX > cubeUISize.x / 4.0f) {
                                 // Delete the WebView page, control currently far right of web page
                                 gvrContext.unregisterDrawFrameListener(mOnDrawFrame);
                                 if (gvrTextScaleObject != null) {
@@ -522,10 +524,10 @@ public class AnchorImplementation {
                                 gvrWebView = null;
                                 webPagePlusUISceneObject = null;
                                 webPageActive = false;
-                            } else if (event.getPickedObject().getHitX() > 0) {
+                            } else if (hitX > 0) {
                                 // TODO: Rotate the web view, control currently right side of control bar
                                 webViewTranslation = false;
-                            } else if (event.getPickedObject().getHitX() > -cubeUISize.x / 4.0f) {
+                            } else if (hitX > -cubeUISize.x / 4.0f) {
                                 // Translate the web view, control currently left side of control bar
                                 TranslationControl(gvrWebViewSceneObjectFinal);
                             }   // end transltion web window, hit between 0 and .25,
@@ -538,16 +540,16 @@ public class AnchorImplementation {
                             if (mOnDrawFrame != null)
                                 // wrap up any lose ends closing the web page.
                                 gvrContext.unregisterDrawFrameListener(mOnDrawFrame);
-                            if (event.getPickedObject().getHitX() > 0) {
+                            if (hitX > 0) {
                                 // TODO: Stop Rotating the web page
-                            } else if (event.getPickedObject().getHitX() > -cubeUISize.x / 4.0f) {
+                            } else if (hitX > -cubeUISize.x / 4.0f) {
                                 // Stop translating the web page
                                 if (gvrTextTranslationObject != null) {
                                     gvrTextTranslationObject.setTextColor(textColorIsOver);
                                 }
                                 webViewTranslation = false;
                             }   // end transltion web window, hit between 0 and .25,
-                            else if (event.getPickedObject().getHitX() < -cubeUISize.x / 4.0f) {
+                            else if (hitX < -cubeUISize.x / 4.0f) {
                                 // Stop scaling the web page
                                 if (gvrTextScaleObject != null) {
                                     gvrTextScaleObject.setTextColor(textColorIsOver);
@@ -558,7 +560,7 @@ public class AnchorImplementation {
                     }
                 } else if (event.isOver() && !uiObjectIsActive) {
                     // highlight the icons to give visual cue to users
-                    if (event.getPickedObject().getHitX() > cubeUISize.x / 4.0f) {
+                    if (hitX > cubeUISize.x / 4.0f) {
                         if (gvrTextExitObject != null)
                             gvrTextExitObject.setTextColor(textColorIsOver);
                         if (gvrTextRotateObject != null)
@@ -569,7 +571,7 @@ public class AnchorImplementation {
                             gvrTextScaleObject.setTextColor(textColorDefault);
                         webViewTranslation = false;
                         webViewScale = false;
-                    } else if (event.getPickedObject().getHitX() > 0) {
+                    } else if (hitX > 0) {
                         if (gvrTextExitObject != null) gvrTextExitObject.setTextColor(textColorDefault);
                         if (gvrTextRotateObject != null) gvrTextRotateObject.setTextColor(textColorIsOver);
                         if (gvrTextTranslationObject != null) gvrTextTranslationObject.setTextColor(textColorDefault);
@@ -577,7 +579,7 @@ public class AnchorImplementation {
                         webViewTranslation = false;
                         webViewScale = false;
                     }  // end scaling web window, hit between 0 and .25,
-                    else if (event.getPickedObject().getHitX() > -cubeUISize.x / 4.0f) {
+                    else if (hitX > -cubeUISize.x / 4.0f) {
                         if (gvrTextExitObject != null) gvrTextExitObject.setTextColor(textColorDefault);
                         if (gvrTextRotateObject != null) gvrTextRotateObject.setTextColor(textColorDefault);
                         if (gvrTextTranslationObject != null) gvrTextTranslationObject.setTextColor(textColorIsOver);

--- a/GVRf/Framework/framework/src/main/jni/engine/picker/picker_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/picker/picker_jni.cpp
@@ -18,6 +18,7 @@
  * JNI
  ***************************************************************************/
 
+#include <objects/components/mesh_collider.h>
 #include "picker.h"
 #include "objects/scene.h"
 
@@ -73,10 +74,12 @@ Java_org_gearvrf_NativePicker_pickObjects(JNIEnv * env,
                                           jobject obj, jlong jscene, jlong jtransform, jfloat ox, jfloat oy, jfloat oz, jfloat dx,
                                           jfloat dy, jfloat dz)
 {
-    Scene* scene = reinterpret_cast<Scene*>(jscene);
     jclass pickerClass = env->FindClass("org/gearvrf/GVRPicker");
     jclass hitClass = env->FindClass("org/gearvrf/GVRPicker$GVRPickedObject");
-    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFFIFFFFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+    jmethodID makeHitMesh = env->GetStaticMethodID(pickerClass, "makeHitMesh", "(JFFFFIFFFFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+
+    Scene* scene = reinterpret_cast<Scene*>(jscene);
     std::vector<ColliderData> colliders;
     Transform* t = reinterpret_cast<Transform*>(jtransform);
 
@@ -93,12 +96,22 @@ Java_org_gearvrf_NativePicker_pickObjects(JNIEnv * env,
     {
         const ColliderData& data = *it;
         jlong pointerCollider = reinterpret_cast<jlong>(data.ColliderHit);
-        jobject hitObject = env->CallStaticObjectMethod(pickerClass, makeHit, pointerCollider, data.Distance,
-                                                        data.HitPosition.x, data.HitPosition.y, data.HitPosition.z,
-                                                        data.FaceIndex,
-                                                        data.BarycentricCoordinates.x, data.BarycentricCoordinates.y, data.BarycentricCoordinates.z,
-                                                        data.TextureCoordinates.x, data.TextureCoordinates.y,
-                                                        data.NormalCoordinates.x, data.NormalCoordinates.y, data.NormalCoordinates.z);
+        jobject hitObject;
+        MeshCollider* meshCollider = (MeshCollider *) data.ColliderHit;
+        if(meshCollider && meshCollider->shape_type() == COLLIDER_SHAPE_MESH && meshCollider->pickCoordinatesEnabled()) {
+            hitObject = env->CallStaticObjectMethod(pickerClass, makeHitMesh, pointerCollider,
+                                                    data.Distance,
+                                                    data.HitPosition.x, data.HitPosition.y, data.HitPosition.z,
+                                                    data.FaceIndex,
+                                                    data.BarycentricCoordinates.x, data.BarycentricCoordinates.y, data.BarycentricCoordinates.z,
+                                                    data.TextureCoordinates.x, data.TextureCoordinates.y,
+                                                    data.NormalCoordinates.x, data.NormalCoordinates.y, data.NormalCoordinates.z);
+        }
+        else {
+            hitObject = env->CallStaticObjectMethod(pickerClass, makeHit, pointerCollider,
+                                                    data.Distance,
+                                                    data.HitPosition.x, data.HitPosition.y, data.HitPosition.z);
+        }
         if (hitObject != 0)
         {
             env->SetObjectArrayElement(pickList, i++, hitObject);
@@ -115,27 +128,33 @@ Java_org_gearvrf_NativePicker_pickSceneObject(JNIEnv * env,
                                               jobject obj, jlong jscene_object,
                                               jfloat ox, jfloat oy, jfloat oz,
                                               jfloat dx, jfloat dy, jfloat dz) {
-    SceneObject* scene_object =
-            reinterpret_cast<SceneObject*>(jscene_object);
+    jclass pickerClass = env->FindClass("org/gearvrf/GVRPicker");
+    jmethodID makeHitMesh = env->GetStaticMethodID(pickerClass, "makeHitMesh", "(JFFFFIFFFFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+
+    SceneObject* scene_object = reinterpret_cast<SceneObject*>(jscene_object);
 
     ColliderData data;
     Picker::pickSceneObject(scene_object, ox, oy, oz, dx, dy, dz, data);
-
-    jclass pickerClass = env->FindClass("org/gearvrf/GVRPicker");
-    jclass hitClass = env->FindClass("org/gearvrf/GVRPicker$GVRPickedObject");
-    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFFIFFFFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
-
     jlong pointerCollider = reinterpret_cast<jlong>(data.ColliderHit);
-
-    jobject hitObject = env->CallStaticObjectMethod(pickerClass, makeHit, pointerCollider, data.Distance,
-                                                    data.HitPosition.x, data.HitPosition.y, data.HitPosition.z,
-                                                    data.FaceIndex,
-                                                    data.BarycentricCoordinates.x, data.BarycentricCoordinates.y, data.BarycentricCoordinates.z,
-                                                    data.TextureCoordinates.x, data.TextureCoordinates.y,
-                                                    data.NormalCoordinates.x, data.NormalCoordinates.y, data.NormalCoordinates.z);
+    jobject hitObject;
+    MeshCollider* meshCollider = (MeshCollider *) data.ColliderHit;
+    if(meshCollider && meshCollider->shape_type() == COLLIDER_SHAPE_MESH && meshCollider->pickCoordinatesEnabled()) {
+        hitObject = env->CallStaticObjectMethod(pickerClass, makeHitMesh, pointerCollider,
+                                                data.Distance,
+                                                data.HitPosition.x, data.HitPosition.y, data.HitPosition.z,
+                                                data.FaceIndex,
+                                                data.BarycentricCoordinates.x, data.BarycentricCoordinates.y, data.BarycentricCoordinates.z,
+                                                data.TextureCoordinates.x, data.TextureCoordinates.y,
+                                                data.NormalCoordinates.x, data.NormalCoordinates.y, data.NormalCoordinates.z);
+    }
+    else {
+        hitObject = env->CallStaticObjectMethod(pickerClass, makeHit, pointerCollider,
+                                                data.Distance,
+                                                data.HitPosition.x, data.HitPosition.y, data.HitPosition.z);
+    }
 
     env->DeleteLocalRef(pickerClass);
-    env->DeleteLocalRef(hitClass);
     return hitObject;
 }
 
@@ -168,10 +187,12 @@ JNIEXPORT jobjectArray JNICALL
 Java_org_gearvrf_NativePicker_pickVisible(JNIEnv * env,
                                           jobject obj, jlong jscene)
 {
-    Scene* scene = reinterpret_cast<Scene*>(jscene);
     jclass pickerClass = env->FindClass("org/gearvrf/GVRPicker");
     jclass hitClass = env->FindClass("org/gearvrf/GVRPicker$GVRPickedObject");
-    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFFIFFFFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+    jmethodID makeHitMesh = env->GetStaticMethodID(pickerClass, "makeHitMesh", "(JFFFFIFFFFFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+    jmethodID makeHit = env->GetStaticMethodID(pickerClass, "makeHit", "(JFFFF)Lorg/gearvrf/GVRPicker$GVRPickedObject;");
+
+    Scene* scene = reinterpret_cast<Scene*>(jscene);
     std::vector<ColliderData> colliders;
     Transform* t = scene->main_camera_rig()->getHeadTransform();
 
@@ -185,12 +206,22 @@ Java_org_gearvrf_NativePicker_pickVisible(JNIEnv * env,
     {
         const ColliderData& data = *it;
         jlong pointerCollider = reinterpret_cast<jlong>(data.ColliderHit);
-        jobject hitObject = env->CallStaticObjectMethod(pickerClass, makeHit, pointerCollider, data.Distance,
-                                                        data.HitPosition.x, data.HitPosition.y, data.HitPosition.z,
-                                                        data.FaceIndex,
-                                                        data.BarycentricCoordinates.x, data.BarycentricCoordinates.y, data.BarycentricCoordinates.z,
-                                                        data.TextureCoordinates.x, data.TextureCoordinates.y,
-                                                        data.NormalCoordinates.x, data.NormalCoordinates.y, data.NormalCoordinates.z);
+        jobject hitObject;
+        MeshCollider* meshCollider = (MeshCollider *) data.ColliderHit;
+        if(meshCollider && meshCollider->shape_type() == COLLIDER_SHAPE_MESH && meshCollider->pickCoordinatesEnabled()) {
+            hitObject = env->CallStaticObjectMethod(pickerClass, makeHitMesh, pointerCollider,
+                                                    data.Distance,
+                                                    data.HitPosition.x, data.HitPosition.y, data.HitPosition.z,
+                                                    data.FaceIndex,
+                                                    data.BarycentricCoordinates.x, data.BarycentricCoordinates.y, data.BarycentricCoordinates.z,
+                                                    data.TextureCoordinates.x, data.TextureCoordinates.y,
+                                                    data.NormalCoordinates.x, data.NormalCoordinates.y, data.NormalCoordinates.z);
+        }
+        else {
+            hitObject = env->CallStaticObjectMethod(pickerClass, makeHit, pointerCollider,
+                                                    data.Distance,
+                                                    data.HitPosition.x, data.HitPosition.y, data.HitPosition.z);
+        }
         if (hitObject != 0)
         {
             env->SetObjectArrayElement(pickList, i++, hitObject);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
@@ -48,6 +48,10 @@ public:
         mesh_ = mesh;
     }
 
+    bool pickCoordinatesEnabled(){
+        return pickCoordinates_;
+    }
+
     ColliderData isHit(const glm::vec3& rayStart, const glm::vec3& rayDir);
     static ColliderData isHit(const BoundingVolume& bounds, const glm::vec3& rayStart, const glm::vec3& rayDir);
 


### PR DESCRIPTION
There are now two separate functions for creating GVRPickedObjects from picker_jni depending on the type of pick/collider.

Dependent on #1290.

@NolaDonato Please see if this accomplishes what you mentioned earlier.