### PR TITLE
framework, backend_oculus: add support for building with clang

### DIFF
--- a/GVRf/Framework/backend_oculus/build.gradle
+++ b/GVRf/Framework/backend_oculus/build.gradle
@@ -30,7 +30,6 @@ android {
 
         ndk {
             moduleName "gvrf-oculus"
-            stl "gnustl_static"
             if (rootProject.hasProperty("ARM64")) {
                 abiFilters = ['arm64-v8a']
             } else {
@@ -112,7 +111,11 @@ android {
 
     externalNativeBuild {
         ndkBuild {
-            path 'src/main/jni/Android.mk'
+            if (rootProject.hasProperty("GVRF_USE_CLANG") && rootProject.property("GVRF_USE_CLANG")) {
+                path 'src/main/clang/Android.mk'
+            } else {
+                path 'src/main/jni/Android.mk'
+            }
         }
     }
 }

--- a/GVRf/Framework/backend_oculus/src/main/clang/Android.mk
+++ b/GVRf/Framework/backend_oculus/src/main/clang/Android.mk
@@ -1,0 +1,71 @@
+ #   
+ # Copyright 2015 Samsung Electronics Co., LTD
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+ifndef OVR_MOBILE_SDK
+	OVR_MOBILE_SDK=../../../../../ovr_sdk_mobile
+endif
+
+$(info OVR_MOBILE_SDK is set to $(OVR_MOBILE_SDK))
+include $(OVR_MOBILE_SDK)/cflags.mk
+
+LOCAL_MODULE := gvrf-oculus
+
+LOCAL_C_INCLUDES += $(OVR_MOBILE_SDK)/VrApi/Include
+LOCAL_C_INCLUDES += $(OVR_MOBILE_SDK)/VrAppSupport/SystemUtils/Include
+
+ROOT_PATH := $(LOCAL_PATH)/../jni
+LOCAL_C_INCLUDES += $(ROOT_PATH)/../../../../framework/src/main/jni/
+LOCAL_C_INCLUDES += $(ROOT_PATH)/../../../../framework/src/main/jni/util
+LOCAL_C_INCLUDES += $(ROOT_PATH)/../../../../framework/src/main/jni/contrib
+
+# Uncomment for logs
+# LOCAL_CFLAGS += -DANDROID -DJNI_LOG
+
+LOCAL_C_INCLUDES += $(ROOT_PATH)/src/main/jni
+LOCAL_C_INCLUDES += $(ROOT_PATH)/src/main/jni/util
+LOCAL_C_INCLUDES += $(ROOT_PATH)/src/main/jni/objects
+
+FILE_LIST := $(wildcard $(ROOT_PATH)/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/objects/components/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/util/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/monoscopic/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+
+LOCAL_SHARED_LIBRARIES += vrapi
+
+## CPP flags are already defined in cflags.mk.
+#LOCAL_CPPFLAGS += -fexceptions -frtti -std=c++11 -D__GXX_EXPERIMENTAL_CXX0X__ -mhard-float -D_NDK_MATH_NO_SOFTFP=1
+#for NO_RTTI and softFP
+LOCAL_CPPFLAGS += -fexceptions -std=c++11 -D__GXX_EXPERIMENTAL_CXX0X__
+LOCAL_CFLAGS := -Wattributes
+
+# include ld libraries defined in oculus's cflags.mk
+#LOCAL_LDLIBS += -ljnigraphics -lm_hard
+#softFP
+LOCAL_LDLIBS += -ljnigraphics -llog -lGLESv3 -lEGL -lz -landroid
+#LOCAL_LDLIBS += -ldl
+LOCAL_LDLIBS += $(PROJECT_DIR)/../framework/build/intermediates/ndkBuild/$(APP_OPTIM)/obj/local/$(TARGET_ARCH_ABI)/libgvrf.so
+
+include $(BUILD_SHARED_LIBRARY)
+
+$(call import-add-path, $(OVR_MOBILE_SDK))
+$(call import-module,VrApi/Projects/AndroidPrebuilt/jni)

--- a/GVRf/Framework/backend_oculus/src/main/clang/Application.mk
+++ b/GVRf/Framework/backend_oculus/src/main/clang/Application.mk
@@ -1,0 +1,30 @@
+ #   
+ # Copyright 2015 Samsung Electronics Co., LTD
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+ifndef ARM64
+APP_ABI := armeabi-v7a
+else
+APP_ABI := arm64-v8a
+endif
+
+APP_PLATFORM := android-21
+APP_STL := c++_static
+NDK_TOOLCHAIN_VERSION := clang
+ifndef OVR_MOBILE_SDK
+   	OVR_MOBILE_SDK=../../../../../ovr_sdk_mobile
+endif
+APP_CPPFLAGS := -fexceptions -Wno-everything
+
+NDK_MODULE_PATH := $(OVR_MOBILE_SDK)

--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -25,7 +25,6 @@ android {
         }
         ndk {
             moduleName "gvrf"
-            stl "gnustl_static"
             if (rootProject.hasProperty("ARM64")) {
                 abiFilters = ['arm64-v8a']
             } else {
@@ -36,7 +35,11 @@ android {
 
     externalNativeBuild {
         ndkBuild {
-            path 'src/main/jni/Android.mk'
+            if (rootProject.hasProperty("GVRF_USE_CLANG") && rootProject.property("GVRF_USE_CLANG")) {
+                path 'src/main/clang/Android.mk'
+            } else {
+                path 'src/main/jni/Android.mk'
+            }
         }
     }
 

--- a/GVRf/Framework/framework/src/main/clang/Android.mk
+++ b/GVRf/Framework/framework/src/main/clang/Android.mk
@@ -1,0 +1,120 @@
+ #   
+ # Copyright 2015 Samsung Electronics Co., LTD
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE    := assimp
+LOCAL_SRC_FILES := ../prebuilt/$(TARGET_ARCH_ABI)/libassimp.so
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE    := jnlua
+LOCAL_SRC_FILES := ../prebuilt/$(TARGET_ARCH_ABI)/libjnlua.so
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE    := jav8
+LOCAL_SRC_FILES := ../prebuilt/$(TARGET_ARCH_ABI)/libjav8.so
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := gvrf
+
+ROOT_PATH := $(LOCAL_PATH)/../jni
+FILE_LIST := $(wildcard $(ROOT_PATH)/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+
+LOCAL_C_INCLUDES += $(ROOT_PATH)/contrib/assimp
+LOCAL_C_INCLUDES +=	$(ROOT_PATH)/contrib/assimp/include
+LOCAL_C_INCLUDES +=	$(ROOT_PATH)/contrib/assimp/include/Compiler
+
+LOCAL_C_INCLUDES += $(ROOT_PATH)/contrib/jassimp
+# Uncomment for logs
+# LOCAL_CFLAGS += -DANDROID -DJNI_LOG
+FILE_LIST := $(wildcard $(ROOT_PATH)/contrib/jassimp/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+
+LOCAL_C_INCLUDES += $(ROOT_PATH)/contrib
+LOCAL_C_INCLUDES += $(ROOT_PATH)/util
+LOCAL_C_INCLUDES += $(ROOT_PATH)
+
+FILE_LIST := $(wildcard $(ROOT_PATH)/contrib/glm/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/contrib/glm/detail/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(LOCAL_PATH)/contrib/glm/gtc/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(LOCAL_PATH)/contrib/glm/gtx/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+
+FILE_LIST := $(wildcard $(ROOT_PATH)/eglextension/msaa/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/eglextension/tiledrendering/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/engine/importer/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/engine/exporter/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/engine/picker/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/engine/renderer/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/engine/memory/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/gl/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/objects/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/objects/components/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/objects/textures/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/shaders/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/shaders/material/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/shaders/posteffect/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/util/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+FILE_LIST := $(wildcard $(ROOT_PATH)/vulkan/*.cpp)
+LOCAL_SRC_FILES += $(FILE_LIST)
+
+LOCAL_SHARED_LIBRARIES += assimp
+LOCAL_SHARED_LIBRARIES += jnlua
+LOCAL_SHARED_LIBRARIES += jav8
+
+ifeq ($(TARGET_ARCH_ABI),$(filter $(TARGET_ARCH_ABI), armeabi-v7a x86))
+#LOCAL_ARM_NEON  := true
+endif
+
+## CPP flags are already defined in cflags.mk.
+#LOCAL_CPPFLAGS += -fexceptions -frtti -std=c++11 -D__GXX_EXPERIMENTAL_CXX0X__ -mhard-float -D_NDK_MATH_NO_SOFTFP=1
+#for NO_RTTI and softFP
+LOCAL_CPPFLAGS += -fexceptions -std=c++1y -D__GXX_EXPERIMENTAL_CXX0X__
+ifdef ARM64
+LOCAL_CPPFLAGS += -DARM64
+endif
+LOCAL_CFLAGS := -Wattributes
+
+# include ld libraries defined in oculus's cflags.mk
+#LOCAL_LDLIBS += -ljnigraphics -lm_hard
+#softFP
+LOCAL_LDLIBS += -ljnigraphics -llog -lGLESv3 -lEGL -lz -landroid
+#LOCAL_LDLIBS += -ldl -lbinder -lgui
+
+include $(BUILD_SHARED_LIBRARY)

--- a/GVRf/Framework/framework/src/main/clang/Application.mk
+++ b/GVRf/Framework/framework/src/main/clang/Application.mk
@@ -1,0 +1,27 @@
+ #   
+ # Copyright 2015 Samsung Electronics Co., LTD
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+
+ifndef ARM64
+APP_ABI := armeabi-v7a
+else
+APP_ABI := arm64-v8a
+endif
+
+APP_PLATFORM := android-21
+APP_STL := c++_static
+NDK_TOOLCHAIN_VERSION := clang
+APP_CPPFLAGS := -fexceptions -Wno-unused-value -Wno-c++11-narrowing -Wno-everything
+

--- a/GVRf/Framework/framework/src/main/jni/contrib/jassimp/jassimp.cpp
+++ b/GVRf/Framework/framework/src/main/jni/contrib/jassimp/jassimp.cpp
@@ -3,6 +3,8 @@
 #include <assimp/cimport.h>
 #include <assimp/scene.h>
 #include <assimp/include/assimp/port/AndroidJNI/AndroidJNIIOSystem.h>
+#include <malloc.h>
+#include <cstdlib>
 
 #ifdef JNI_LOG
 #ifdef ANDROID
@@ -1702,7 +1704,7 @@ static jobject importHelper(JNIEnv *env, jclass jClazz, jstring jFilename, jlong
 		if (!pBuffer)
 			return NULL;
 
-		char* extension = 0;
+		const char* extension = 0;
 		if (cFilename != 0) {
 			extension = strrchr(cFilename, '.');
 			if (extension && extension != cFilename) {

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_program.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_program.h
@@ -20,6 +20,7 @@
 #ifndef GL_PROGRAM_H_
 #define GL_PROGRAM_H_
 
+#include <string>
 #include "gl/gl_headers.h"
 
 #include "util/gvr_log.h"

--- a/GVRf/Framework/framework/src/main/jni/util/gvr_java_stack_trace.h
+++ b/GVRf/Framework/framework/src/main/jni/util/gvr_java_stack_trace.h
@@ -21,6 +21,7 @@
 #define GVR_JAVA_STACK_TRACE_H_
 
 #include "jni.h"
+#include <string>
 
 namespace gvr {
 static void printJavaCallStack(JNIEnv *env, const char *msg) {


### PR DESCRIPTION
Set GVRF_USE_CLANG to true to enable. For now the main make files have been duplicated.

Some projects require everything to be built with clang. Also gcc has been deprecated for some time anyway.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>