### PR TITLE
backend_oculus: enable onBack handling regardless presence of a home key on the headset

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
@@ -125,9 +125,7 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
 
     @Override
     public boolean onBack() {
-        if (!mActivity.getConfigurationManager().isHomeKeyPresent()) {
-            nativeShowConfirmQuit(mPtr);
-        }
+        nativeShowConfirmQuit(mPtr);
         return true;
     }
 


### PR DESCRIPTION
For issue https://github.com/Samsung/GearVRf/issues/1194

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>