### PR TITLE
backend_oculus: elevate the render and main thread's priority

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -20,6 +20,7 @@
 #include "VrApi_Helpers.h"
 #include "VrApi_SystemUtils.h"
 #include <cstring>
+#include <unistd.h>
 #include "engine/renderer/renderer.h"
 
 
@@ -40,6 +41,8 @@ GVRActivity::GVRActivity(JNIEnv& env, jobject activity, jobject vrAppSettings,
 
     onDrawEyeMethodId = GetMethodId(env, env.FindClass(viewManagerClassName), "onDrawEye", "(I)V");
     updateSensoredSceneMethodId = GetMethodId(env, activityClass_, "updateSensoredScene", "()Z");
+
+    mainThreadId_ = gettid();
 }
 
 GVRActivity::~GVRActivity() {
@@ -124,6 +127,8 @@ void GVRActivity::onSurfaceChanged(JNIEnv& env) {
 
         oculusPerformanceParms_ = vrapi_DefaultPerformanceParms();
         configurationHelper_.getPerformanceConfiguration(env, oculusPerformanceParms_);
+        oculusPerformanceParms_.MainThreadTid = mainThreadId_;
+        oculusPerformanceParms_.RenderThreadTid = gettid();
 
         oculusHeadModelParms_ = vrapi_DefaultHeadModelParms();
         configurationHelper_.getHeadModelConfiguration(env, oculusHeadModelParms_);

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.h
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.h
@@ -78,6 +78,7 @@ private:
     bool docked_ = false;
     bool clampToBorderSupported_ = false;
     GearController *gearController;
+    int mainThreadId_ = 0;
 
 public:
     void onSurfaceCreated(JNIEnv& env);


### PR DESCRIPTION
This dates back to Oculus 0.6.0. Ever since then we have not been
passing the thread ids. The TimeWarp thread itself has always been
elevated.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>