### PR TITLE
Run GVRWorld on own thread and use thread-safe transforms

### DIFF
--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsContext.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsContext.java
@@ -1,0 +1,65 @@
+package org.gearvrf.physics;
+
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.os.Handler;
+import android.os.HandlerThread;
+
+/**
+ * This class represents the Physics context
+ * with its own main loop.
+ */
+public class GVRPhysicsContext {
+    private static GVRPhysicsContext mInstance;
+    private final HandlerThread mHandlerThread;
+    private final Handler mHandler;
+
+    public static GVRPhysicsContext getInstance() {
+        if (mInstance == null) {
+            mInstance = new GVRPhysicsContext();
+        }
+
+        return mInstance;
+    }
+
+    private GVRPhysicsContext() {
+        mHandlerThread = new HandlerThread("gvrf-physics");
+        mHandlerThread.start();
+        mHandler = new Handler(mHandlerThread.getLooper());
+    }
+
+    public boolean runOnPhysicsThread(Runnable r) {
+        return mHandler.post(r);
+    }
+
+    public boolean runDelayedOnPhysicsThread(Runnable r, long delayMillis) {
+        return mHandler.postDelayed(r, delayMillis);
+    }
+
+    public boolean runAtTimeOnPhysicsThread(Runnable r, long uptimeMillis) {
+        return mHandler.postAtTime(r, uptimeMillis);
+    }
+
+    public void removeTask(Runnable r) {
+        mHandler.removeCallbacks(r);
+    }
+
+    void onDestroy() {
+        if (null != mHandlerThread) {
+            mHandlerThread.getLooper().quitSafely();
+        }
+    }
+}

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRRigidBody.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRRigidBody.java
@@ -42,6 +42,7 @@ public class GVRRigidBody extends GVRPhysicsWorldObject {
     }
 
     private final int mCollisionGroup;
+    private final GVRPhysicsContext mPhysicsContext;
 
     /**
      * Constructs new instance to simulate a rigid body in {@link GVRWorld}.
@@ -75,6 +76,7 @@ public class GVRRigidBody extends GVRPhysicsWorldObject {
         super(gvrContext, Native3DRigidBody.ctor());
         Native3DRigidBody.setMass(getNative(), mass);
         mCollisionGroup = collisionGroup;
+        mPhysicsContext = GVRPhysicsContext.getInstance();
     }
 
     static public long getComponentType() {
@@ -172,8 +174,13 @@ public class GVRRigidBody extends GVRPhysicsWorldObject {
      * @param y factor on the 'Y' axis.
      * @param z factor on the 'Z' axis.
      */
-    public void applyCentralForce(float x, float y, float z) {
-        Native3DRigidBody.applyCentralForce(getNative(), x, y, z);
+    public void applyCentralForce(final float x, final float y, final float z) {
+        mPhysicsContext.runOnPhysicsThread(new Runnable() {
+            @Override
+            public void run() {
+                Native3DRigidBody.applyCentralForce(getNative(), x, y, z);
+            }
+        });
     }
 
     /**
@@ -183,8 +190,13 @@ public class GVRRigidBody extends GVRPhysicsWorldObject {
      * @param y factor on the 'Y' axis.
      * @param z factor on the 'Z' axis.
      */
-    public void applyTorque(float x, float y, float z) {
-        Native3DRigidBody.applyTorque(getNative(), x, y, z);
+    public void applyTorque(final float x, final float y, final float z) {
+        mPhysicsContext.runOnPhysicsThread(new Runnable() {
+            @Override
+            public void run() {
+                Native3DRigidBody.applyTorque(getNative(), x, y, z);
+            }
+        });
     }
 
     /**

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
@@ -292,7 +292,7 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
 
         @Override
         public void run(){
-            if(running){
+            if(running && isEnabled()){
                 mFrameTime += interval;
                 if (mIsProcessing) {
                     return;

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
@@ -15,17 +15,14 @@
 
 package org.gearvrf.physics;
 
+import android.os.SystemClock;
 import android.util.LongSparseArray;
 
-import org.gearvrf.GVRBehavior;
 import org.gearvrf.GVRComponent;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRSceneObject.ComponentVisitor;
 import org.gearvrf.ISceneObjectEvents;
-
-import java.util.Timer;
-import java.util.TimerTask;
 
 /**
  * Represents a physics world where all {@link GVRSceneObject} with {@link GVRRigidBody} component
@@ -33,10 +30,10 @@ import java.util.TimerTask;
  * <p>
  * {@link GVRWorld} is a component that must be attached to the scene's root object.
  */
-public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, ComponentVisitor {
-    protected float mFrameTime;
-    private boolean mIsProcessing;
-    private GVRWorldTask gvrWorldTask;
+public class GVRWorld extends GVRComponent {
+    private boolean mInitialized;
+    private final GVRPhysicsContext mPhysicsContext;
+    private GVRWorldTask mWorldTask;
     private static final long DEFAULT_INTERVAL = 15;
 
     static {
@@ -73,14 +70,7 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
      * @param collisionMatrix a matrix that represents the collision relations of the bodies on the scene
      */
     public GVRWorld(GVRContext gvrContext, GVRCollisionMatrix collisionMatrix) {
-        super(gvrContext, NativePhysics3DWorld.ctor());
-        mHasFrameCallback = false;
-        mIsProcessing = false;
-        mFrameTime = 0.0f;
-        mCollisionMatrix = collisionMatrix;
-        gvrWorldTask = new GVRWorldTask(DEFAULT_INTERVAL);
-        Timer timer = new Timer();
-        timer.scheduleAtFixedRate(gvrWorldTask, 0, DEFAULT_INTERVAL);
+        this(gvrContext, collisionMatrix, DEFAULT_INTERVAL);
     }
 
     /**
@@ -92,29 +82,28 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
      */
     public GVRWorld(GVRContext gvrContext, GVRCollisionMatrix collisionMatrix, long interval) {
         super(gvrContext, NativePhysics3DWorld.ctor());
-        mHasFrameCallback = false;
-        mIsProcessing = false;
-        mFrameTime = 0.0f;
+        mInitialized = false;
         mCollisionMatrix = collisionMatrix;
-        gvrWorldTask = new GVRWorldTask(interval);
-        Timer timer = new Timer();
-        timer.scheduleAtFixedRate(gvrWorldTask,0, interval);
+        mWorldTask = new GVRWorldTask(interval);
+        mPhysicsContext = GVRPhysicsContext.getInstance();
     }
-
-
 
     static public long getComponentType() {
         return NativePhysics3DWorld.getComponentType();
     }
-
 
     /**
      * Add a {@link GVRConstraint} to this physics world.
      *
      * @param gvrConstraint The {@link GVRConstraint} to add.
      */
-    public void addConstraint(GVRConstraint gvrConstraint) {
-        NativePhysics3DWorld.addConstraint(getNative(), gvrConstraint.getNative());
+    public void addConstraint(final GVRConstraint gvrConstraint) {
+        mPhysicsContext.runOnPhysicsThread(new Runnable() {
+            @Override
+            public void run() {
+                NativePhysics3DWorld.addConstraint(getNative(), gvrConstraint.getNative());
+            }
+        });
     }
 
     /**
@@ -122,8 +111,13 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
      *
      * @param gvrConstraint the {@link GVRFixedConstraint} to remove.
      */
-    public void removeConstraint(GVRConstraint gvrConstraint) {
-        NativePhysics3DWorld.removeConstraint(getNative(), gvrConstraint.getNative());
+    public void removeConstraint(final GVRConstraint gvrConstraint) {
+        mPhysicsContext.runOnPhysicsThread(new Runnable() {
+            @Override
+            public void run() {
+                NativePhysics3DWorld.removeConstraint(getNative(), gvrConstraint.getNative());
+            }
+        });
     }
 
     /**
@@ -141,21 +135,26 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
      *
      * @param gvrBody The {@link GVRRigidBody} to add.
      */
-    public void addBody(GVRRigidBody gvrBody) {
-        if (contains(gvrBody)) {
-            return;
-        }
+    public void addBody(final GVRRigidBody gvrBody) {
+        mPhysicsContext.runOnPhysicsThread(new Runnable() {
+            @Override
+            public void run() {
+                if (contains(gvrBody)) {
+                    return;
+                }
 
-        if (gvrBody.getCollisionGroup() < 0 || gvrBody.getCollisionGroup() > 15
-                || mCollisionMatrix == null) {
-            NativePhysics3DWorld.addRigidBody(getNative(), gvrBody.getNative());
-        } else {
-            NativePhysics3DWorld.addRigidBodyWithMask(getNative(), gvrBody.getNative(),
-                    mCollisionMatrix.getCollisionFilterGroup(gvrBody.getCollisionGroup()),
-                    mCollisionMatrix.getCollisionFilterMask(gvrBody.getCollisionGroup()));
-        }
+                if (gvrBody.getCollisionGroup() < 0 || gvrBody.getCollisionGroup() > 15
+                        || mCollisionMatrix == null) {
+                    NativePhysics3DWorld.addRigidBody(getNative(), gvrBody.getNative());
+                } else {
+                    NativePhysics3DWorld.addRigidBodyWithMask(getNative(), gvrBody.getNative(),
+                            mCollisionMatrix.getCollisionFilterGroup(gvrBody.getCollisionGroup()),
+                            mCollisionMatrix.getCollisionFilterMask(gvrBody.getCollisionGroup()));
+                }
 
-        mRigidBodies.put(gvrBody.getNative(), gvrBody);
+                mRigidBodies.put(gvrBody.getNative(), gvrBody);
+            }
+        });
     }
 
     /**
@@ -163,11 +162,24 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
      *
      * @param gvrBody the {@link GVRRigidBody} to remove.
      */
-    public void removeBody(GVRRigidBody gvrBody) {
-        if (contains(gvrBody)) {
-            NativePhysics3DWorld.removeRigidBody(getNative(), gvrBody.getNative());
-            mRigidBodies.remove(gvrBody.getNative());
-        }
+    public void removeBody(final GVRRigidBody gvrBody) {
+        mPhysicsContext.runOnPhysicsThread(new Runnable() {
+            @Override
+            public void run() {
+                if (contains(gvrBody)) {
+                    NativePhysics3DWorld.removeRigidBody(getNative(), gvrBody.getNative());
+                    mRigidBodies.remove(gvrBody.getNative());
+                }
+            }
+        });
+    }
+
+    private void startSimulation() {
+        mWorldTask.start();
+    }
+
+    private void stopSimulation() {
+        mWorldTask.stop();
     }
 
     private void generateCollisionEvents() {
@@ -179,11 +191,13 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
         for (GVRCollisionInfo info : collisionInfos) {
             if (info.isHit) {
                 sendCollisionEvent(info, onEnter);
-            }
-            else {
+            } else if (mRigidBodies.get(info.bodyA) != null
+                    && mRigidBodies.get(info.bodyB) != null) {
+                // If both bodies are in the scene.
                 sendCollisionEvent(info, onExit);
             }
         }
+
     }
 
     private void sendCollisionEvent(GVRCollisionInfo info, String eventName) {
@@ -198,22 +212,24 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
     }
 
     private void doPhysicsAttach(GVRSceneObject rootSceneObject) {
-        if (!mHasFrameCallback) {
-            rootSceneObject.getEventReceiver().addListener(this);
+        rootSceneObject.forAllComponents(mComponentVisitor, GVRRigidBody.getComponentType());
+
+        if (!mInitialized) {
+            rootSceneObject.getEventReceiver().addListener(mSceneEventsHandler);
         } else if (isEnabled()){
-            gvrWorldTask.start();
+            startSimulation();
         }
-        rootSceneObject.forAllComponents(this, GVRRigidBody.getComponentType());
     }
 
     private void doPhysicsDetach(GVRSceneObject rootSceneObject) {
-        if (!mHasFrameCallback) {
-            rootSceneObject.getEventReceiver().removeListener(this);
+        rootSceneObject.forAllComponents(mComponentVisitor, GVRRigidBody.getComponentType());
+
+        if (!mInitialized) {
+            rootSceneObject.getEventReceiver().removeListener(mSceneEventsHandler);
         }
         if (isEnabled()) {
-            gvrWorldTask.stop();
+            stopSimulation();
         }
-        rootSceneObject.forAllComponents(this, GVRRigidBody.getComponentType());
     }
 
     @Override
@@ -236,83 +252,152 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
     }
 
     @Override
-    public void onInit(GVRContext gvrContext, GVRSceneObject sceneObject) {
-        if (mHasFrameCallback)
-            return;
+    public void onEnable() {
+        super.onEnable();
 
-        mHasFrameCallback = true;
-        getOwnerObject().getEventReceiver().removeListener(this);
-
-        if (isEnabled()) {
-            gvrWorldTask.start();
+        if (getOwnerObject() != null && mInitialized) {
+            startSimulation();
         }
     }
 
     @Override
-    public void onLoaded() {
+    public void onDisable() {
+        super.onDisable();
 
+        stopSimulation();
     }
 
-    @Override
-    public void onAfterInit() {
-
-    }
-
-    @Override
-    public void onStep() {
-    }
-
-    public void setGravity(float x, float y, float z) {
-        NativePhysics3DWorld.setGravity(getNative(), x, y, z);
+    public void setGravity(final float x, final float y, final float z) {
+        mPhysicsContext.runOnPhysicsThread(new Runnable() {
+            @Override
+            public void run() {
+                NativePhysics3DWorld.setGravity(getNative(), x, y, z);
+            }
+        });
     }
 
     public void getGravity(float[] gravity) {
         NativePhysics3DWorld.getGravity(getNative(), gravity);
     }
 
-    @Override
-    public boolean visit(GVRComponent gvrComponent) {
-        if (!gvrComponent.isEnabled()) {
-            return false;
-        }
-        if (this.owner != null) {
-            addBody((GVRRigidBody) gvrComponent);
-        } else {
-            removeBody((GVRRigidBody) gvrComponent);
-        }
-        return true;
-    }
-    private class GVRWorldTask extends TimerTask {
+    private class GVRWorldTask implements Runnable {
         private boolean running = false;
-        private final float interval;
+        private final long intervalMillis;
+        private float timeStep;
+        private int maxSubSteps;
+        private long simulationTime;
+        private long lastSimulTime;
 
-        public GVRWorldTask(long milliseconds){
-            interval = milliseconds/1000f;
+
+        public GVRWorldTask(long milliseconds) {
+            intervalMillis = milliseconds;
         }
 
         @Override
-        public void run(){
-            if(running && isEnabled()){
-                mFrameTime += interval;
-                if (mIsProcessing) {
-                    return;
+        public void run() {
+            if (!running) {
+                return;
+            }
+
+
+            simulationTime = SystemClock.uptimeMillis();
+
+            /* To debug physics step
+            if (BuildConfig.DEBUG && timeStep != simulationTime - lastSimulTime) {
+                Log.v("GVRPhysicsWorld", "onStep " + timeStep + "ms" + ", subSteps " + maxSubSteps);
+            }*/
+
+            timeStep  = simulationTime - lastSimulTime;
+            maxSubSteps = (int) (timeStep * 60) / 1000 + 1;
+
+            NativePhysics3DWorld.step(getNative(), timeStep, maxSubSteps);
+
+            generateCollisionEvents();
+
+            lastSimulTime = simulationTime;
+
+            simulationTime = intervalMillis + simulationTime - SystemClock.uptimeMillis();
+            if (simulationTime < 0) {
+                simulationTime += intervalMillis;
+            }
+            // Time of the next simulation;
+            simulationTime = simulationTime + SystemClock.uptimeMillis();
+
+            mPhysicsContext.runAtTimeOnPhysicsThread(this, simulationTime);
+
+
+        }
+
+        public void start() {
+            // To avoid concurrency
+            mPhysicsContext.runOnPhysicsThread(new Runnable() {
+                @Override
+                public void run() {
+                    if (!running) {
+                        running = true;
+                        lastSimulTime = SystemClock.uptimeMillis();
+                        mPhysicsContext.runDelayedOnPhysicsThread(GVRWorldTask.this,
+                                intervalMillis);
+                    }
                 }
-                mIsProcessing = true;
-                NativePhysics3DWorld.step(getNative(), mFrameTime);
-                generateCollisionEvents();
-                mFrameTime = 0.0f;
-                mIsProcessing = false;
+            });
+        }
+
+        public void stop() {
+            // To avoid concurrency
+            mPhysicsContext.runOnPhysicsThread(new Runnable() {
+                @Override
+                public void run() {
+                    if (running) {
+                        running = false;
+                        mPhysicsContext.removeTask(GVRWorldTask.this);
+                    }
+                }
+            });
+        }
+    }
+
+    private ISceneObjectEvents mSceneEventsHandler = new ISceneObjectEvents() {
+
+        @Override
+        public void onInit(GVRContext gvrContext, GVRSceneObject sceneObject) {
+            if (mInitialized)
+                return;
+
+            mInitialized = true;
+            getOwnerObject().getEventReceiver().removeListener(this);
+
+            if (isEnabled()) {
+                startSimulation();
             }
         }
 
-        public void start(){
-            running = true;
-        }
+        @Override
+        public void onLoaded() {}
 
-        public void stop(){
-            running = false;
+        @Override
+        public void onAfterInit() {}
+
+        @Override
+        public void onStep() {}
+    };
+
+    private ComponentVisitor mComponentVisitor = new ComponentVisitor() {
+
+        @Override
+        public boolean visit(GVRComponent gvrComponent) {
+            if (!gvrComponent.isEnabled()) {
+                return false;
+            }
+
+            if (GVRWorld.this.owner != null) {
+                addBody((GVRRigidBody) gvrComponent);
+            } else {
+                removeBody((GVRRigidBody) gvrComponent);
+            }
+            return true;
         }
-    }
+    };
 }
 
 class NativePhysics3DWorld {
@@ -330,7 +415,7 @@ class NativePhysics3DWorld {
 
     static native void removeRigidBody(long jphysics_world, long jrigid_body);
 
-    static native void step(long jphysics_world, float jtime_step);
+    static native void step(long jphysics_world, float jtime_step, int maxSubSteps);
 
     static native void getGravity(long jworld, float[] array);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
@@ -24,6 +24,9 @@ import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRSceneObject.ComponentVisitor;
 import org.gearvrf.ISceneObjectEvents;
 
+import java.util.Timer;
+import java.util.TimerTask;
+
 /**
  * Represents a physics world where all {@link GVRSceneObject} with {@link GVRRigidBody} component
  * attached to are simulated.
@@ -33,6 +36,8 @@ import org.gearvrf.ISceneObjectEvents;
 public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, ComponentVisitor {
     protected float mFrameTime;
     private boolean mIsProcessing;
+    private GVRWorldTask gvrWorldTask;
+    private static final long DEFAULT_INTERVAL = 15;
 
     static {
         System.loadLibrary("gvrf-physics");
@@ -42,7 +47,7 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
     private final GVRCollisionMatrix mCollisionMatrix;
 
     /**
-     * Constructs new instance to simulatethe Physics World of the Scene.
+     * Constructs new instance to simulate the Physics World of the Scene.
      *
      * @param gvrContext The context of the app.
      */
@@ -51,7 +56,18 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
     }
 
     /**
-     * Constructs new instance to simulatethe Physics World of the Scene.
+     * Constructs new instance to simulate the Physics World of the Scene.
+     *
+     * @param gvrContext The context of the app.
+     * @param interval interval (in milliseconds) at which the collisions will be updated.
+     */
+    public GVRWorld(GVRContext gvrContext, long interval) {
+        this(gvrContext, null, interval);
+    }
+
+    /**
+     * Constructs new instance to simulate the Physics World of the Scene. Defaults to a 15ms
+     * update interval.
      *
      * @param gvrContext The context of the app.
      * @param collisionMatrix a matrix that represents the collision relations of the bodies on the scene
@@ -62,7 +78,30 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
         mIsProcessing = false;
         mFrameTime = 0.0f;
         mCollisionMatrix = collisionMatrix;
+        gvrWorldTask = new GVRWorldTask(DEFAULT_INTERVAL);
+        Timer timer = new Timer();
+        timer.scheduleAtFixedRate(gvrWorldTask, 0, DEFAULT_INTERVAL);
     }
+
+    /**
+     * Constructs new instance to simulate the Physics World of the Scene.
+     *
+     * @param gvrContext The context of the app.
+     * @param collisionMatrix a matrix that represents the collision relations of the bodies on the scene
+     * @param interval interval (in milliseconds) at which the collisions will be updated.
+     */
+    public GVRWorld(GVRContext gvrContext, GVRCollisionMatrix collisionMatrix, long interval) {
+        super(gvrContext, NativePhysics3DWorld.ctor());
+        mHasFrameCallback = false;
+        mIsProcessing = false;
+        mFrameTime = 0.0f;
+        mCollisionMatrix = collisionMatrix;
+        gvrWorldTask = new GVRWorldTask(interval);
+        Timer timer = new Timer();
+        timer.scheduleAtFixedRate(gvrWorldTask,0, interval);
+    }
+
+
 
     static public long getComponentType() {
         return NativePhysics3DWorld.getComponentType();
@@ -131,19 +170,6 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
         }
     }
 
-    @Override
-    public void onDrawFrame(float frameTime) {
-        mFrameTime += frameTime;
-        if (mIsProcessing) {
-            return;
-        }
-        mIsProcessing = true;
-        NativePhysics3DWorld.step(getNative(), mFrameTime);
-        generateCollisionEvents();
-        mFrameTime = 0.0f;
-        mIsProcessing = false;
-    }
-
     private void generateCollisionEvents() {
         GVRCollisionInfo collisionInfos[] = NativePhysics3DWorld.listCollisions(getNative());
 
@@ -175,7 +201,7 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
         if (!mHasFrameCallback) {
             rootSceneObject.getEventReceiver().addListener(this);
         } else if (isEnabled()){
-            startListening();
+            gvrWorldTask.start();
         }
         rootSceneObject.forAllComponents(this, GVRRigidBody.getComponentType());
     }
@@ -185,7 +211,7 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
             rootSceneObject.getEventReceiver().removeListener(this);
         }
         if (isEnabled()) {
-            stopListening();
+            gvrWorldTask.stop();
         }
         rootSceneObject.forAllComponents(this, GVRRigidBody.getComponentType());
     }
@@ -218,7 +244,7 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
         getOwnerObject().getEventReceiver().removeListener(this);
 
         if (isEnabled()) {
-            startListening();
+            gvrWorldTask.start();
         }
     }
 
@@ -234,7 +260,6 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
 
     @Override
     public void onStep() {
-
     }
 
     public void setGravity(float x, float y, float z) {
@@ -256,6 +281,37 @@ public class GVRWorld extends GVRBehavior implements ISceneObjectEvents, Compone
             removeBody((GVRRigidBody) gvrComponent);
         }
         return true;
+    }
+    private class GVRWorldTask extends TimerTask {
+        private boolean running = false;
+        private final float interval;
+
+        public GVRWorldTask(long milliseconds){
+            interval = milliseconds/1000f;
+        }
+
+        @Override
+        public void run(){
+            if(running){
+                mFrameTime += interval;
+                if (mIsProcessing) {
+                    return;
+                }
+                mIsProcessing = true;
+                NativePhysics3DWorld.step(getNative(), mFrameTime);
+                generateCollisionEvents();
+                mFrameTime = 0.0f;
+                mIsProcessing = false;
+            }
+        }
+
+        public void start(){
+            running = true;
+        }
+
+        public void stop(){
+            running = false;
+        }
     }
 }
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_conetwistconstraint.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_conetwistconstraint.cpp
@@ -100,19 +100,11 @@ namespace gvr {
         }
     }
 
-    void BulletConeTwistConstraint::set_owner_object(SceneObject* obj) {
-        if (obj == owner_object())
-        {
-            return;
+    void BulletConeTwistConstraint::updateConstructionInfo() {
+        if (mConeTwistConstraint != 0) {
+            delete (mConeTwistConstraint);
         }
-        Component::set_owner_object(obj);
-        if (obj)
-        {
-            onAttach(obj);
-        }
-    }
 
-    void BulletConeTwistConstraint::onAttach(SceneObject *owner) {
         btRigidBody *rbA = reinterpret_cast<BulletRigidBody*>(owner_object()
                 ->getComponent(COMPONENT_TYPE_PHYSICS_RIGID_BODY))->getRigidBody();
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_conetwistconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_conetwistconstraint.h
@@ -46,8 +46,6 @@ namespace gvr {
 
         float getTwistLimit() const;
 
-        void set_owner_object(SceneObject* obj);
-
         void* getUnderlying() {
             return this->mConeTwistConstraint;
         }
@@ -56,8 +54,9 @@ namespace gvr {
 
         float getBreakingImpulse() const;
 
+        void updateConstructionInfo();
+
     private:
-        void onAttach(SceneObject* owner);
 
         btConeTwistConstraint *mConeTwistConstraint;
         BulletRigidBody *mRigidBodyB;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fixedconstraint.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fixedconstraint.cpp
@@ -22,18 +22,6 @@ BulletFixedConstraint::~BulletFixedConstraint() {
     }
 }
 
-void BulletFixedConstraint::set_owner_object(SceneObject* obj) {
-    if (obj == owner_object())
-    {
-        return;
-    }
-    Component::set_owner_object(obj);
-    if (obj)
-    {
-        onAttach(obj);
-    }
-}
-
 void BulletFixedConstraint::setBreakingImpulse(float impulse) {
     if (0 != mFixedConstraint) {
         mFixedConstraint->setBreakingImpulseThreshold(impulse);
@@ -52,7 +40,10 @@ float BulletFixedConstraint::getBreakingImpulse() const {
     }
 }
 
-void BulletFixedConstraint::onAttach(SceneObject* owner) {
+void BulletFixedConstraint::updateConstructionInfo() {
+    if (mFixedConstraint != 0) {
+        delete (mFixedConstraint);
+    }
     btRigidBody* rbA = ((BulletRigidBody*)this->owner_object()->
             getComponent(COMPONENT_TYPE_PHYSICS_RIGID_BODY))->getRigidBody();
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fixedconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fixedconstraint.h
@@ -35,8 +35,6 @@ namespace gvr {
 
         ~BulletFixedConstraint();
 
-        void set_owner_object(SceneObject* obj);
-
         void* getUnderlying() {
             return this->mFixedConstraint;
         }
@@ -45,8 +43,7 @@ namespace gvr {
 
         float getBreakingImpulse() const;
 
-    private:
-        void onAttach(SceneObject* owner);
+        void updateConstructionInfo();
 
     private:
         btFixedConstraint *mFixedConstraint;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_generic6dofconstraint.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_generic6dofconstraint.cpp
@@ -143,17 +143,11 @@ namespace gvr {
         }
     }
 
-    void BulletGeneric6dofConstraint::set_owner_object(SceneObject *obj) {
-        if (obj == owner_object()) {
-            return;
+    void BulletGeneric6dofConstraint::updateConstructionInfo() {
+        if (mGeneric6DofConstraint != 0) {
+            delete (mGeneric6DofConstraint);
         }
-        Component::set_owner_object(obj);
-        if (obj) {
-            onAttach(obj);
-        }
-    }
 
-    void BulletGeneric6dofConstraint::onAttach(SceneObject *owner) {
         btRigidBody *rbA = ((BulletRigidBody*)owner_object()->
                 getComponent(COMPONENT_TYPE_PHYSICS_RIGID_BODY))->getRigidBody();
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_generic6dofconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_generic6dofconstraint.h
@@ -59,11 +59,9 @@ namespace gvr {
 
         float getBreakingImpulse() const;
 
-        void set_owner_object(SceneObject* obj);
+        void updateConstructionInfo();
 
     private:
-        void onAttach(SceneObject *owner);
-
         btGeneric6DofConstraint *mGeneric6DofConstraint;
         BulletRigidBody *mRigidBodyB;
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_hingeconstraint.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_hingeconstraint.cpp
@@ -91,19 +91,11 @@ namespace gvr {
         }
     }
 
-    void BulletHingeConstraint::set_owner_object(SceneObject *obj) {
-        if (obj == owner_object())
-        {
-            return;
+    void BulletHingeConstraint::updateConstructionInfo() {
+        if (mHingeConstraint != 0) {
+            delete (mHingeConstraint);
         }
-        Component::set_owner_object(obj);
-        if (obj)
-        {
-            onAttach(obj);
-        }
-    }
 
-    void BulletHingeConstraint::onAttach(SceneObject *owner) {
         btVector3 pivotInA(mPivotInA.x, mPivotInA.y, mPivotInA.z);
         btVector3 pivotInB(mPivotInB.x, mPivotInB.y, mPivotInB.z);
         btVector3 axisInA(mAxisInA.x, mAxisInA.y, mAxisInA.z);

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_hingeconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_hingeconstraint.h
@@ -39,8 +39,6 @@ namespace gvr {
 
         ~BulletHingeConstraint();
 
-        void set_owner_object(SceneObject* obj);
-
         void setLimits(float lower, float upper);
 
         float getLowerLimit() const;
@@ -53,8 +51,7 @@ namespace gvr {
 
         float getBreakingImpulse() const;
 
-    private:
-        void onAttach(SceneObject* owner);
+        void updateConstructionInfo();
 
     private:
         btHingeConstraint *mHingeConstraint;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_object.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_object.h
@@ -19,11 +19,8 @@
 
 class SceneObject;
 namespace gvr {
-
     class BulletObject {
     public:
-        virtual void set_owner_object(SceneObject* obj) = 0;
-        virtual void onAttach(SceneObject* owner) = 0;
     };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.cpp
@@ -58,19 +58,11 @@ namespace gvr {
         }
     }
 
-    void BulletPoint2PointConstraint::set_owner_object(SceneObject* obj) {
-        if (obj == owner_object())
-        {
-            return;
+    void BulletPoint2PointConstraint::updateConstructionInfo() {
+        if (mPoint2PointConstraint != 0) {
+            delete (mPoint2PointConstraint);
         }
-        Component::set_owner_object(obj);
-        if (obj)
-        {
-            onAttach(obj);
-        }
-    }
 
-    void BulletPoint2PointConstraint::onAttach(SceneObject* owner) {
         btVector3 pivotInA(mPivotInA.x, mPivotInA.y, mPivotInA.z);
         btVector3 pivotInB(mPivotInB.x, mPivotInB.y, mPivotInB.z);
         btRigidBody* rbA = ((BulletRigidBody*)owner_object()->

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.h
@@ -36,8 +36,6 @@ namespace gvr {
 
         ~BulletPoint2PointConstraint();
 
-        virtual void set_owner_object(SceneObject* obj);
-
         virtual void* getUnderlying() {
             return this->mPoint2PointConstraint;
         }
@@ -54,9 +52,7 @@ namespace gvr {
 
         PhysicsVec3 getPivotInB() const { return mPivotInB; }
 
-    private:
-        void onAttach(SceneObject* owner);
-
+        void updateConstructionInfo();
     private:
         btPoint2PointConstraint *mPoint2PointConstraint;
         BulletRigidBody *mRigidBodyB;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.cpp
@@ -73,22 +73,10 @@ BulletRigidBody::SimulationType BulletRigidBody::getSimulationType() const
     return mSimType;
 }
 
-void BulletRigidBody::set_owner_object(SceneObject* obj) {
-    if (obj == owner_object())
-    {
-        return;
-    }
-    Component::set_owner_object(obj);
-    if (obj)
-    {
-        onAttach(obj);
-    }
-}
-
-void BulletRigidBody::onAttach(SceneObject* owner) {
+void BulletRigidBody::updateConstructionInfo() {
     bool isDynamic = (getMass() != 0.f);
-    Collider* collider = owner->collider();
-    RenderData* rdata = owner->render_data();
+    Collider* collider = owner_object_->collider();
+    RenderData* rdata = owner_object_->render_data();
     if (mConstructionInfo.m_collisionShape) {
         delete mConstructionInfo.m_collisionShape;
     }
@@ -275,67 +263,54 @@ void  BulletRigidBody::updateColisionShapeLocalScaling() {
 
 
 void BulletRigidBody::setGravity(float x, float y, float z) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setGravity(btVector3(x, y, z));
 }
 
 void BulletRigidBody::setDamping(float linear, float angular) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setDamping(linear, angular);
 }
 
 void BulletRigidBody::setLinearVelocity(float x, float y, float z) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setLinearVelocity(btVector3(x, y, z));
 }
 
 void BulletRigidBody::setAngularVelocity(float x, float y, float z) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setAngularVelocity(btVector3(x, y, z));
 }
 
 void BulletRigidBody::setAngularFactor(float x, float y, float z) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setAngularFactor(btVector3(x, y, z));
 }
 
 void BulletRigidBody::setLinearFactor(float x, float y, float z) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setLinearFactor(btVector3(x, y, z));
 }
 
 void BulletRigidBody::setFriction(float n) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setFriction(n);
 }
 
 void BulletRigidBody::setRestitution(float n) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setRestitution(n);
 }
 
 void BulletRigidBody::setSleepingThresholds(float linear, float angular) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setSleepingThresholds(linear, angular);
 }
 
 void BulletRigidBody::setCcdMotionThreshold(float n) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setCcdMotionThreshold(n);
 }
 
 void BulletRigidBody::setCcdSweptSphereRadius(float n) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setCcdSweptSphereRadius(n);
 }
 
 void BulletRigidBody::setContactProcessingThreshold(float n) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setContactProcessingThreshold(n);
 }
 
 void BulletRigidBody::setIgnoreCollisionCheck(PhysicsRigidBody *collisionObj, bool ignore) {
-    std::lock_guard<std::mutex> lock(BulletWorld::worldLock);
     mRigidBody->setIgnoreCollisionCheck(((BulletRigidBody *) collisionObj)->getRigidBody(),
                                         ignore);
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.h
@@ -136,7 +136,7 @@ class BulletRigidBody : public PhysicsRigidBody,
 
     const float getCcdSweptSphereRadius() const;
 
-    virtual void set_owner_object(SceneObject* obj);
+    void updateConstructionInfo();
 
  private:
     void initialize();
@@ -144,8 +144,6 @@ class BulletRigidBody : public PhysicsRigidBody,
     void finalize();
 
     void updateColisionShapeLocalScaling();
-
-    void onAttach(SceneObject* owner);
 
 private:
     btRigidBody *mRigidBody;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.cpp
@@ -133,19 +133,11 @@ namespace gvr {
         }
     }
 
-    void BulletSliderConstraint::set_owner_object(SceneObject* obj) {
-        if (obj == owner_object())
-        {
-            return;
+    void BulletSliderConstraint::updateConstructionInfo() {
+        if (mSliderConstraint != 0) {
+            delete (mSliderConstraint);
         }
-        Component::set_owner_object(obj);
-        if (obj)
-        {
-            onAttach(obj);
-        }
-    }
 
-    void BulletSliderConstraint::onAttach(SceneObject* owner) {
         btRigidBody* rbA = ((BulletRigidBody*)this->owner_object()->getComponent(COMPONENT_TYPE_PHYSICS_RIGID_BODY))->getRigidBody();
 
         btTransform frameInA, frameInB;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.h
@@ -57,13 +57,11 @@ namespace gvr {
 
         float getBreakingImpulse() const;
 
-        void set_owner_object(SceneObject* obj);
-
         void *getUnderlying() { return mSliderConstraint; }
 
-    private:
-        void onAttach(SceneObject* owner);
+        void updateConstructionInfo();
 
+    private:
         btSliderConstraint *mSliderConstraint;
         BulletRigidBody *mRigidBodyB;
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_world.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_world.cpp
@@ -26,7 +26,6 @@
 #include <android/log.h>
 
 namespace gvr {
-std::mutex BulletWorld::worldLock;
 
 BulletWorld::BulletWorld() {
     initialize();
@@ -80,36 +79,34 @@ void BulletWorld::finalize() {
 }
 
 void BulletWorld::addConstraint(PhysicsConstraint *constraint) {
-    std::lock_guard<std::mutex> lock(worldLock);
+    constraint->updateConstructionInfo();
+
     btTypedConstraint *_constr = reinterpret_cast<btTypedConstraint*>(constraint->getUnderlying());
     mPhysicsWorld->addConstraint(_constr);
 }
 
 void BulletWorld::removeConstraint(PhysicsConstraint *constraint) {
-    std::lock_guard<std::mutex> lock(worldLock);
     mPhysicsWorld->removeConstraint(reinterpret_cast<btTypedConstraint*>(constraint->getUnderlying()));
 }
 
 void BulletWorld::addRigidBody(PhysicsRigidBody *body) {
-    std::lock_guard<std::mutex> lock(worldLock);
     btRigidBody *b = (static_cast<BulletRigidBody *>(body))->getRigidBody();
+    body->updateConstructionInfo();
     mPhysicsWorld->addRigidBody(b);
 }
 
 void BulletWorld::addRigidBody(PhysicsRigidBody *body, int collisiontype, int collidesWith) {
-    std::lock_guard<std::mutex> lock(worldLock);
+    body->updateConstructionInfo();
     mPhysicsWorld->addRigidBody((static_cast<BulletRigidBody *>(body))->getRigidBody(),
                                 collidesWith, collisiontype);
 }
 
 void BulletWorld::removeRigidBody(PhysicsRigidBody *body) {
-    std::lock_guard<std::mutex> lock(worldLock);
     mPhysicsWorld->removeRigidBody((static_cast<BulletRigidBody *>(body))->getRigidBody());
 }
 
-void BulletWorld::step(float timeStep) {
-    std::lock_guard<std::mutex> lock(worldLock);
-    mPhysicsWorld->stepSimulation(timeStep);
+void BulletWorld::step(float timeStep, int maxSubSteps) {
+    mPhysicsWorld->stepSimulation(timeStep, maxSubSteps);
 }
 
 /**

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_world.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_world.h
@@ -53,7 +53,7 @@ class BulletWorld : public PhysicsWorld {
 
     void removeRigidBody(PhysicsRigidBody *body);
 
-    void step(float timeStep);
+    void step(float timeStep, int maxSubSteps);
 
     void listCollisions(std::list <ContactPoint> &contactPoints);
 
@@ -62,8 +62,6 @@ class BulletWorld : public PhysicsWorld {
     void setGravity(glm::vec3 gravity);
 
     PhysicsVec3 getGravity() const;
-
-    static std::mutex worldLock;
 
  private:
     void initialize();

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_constraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_constraint.h
@@ -46,6 +46,7 @@ namespace gvr {
         virtual void setBreakingImpulse(float impulse) = 0;
         virtual float getBreakingImpulse() const = 0;
 
+        virtual void updateConstructionInfo() = 0;
     };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_rigidbody.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_rigidbody.h
@@ -79,6 +79,8 @@ class PhysicsRigidBody : public Component {
 	virtual const float getCcdMotionThreshold() const = 0;
 	virtual const float getCcdSweptSphereRadius() const = 0;
 	virtual const float getContactProcessingThreshold() const = 0;
+
+	virtual void updateConstructionInfo() = 0;
 };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_world.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_world.h
@@ -54,7 +54,7 @@ class PhysicsWorld : public Component {
 
 	virtual void removeRigidBody(PhysicsRigidBody *body) = 0;
 
-	virtual void step(float timeStep) = 0;
+	virtual void step(float timeStep, int maxSubSteps) = 0;
 
 	virtual void listCollisions(std::list<ContactPoint>& contactPoints) = 0;
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_world_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_world_jni.cpp
@@ -55,7 +55,7 @@ extern "C" {
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_physics_NativePhysics3DWorld_step(JNIEnv * env, jobject obj,
-            jlong jworld, jfloat jtime_step);
+            jlong jworld, jfloat jtime_step, int maxSubSteps);
 
     JNIEXPORT jobjectArray JNICALL
     Java_org_gearvrf_physics_NativePhysics3DWorld_listCollisions(JNIEnv * env, jobject obj,
@@ -127,10 +127,10 @@ Java_org_gearvrf_physics_NativePhysics3DWorld_removeRigidBody(JNIEnv * env, jobj
 
 JNIEXPORT void JNICALL
 Java_org_gearvrf_physics_NativePhysics3DWorld_step(JNIEnv * env, jobject obj,
-        jlong jworld, jfloat jtime_step) {
+        jlong jworld, jfloat jtime_step, int maxSubSteps) {
     PhysicsWorld *world = reinterpret_cast<PhysicsWorld*>(jworld);
 
-    world->step((float)jtime_step);
+    world->step((float)jtime_step, maxSubSteps);
 }
 
 JNIEXPORT jobjectArray JNICALL

--- a/GVRf/Framework/framework/src/main/jni/objects/components/transform.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/transform.h
@@ -21,6 +21,7 @@
 #ifndef TRANSFORM_H_
 #define TRANSFORM_H_
 
+#include <mutex>
 #include <memory>
 
 #include "glm/glm.hpp"
@@ -45,41 +46,59 @@ public:
     }
 
     float position_x() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return position_.x;
     }
 
     float position_y() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return position_.y;
     }
 
     float position_z() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return position_.z;
     }
 
     void set_position(const glm::vec3& position) {
-        position_ = position;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            position_ = position;
+        }
         invalidate(false);
     }
 
     void set_position(float x, float y, float z) {
-        position_.x = x;
-        position_.y = y;
-        position_.z = z;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            position_.x = x;
+            position_.y = y;
+            position_.z = z;
+        }
         invalidate(false);
     }
 
     void set_position_x(float x) {
-        position_.x = x;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            position_.x = x;
+        }
         invalidate(false);
     }
 
     void set_position_y(float y) {
-        position_.y = y;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            position_.y = y;
+        }
         invalidate(false);
     }
 
     void set_position_z(float z) {
-        position_.z = z;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            position_.z = z;
+        }
         invalidate(false);
     }
 
@@ -88,46 +107,59 @@ public:
     }
 
     float rotation_w() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return rotation_.w;
     }
 
     float rotation_x() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return rotation_.x;
     }
 
     float rotation_y() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return rotation_.y;
     }
 
     float rotation_z() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return rotation_.z;
     }
 
-    // in radians
+// in radians
     float rotation_yaw() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return glm::yaw(rotation_);
     }
 
-    // in radians
+// in radians
     float rotation_pitch() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return glm::pitch(rotation_);
     }
 
-    // in radians
+// in radians
     float rotation_roll() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return glm::roll(rotation_);
     }
 
     void set_rotation(float w, float x, float y, float z) {
-        rotation_.w = w;
-        rotation_.x = x;
-        rotation_.y = y;
-        rotation_.z = z;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            rotation_.w = w;
+            rotation_.x = x;
+            rotation_.y = y;
+            rotation_.z = z;
+        }
         invalidate(true);
     }
 
-    void set_rotation(const glm::quat& roation) {
-        rotation_ = roation;
+    void set_rotation(const glm::quat& rotation) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            rotation_ = rotation;
+        }
         invalidate(true);
     }
 
@@ -136,45 +168,64 @@ public:
     }
 
     float scale_x() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return scale_.x;
     }
 
     float scale_y() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return scale_.y;
     }
 
     float scale_z() const {
+        std::lock_guard<std::mutex> lock(mutex_);
         return scale_.z;
     }
 
     void set_scale(const glm::vec3& scale) {
-        scale_ = scale;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            scale_ = scale;
+        }
         invalidate(false);
     }
 
     void set_scale(float x, float y, float z) {
-        scale_.x = x;
-        scale_.y = y;
-        scale_.z = z;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            scale_.x = x;
+            scale_.y = y;
+            scale_.z = z;
+        }
         invalidate(false);
     }
 
     void set_scale_x(float x) {
-        scale_.x = x;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            scale_.x = x;
+        }
         invalidate(false);
     }
 
     void set_scale_y(float y) {
-        scale_.y = y;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            scale_.y = y;
+        }
         invalidate(false);
     }
 
     void set_scale_z(float z) {
-        scale_.z = z;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            scale_.z = z;
+        }
         invalidate(false);
     }
 
     bool isModelMatrixValid() {
+        std::lock_guard<std::mutex> lock(mutex_);
         return model_matrix_.isValid();
     }
 
@@ -203,6 +254,8 @@ private:
     glm::vec3 scale_;
 
     Lazy<glm::mat4> model_matrix_;
+
+    mutable std::mutex mutex_;
 };
 
 }


### PR DESCRIPTION
This change allows the gvrf-physics extension to calculate collisions in a thread of its own. Furthermore, the transform class has been refactored to allow for thread-safe reads and writes.