### PR TITLE
BoxCollider and MeshCollider fixes

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.cpp
@@ -162,8 +162,15 @@ void BoundingVolume::transform(const BoundingVolume &in_volume, glm::mat4 matrix
     expand(glm::vec3(bb_min.x, bb_min.y, bb_min.z));
     expand(glm::vec3(bb_max.x, bb_max.y, bb_max.z));
 }
+bool BoundingVolume::intersect(glm::vec3 &hitPoint, const glm::vec3 &rayStart,
+                               const glm::vec3 &rayDir) const
+{
+    return intersect(hitPoint, rayStart, rayDir, min_corner_, max_corner_);
+}
 
-bool BoundingVolume::intersect(glm::vec3& hitPoint, const glm::vec3& rayStart, const glm::vec3& rayDir)  const
+bool BoundingVolume::intersect(glm::vec3& hitPoint, const glm::vec3& rayStart,
+                               const glm::vec3& rayDir, const glm::vec3& minCorner,
+                               const glm::vec3& maxCorner)
 {
 	/* Algorithm from http://gamedev.stackexchange.com/questions/18436/most-efficient-aabb-vs-ray-collision-algorithms */
 	glm::vec3 direction = glm::normalize(rayDir);
@@ -174,12 +181,12 @@ bool BoundingVolume::intersect(glm::vec3& hitPoint, const glm::vec3& rayStart, c
 	dirfrac.y = 1.0f / direction.y;
 	dirfrac.z = 1.0f / direction.z;
 
-	float t1 = (min_corner_.x - rayStart.x) * dirfrac.x;
-	float t2 = (max_corner_.x - rayStart.x) * dirfrac.x;
-	float t3 = (min_corner_.y - rayStart.y) * dirfrac.y;
-	float t4 = (max_corner_.y - rayStart.y) * dirfrac.y;
-	float t5 = (min_corner_.z - rayStart.z) * dirfrac.z;
-	float t6 = (max_corner_.z - rayStart.z) * dirfrac.z;
+	float t1 = (minCorner.x - rayStart.x) * dirfrac.x;
+	float t2 = (maxCorner.x - rayStart.x) * dirfrac.x;
+	float t3 = (minCorner.y - rayStart.y) * dirfrac.y;
+	float t4 = (maxCorner.y - rayStart.y) * dirfrac.y;
+	float t5 = (minCorner.z - rayStart.z) * dirfrac.z;
+	float t6 = (maxCorner.z - rayStart.z) * dirfrac.z;
 
 	float tmin = glm::max( glm::max( glm::min(t1,t2), glm::min(t3,t4)), glm::min(t5,t6) );
 	float tmax = glm::min( glm::min( glm::max(t1,t2), glm::max(t3,t4)), glm::max(t5,t6) );
@@ -198,6 +205,7 @@ bool BoundingVolume::intersect(glm::vec3& hitPoint, const glm::vec3& rayStart, c
 	}
 	t = tmin; // Store length of ray until intersection in t
 	hitPoint = rayStart + direction * t; // intersection point
+    return true;
 }
 
 } // namespace

--- a/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.h
@@ -56,7 +56,8 @@ public:
     void expand(const BoundingVolume &volume);
     void expand(const glm::vec3 &in_center, float in_radius);
     void transform(const BoundingVolume &volume, glm::mat4 matrix);
-    bool intersect(glm::vec3& hitPoint, const glm::vec3& rayStart, const glm::vec3& rayDir)  const;
+    bool intersect(glm::vec3 &hitPoint, const glm::vec3 &rayStart, const glm::vec3 &rayDir) const;
+    static bool intersect(glm::vec3& hitPoint, const glm::vec3& rayStart, const glm::vec3& rayDir, const glm::vec3& minCorner, const glm::vec3& maxCorner);
 
 private:
     void updateCenterAndRadius();

--- a/GVRf/Framework/framework/src/main/jni/objects/components/box_collider.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/box_collider.cpp
@@ -1,0 +1,38 @@
+//
+// Created by j.reynolds on 7/26/2017.
+//
+#include <limits>
+
+#include "glm/glm.hpp"
+#include "glm/gtc/matrix_inverse.hpp"
+#include "box_collider.h"
+#include "objects/scene_object.h"
+
+namespace gvr {
+
+ColliderData BoxCollider::isHit(const glm::vec3 &rayStart, const glm::vec3 &rayDir) {
+    SceneObject* owner = owner_object();
+    glm::vec3 O(rayStart);
+    glm::vec3 D(rayDir);
+    ColliderData colliderData;
+
+    colliderData.ObjectHit = owner;
+    colliderData.ColliderHit = this;
+
+    if (owner != NULL) {
+        glm::mat4 model_matrix = owner->transform()->getModelMatrix();
+        glm::mat4 model_inverse = glm::affineInverse(model_matrix);
+
+        transformRay(model_inverse, O, D);
+    }
+
+    glm::vec3 min_corner = -half_extents_;
+    glm::vec3 max_corner = half_extents_;
+
+    colliderData.IsHit = BoundingVolume::intersect(colliderData.HitPosition, O, D, min_corner, max_corner);
+
+    colliderData.Distance = glm::distance(O, colliderData.HitPosition);
+    return colliderData;
+}
+
+}

--- a/GVRf/Framework/framework/src/main/jni/objects/components/box_collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/box_collider.h
@@ -45,7 +45,7 @@ public:
         return half_extents_;
     }
 
-    ColliderData isHit(const glm::vec3& rayStart, const glm::vec3& rayDir) { return ColliderData(); };
+    ColliderData isHit(const glm::vec3& rayStart, const glm::vec3& rayDir);
 
 private:
     glm::vec3 half_extents_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.cpp
@@ -70,9 +70,7 @@ ColliderData MeshCollider::isHit(const glm::vec3& rayStart, const glm::vec3& ray
     Mesh* mesh = mesh_;
     bool pickCoordinates = pickCoordinates_;
     RenderData* rd = NULL;
-    glm::mat4 model_view;
     SceneObject* owner = owner_object();
-    glm::mat4 model_matrix;
     glm::vec3 O(rayStart);
     glm::vec3 D(rayDir);
 
@@ -85,7 +83,7 @@ ColliderData MeshCollider::isHit(const glm::vec3& rayStart, const glm::vec3& ray
     if (owner != NULL)
     {
         RenderData* rd = owner->render_data();
-        model_matrix = owner->transform()->getModelMatrix();
+        glm::mat4 model_matrix = owner->transform()->getModelMatrix();
         glm::mat4 model_inverse = glm::affineInverse(model_matrix);
 
         transformRay(model_inverse, O, D);
@@ -113,9 +111,7 @@ ColliderData MeshCollider::isHit(const glm::vec3& rayStart, const glm::vec3& ray
         }
         if (data.IsHit)
         {
-            glm::vec4 hitPos = model_matrix * glm::vec4(data.HitPosition, 1);
-
-            data.Distance = glm::distance(rayStart, glm::vec3(hitPos));
+            data.Distance = glm::distance(O, data.HitPosition);
             data.ColliderHit = this;
             data.ObjectHit = owner;
         }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.cpp
@@ -225,7 +225,7 @@ ColliderData MeshCollider::isHit(const Mesh& mesh, const glm::vec3& rayStart, co
                 data.FaceIndex = i/3;
             }
         }
-        if(pickCoordinates){
+        if(pickCoordinates && data.IsHit){
             populateSurfaceCoords(mesh, data);
         }
 


### PR DESCRIPTION
This PR implements an isHit function for BoxColliders, which is necessary in order for it to be used. It uses the same algorithm as the BoundingVolume, and as such, the intersection method for bounding volumes has been made static for both classes to use it.

I also made a small adjustment to mesh_collider.cpp, which removes an unnecessary matrix operation, as no accuracy is gained from calculating the hit distance in world coordinates - a matrix and its inverse produce the same error.