### PR TITLE
framework: propagate all exceptions openStream might throw

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/asynchronous/Throttler.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/asynchronous/Throttler.java
@@ -327,7 +327,7 @@ class Throttler implements Scheduler {
                     {
                         request.openStream();
                     }
-                    catch (IOException ex)
+                    catch (Exception ex)
                     {
                         callback.failed(ex, request);
                     }


### PR DESCRIPTION
Since users can extend from GVRAndroidResource and override openStream their implementations could be throwing all sorts of exceptions, like in a particular case a SecurityException. Propagate them all to the callback.