### PR TITLE
Set MotionEvents in GearCursorController

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrControllerReader.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrControllerReader.java
@@ -28,6 +28,11 @@ class OvrControllerReader implements GearCursorController.ControllerReader {
     }
 
     @Override
+    public boolean isTouched() {
+        return readbackBuffer.get(INDEX_TOUCHED) == 1.0f;
+    }
+
+    @Override
     public void updateRotation(Quaternionf quat) {
         quat.set(readbackBuffer.get(INDEX_ROTATION + 1),
                 readbackBuffer.get(INDEX_ROTATION + 2),
@@ -68,12 +73,13 @@ class OvrControllerReader implements GearCursorController.ControllerReader {
 
     private static final int INDEX_CONNECTED = 0;
     private static final int INDEX_HANDEDNESS = 1;
-    private static final int INDEX_POSITION = 2;
-    private static final int INDEX_ROTATION = 5;
-    private static final int INDEX_BUTTON = 9;
-    private static final int INDEX_TOUCHPAD = 10;
+    private static final int INDEX_TOUCHED = 2;
+    private static final int INDEX_POSITION = 3;
+    private static final int INDEX_ROTATION = 6;
+    private static final int INDEX_BUTTON = 10;
+    private static final int INDEX_TOUCHPAD = 11;
 
-    private static final int DATA_SIZE = 12;
+    private static final int DATA_SIZE = 13;
     private static final int BYTE_TO_FLOAT = 4;
 }
 

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_gear_controller.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_gear_controller.cpp
@@ -86,23 +86,25 @@ namespace gvr {
             ovrQuatf orientation = tracking.HeadPose.Pose.Orientation;
             const glm::quat tmp(orientation.w, orientation.x, orientation.y, orientation.z);
             const glm::quat quat = glm::conjugate(glm::inverse(tmp));
-            orientationTrackingReadbackBuffer[5] = quat.w;
-            orientationTrackingReadbackBuffer[6] = quat.x;
-            orientationTrackingReadbackBuffer[7] = quat.y;
-            orientationTrackingReadbackBuffer[8] = quat.z;
+            orientationTrackingReadbackBuffer[6] = quat.w;
+            orientationTrackingReadbackBuffer[7] = quat.x;
+            orientationTrackingReadbackBuffer[8] = quat.y;
+            orientationTrackingReadbackBuffer[9] = quat.z;
 
             ovrInputStateTrackedRemote state;
             state.Header.ControllerType = ovrControllerType_TrackedRemote;
             vrapi_GetCurrentInputState(ovrMobile_, RemoteDeviceID, &state.Header);
 
-            orientationTrackingReadbackBuffer[9] = state.Buttons;
-            orientationTrackingReadbackBuffer[10] = state.TrackpadPosition.x;
-            orientationTrackingReadbackBuffer[11] = state.TrackpadPosition.y;
+            orientationTrackingReadbackBuffer[2] = state.TrackpadStatus;
+
+            orientationTrackingReadbackBuffer[10] = state.Buttons;
+            orientationTrackingReadbackBuffer[11] = state.TrackpadPosition.x;
+            orientationTrackingReadbackBuffer[12] = state.TrackpadPosition.y;
 
             ovrVector3f position = tracking.HeadPose.Pose.Position;
-            orientationTrackingReadbackBuffer[2] = position.x;
-            orientationTrackingReadbackBuffer[3] = position.y;
-            orientationTrackingReadbackBuffer[4] = position.z;
+            orientationTrackingReadbackBuffer[3] = position.x;
+            orientationTrackingReadbackBuffer[4] = position.y;
+            orientationTrackingReadbackBuffer[5] = position.z;
 
         } else {
             // set disconnected


### PR DESCRIPTION
This PR sets MotionEvents for the GearCursorController. It also enables one to query if the touchpad of the GearVR controller is being touched (not pressed down).