### PR TITLE
X3D Switch Node with interactivity

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
@@ -1243,7 +1243,7 @@ public class AnimationInteractivityManager {
                         argumentNum += 4;
                     }  // end if SFRotation
 
-                    else if ((fieldType.equalsIgnoreCase("SFFloat")) || (fieldType.equalsIgnoreCase("SFBool"))) {
+                    else if ((fieldType.equalsIgnoreCase("SFFloat")) || (fieldType.equalsIgnoreCase("SFBool")) || (fieldType.equalsIgnoreCase("SFInt32")) ) {
                         gearVRinitJavaScript += scriptObject.getFieldName(field) + " = new " + scriptObject.getFieldType(field) +
                                 "( params[" + argumentNum + "]);\n";
                         argumentNum += 1;

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
@@ -300,7 +300,6 @@ public class AnimationInteractivityManager {
                     else if ( (interactiveObject.getScriptObject() == null) && (routeFromScriptObject != null) ) {
                         for (ScriptObject.Field field : routeFromScriptObject.getFieldsArrayList()) {
                             if (fromField.equalsIgnoreCase(routeFromScriptObject.getFieldName(field))) {
-                                //routeFromScriptObject.setToDefinedItem(field, routeToDefinedItem, toField);
                                 routeFromScriptObject.setToEventUtility(field, routeToEventUtility, toField);
                                 routeToEventUtilityFound = true;
                             }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
@@ -23,6 +23,7 @@ import org.gearvrf.GVRSpotLight;
 import org.gearvrf.GVRDirectLight;
 import org.gearvrf.GVRLightBase;
 import org.gearvrf.GVRSceneObject;
+import org.gearvrf.GVRSwitch;
 import org.gearvrf.ISensorEvents;
 import org.gearvrf.SensorEvent;
 import org.gearvrf.animation.GVRAnimation;
@@ -41,6 +42,7 @@ import org.gearvrf.utility.Log;
 import org.gearvrf.x3d.data_types.SFBool;
 import org.gearvrf.x3d.data_types.SFColor;
 import org.gearvrf.x3d.data_types.SFFloat;
+import org.gearvrf.x3d.data_types.SFInt32;
 import org.gearvrf.x3d.data_types.SFTime;
 import org.gearvrf.x3d.data_types.SFVec3f;
 import org.gearvrf.x3d.data_types.SFRotation;
@@ -1099,6 +1101,20 @@ public class AnimationInteractivityManager {
                             }
                         }
                     }  // end if SFFloat
+                    else if (fieldType.equalsIgnoreCase("SFInt32")) {
+                        int parameter = 0;
+                        if (definedItem.getGVRSceneObject() != null) {
+                            GVRComponent gvrComponent = definedItem.getGVRSceneObject().getComponent(GVRSwitch.getComponentType());
+                            if (gvrComponent != null) {
+                                if (gvrComponent instanceof GVRSwitch) {
+                                    // We have a Switch node
+                                    GVRSwitch gvrSwitch = (GVRSwitch) gvrComponent;
+                                    parameter = gvrSwitch.getSwitchIndex();
+                                }
+                            }
+                        }
+                        scriptParameters.add(parameter);
+                    }
                 }  //  end if definedItem != null
             }  //  end INPUT_ONLY, INPUT_OUTPUT (only ways to pass parameters to JS parser
         }  // for loop checking for parameters passed to the JavaScript parser
@@ -1130,8 +1146,8 @@ public class AnimationInteractivityManager {
                     Bindings bindings = gvrJavascriptV8FileFinal.getLocalBindings();
                     SetResultsFromScript(interactiveObjectFinal, bindings);
                 } else {
-                    Log.e(TAG, "Error in SCRIPT node '" +  interactiveObjectFinal.getScriptObject().getName() +
-                            "' running V8 Engine JavaScript function initialize()");
+                    Log.e(TAG, "Error in SCRIPT node '"+  interactiveObjectFinal.getScriptObject().getName() +
+                            "' JavaScript initialize() function.");
                 }
             }
         } else {
@@ -1235,19 +1251,19 @@ public class AnimationInteractivityManager {
                         gearVRinitJavaScript += scriptObject.getFieldName(field) + " = new " + scriptObject.getFieldType(field) +
                                 "( params[" + argumentNum + "], params[" + (argumentNum + 1) + "], params[" + (argumentNum + 2) + "]);\n";
                         argumentNum += 3;
-                    }  // end if SFColor of SFVec3f
+                    }  // end if SFColor of SFVec3f, a 3-value parameter
                     else if (fieldType.equalsIgnoreCase("SFRotation")) {
                         gearVRinitJavaScript += scriptObject.getFieldName(field) + " = new " + scriptObject.getFieldType(field) +
                                 "( params[" + argumentNum + "], params[" + (argumentNum + 1) + "], params[" + (argumentNum + 2)
                                 + "], params[" + (argumentNum + 3) + "]);\n";
                         argumentNum += 4;
-                    }  // end if SFRotation
+                    }  // end if SFRotation, a 4-value parameter
 
                     else if ((fieldType.equalsIgnoreCase("SFFloat")) || (fieldType.equalsIgnoreCase("SFBool")) || (fieldType.equalsIgnoreCase("SFInt32")) ) {
                         gearVRinitJavaScript += scriptObject.getFieldName(field) + " = new " + scriptObject.getFieldType(field) +
                                 "( params[" + argumentNum + "]);\n";
                         argumentNum += 1;
-                    }  // end if SFFloat or SFBool
+                    }  // end if SFFloat, SFBool or SFInt32 - a single parameter
                 }
                 else if (scriptObject.getFromEventUtility(field) != null) {
                     if (fieldType.equalsIgnoreCase("SFBool")) {
@@ -1329,7 +1345,7 @@ public class AnimationInteractivityManager {
             } // second complete check
             else {
                 Log.e(TAG, "Error in SCRIPT node '" + interactiveObjectFinal.getScriptObject().getName() +
-                        "' running V8 Engine JavaScript function '" + functionNameFinal + "'");
+                        "' JavaScript function '" + functionNameFinal + "'");
             }
         } // first complete check
     }  //  end RunScriptThread
@@ -1599,6 +1615,37 @@ public class AnimationInteractivityManager {
                                 Log.e(TAG, "Error: Not setting SFRotation '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "'." );
                             }
                         }  //  end SFRotation
+                        else if (fieldType.equalsIgnoreCase("SFInt32")) {
+                            try {
+                                SFInt32 sfInt32 = new SFInt32(new Integer(returnedJavaScriptValue.toString()).intValue() );
+                                if (scriptObjectToDefinedItem.getGVRSceneObject() != null) {
+                                    // Check if the field is 'whichChoice', meaning it's a Switch node
+                                    if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("whichChoice")) {
+                                        GVRSceneObject gvrSwitchSceneObject = scriptObject.getToDefinedItem(fieldNode).getGVRSceneObject();
+                                        GVRComponent gvrComponent = gvrSwitchSceneObject.getComponent(GVRSwitch.getComponentType());
+                                        if (gvrComponent instanceof GVRSwitch) {
+                                            // Set the value inside the Switch node
+                                            GVRSwitch gvrSwitch = (GVRSwitch) gvrComponent;
+                                            // Check if we are to switch to a value out of range (i.e. no mesh exists)
+                                            // and thus set to not show any object.
+                                            if ( (gvrSwitchSceneObject.getChildrenCount() <= sfInt32.getValue()) ||
+                                                    (sfInt32.getValue() < 0) ) {
+                                                sfInt32.setValue( gvrSwitchSceneObject.getChildrenCount() );
+                                            }
+                                            gvrSwitch.setSwitchIndex( sfInt32.getValue() );
+                                        }
+                                    }
+                                }  // end GVRSceneObject with SFInt32
+                                else {
+                                    Log.e(TAG, "Error: Not setting SFInt32 '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "'.");
+                                }
+                            }
+                            catch (Exception e) {
+                                Log.e(TAG, "Error: Not setting SFInt32 '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT " + scriptObject.getName() + "'.");
+                                Log.e(TAG, "Exception: " + e);
+                            }
+
+                        }  //  end SFInt32
                     }  //  end value != null
                 }  //  end OUTPUT-ONLY or INPUT_OUTPUT
             }  // end for-loop list of fields for a single script

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
@@ -1041,7 +1041,7 @@ public class X3Dobject {
                     String ambientIntensityAttribute = attributes
                             .getValue("ambientIntensity");
                     if (ambientIntensityAttribute != null) {
-                        Log.e(TAG, "ambientIntensity currently not implemented.");
+                        Log.e(TAG, "Material ambientIntensity currently not implemented.");
                         shaderSettings
                                 .setAmbientIntensity(parseSingleFloatString(ambientIntensityAttribute,
                                         true, false));

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
@@ -62,6 +62,7 @@ import org.gearvrf.GVRRenderData.GVRRenderingOrder;
 import org.gearvrf.GVRRenderPass.GVRCullFaceEnum;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRSpotLight;
+import org.gearvrf.GVRSwitch;
 import org.gearvrf.GVRTexture;
 import org.gearvrf.GVRTextureParameters;
 import org.gearvrf.GVRTextureParameters.TextureWrapType;
@@ -515,6 +516,26 @@ public class X3Dobject {
             }
             return mfStrings;
         } // end parseMFString
+
+        private int parseIntegerString(String numberString) {
+            StringReader sr = new StringReader(numberString);
+            StreamTokenizer st = new StreamTokenizer(sr);
+            st.parseNumbers();
+            int tokenType;
+            int returnValue = 0;
+
+            try {
+                if ((tokenType = st.nextToken()) != StreamTokenizer.TT_EOF) {
+                    if (tokenType == StreamTokenizer.TT_NUMBER) {
+                        returnValue = (int) st.nval;
+                    }
+                }
+            }
+            catch (IOException e) {
+                Log.e(TAG, "Error: parseIntegerString - " + e);
+            }
+            return returnValue;
+        } // end parseIntegerString
 
         private void parseNumbersString(String numberString, int componentType,
                                         int componentCount) {
@@ -2475,6 +2496,32 @@ public class X3Dobject {
                 } // end <LOD> Level-of-Detail node
 
 
+                /********** Switch **********/
+                else if (qName.equalsIgnoreCase("Switch")) {
+                    String name = "";
+                    int whichChoice = -1;
+
+                    attributeValue = attributes.getValue("DEF");
+                    if (attributeValue != null) {
+                        name = attributeValue;
+                    }
+                    attributeValue = attributes.getValue("whichChoice");
+                    if (attributeValue != null) {
+                        whichChoice = parseIntegerString(attributeValue);
+                    }
+                    currentSceneObject = AddGVRSceneObject();
+                    currentSceneObject.setName( name );
+
+                    GVRSwitch gvrSwitch = new GVRSwitch( gvrContext );
+                    gvrSwitch.setSwitchIndex( whichChoice );
+                    currentSceneObject.attachComponent(gvrSwitch);
+
+                    DefinedItem definedItem = new DefinedItem(currentSceneObject.getName());
+                    definedItem.setGVRSceneObject(currentSceneObject);
+                    mDefinedItems.add(definedItem); // Array list of DEFined items in the X3D scene
+                } // end <Switch> node
+
+
                 /********** Anchor **********/
                 else if (qName.equalsIgnoreCase("Anchor")) {
                     String name = "";
@@ -3339,6 +3386,18 @@ public class X3Dobject {
                 ;
             } else if (qName.equalsIgnoreCase("LOD")) {
                 ;
+            } else if (qName.equalsIgnoreCase("Switch")) {
+                // Verify the Switch index is between 0 and (max number of children - 1)
+                // if it is not, then no object should appear per the X3D spec.
+                GVRSwitch gvrSwitch = (GVRSwitch)currentSceneObject.getComponent(GVRSwitch.getComponentType());
+                if ( gvrSwitch != null) {
+                    if ( (gvrSwitch.getSwitchIndex() < 0) || (gvrSwitch.getSwitchIndex() >= currentSceneObject.getChildrenCount()) ) {
+                        // if the switch index is outside the array of possible children (which is legal in X3D)
+                        // then no object should appear, which occurs when GVRSwitch is set higher than possilble # children.
+                        gvrSwitch.setSwitchIndex( currentSceneObject.getChildrenCount() );
+                    }
+                }
+                currentSceneObject = currentSceneObject.getParent();
             } else if (qName.equalsIgnoreCase("Box")) {
                 ;
             } else if (qName.equalsIgnoreCase("Cone")) {
@@ -3424,11 +3483,16 @@ public class X3Dobject {
                     }
                 } // end setting based on new camera rig
 
-                animationInteractivityManager.initAnimationsAndInteractivity();
-                // Need to build a JavaScript function that constructs the
-                // X3D data type objects used with a SCRIPT.
-                // Scripts can also have an initialize() method.
-                animationInteractivityManager.InitializeScript();
+                try {
+                    animationInteractivityManager.initAnimationsAndInteractivity();
+                    // Need to build a JavaScript function that constructs the
+                    // X3D data type objects used with a SCRIPT.
+                    // Scripts can also have an initialize() method.
+                    animationInteractivityManager.InitializeScript();
+                }
+                catch (Exception exception) {
+                    Log.e(TAG, "Error initialing X3D <ROUTE> or <Script> node related to Animation or Interactivity.");
+                }
 
             } // end </scene>
             else if (qName.equalsIgnoreCase("x3d")) {
@@ -3700,8 +3764,7 @@ public class X3Dobject {
                 }
             }
         } catch (Exception exception) {
-            Log.e(TAG, "Parse call: Exception = " + exception);
-            exception.printStackTrace();
+            Log.e(TAG, "X3D/XML Parsing Exception = " + exception);
         }
 
     } // end Parse

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/data_types/SFInt32.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/data_types/SFInt32.java
@@ -1,0 +1,50 @@
+/* Copyright 2016 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gearvrf.x3d.data_types;
+
+/**
+ * Defines the X3D SFInt32 data type
+ a 32-bit integer
+ */
+public class SFInt32 {
+
+    private int value = 0;
+
+    public SFInt32() {
+    }
+
+    public SFInt32(int value) {
+        setValue(value);
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder();
+        buf.append(this.value);
+        return buf.toString();
+    }
+
+}
+
+
+


### PR DESCRIPTION
Implements X3D &lt;Switch&gt; node.
Enables JavaScript to control the switching between meshes.

Test cases on test repo at:
https://github.com/gearvrf/GearVRf-Tests/tree/master/x3d/Switch_node

GearVRf-DCO-1.0-Signed-off-by: Mitch Williams
m1.williams@partner.samsung.com