### PR TITLE
Allow GVRGazeCursorController to work from any camera position

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCursorController.java
@@ -646,7 +646,7 @@ public abstract class GVRCursorController {
         origin.set(x,y,z);
     }
 
-    Vector3f getOrigin(){
+    protected Vector3f getOrigin(){
         return origin;
     }
 


### PR DESCRIPTION
A long requested bug-fix from @mwitchwilliams, this PR addresses the problem outlined in #1214. It turns out that Rahul was correct in suggesting that setOrigin must be used on the GVRGazeCursorController when the camera is moved, but unfortunately, the gaze-direction was being calculated incorrectly, which is why problems still persisted for Mitch.

This fix corrects the calculation of the gaze-direction and overrides the getOrigin function to always return the main camera rig position. I believe this is a reasonable change since the gaze direction is always calculated with the main camera's head transform, which implies the GVRGazeController is always intended to be used from the point of view of the main camera.