### PR TITLE
Fix: don't update mFormat while updating from Buffer

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
@@ -71,7 +71,7 @@ int GLBitmapImage::updateFromBitmap(JNIEnv *env, int target, jobject bitmap)
     return 0;
 }
 
-int GLBitmapImage::updateFromBuffer(JNIEnv *env, int target, jobject pixels)
+void GLBitmapImage::updateFromBuffer(JNIEnv *env, int target, jobject pixels)
 {
     void* directPtr = env->GetDirectBufferAddress(pixels);
     glTexSubImage2D(target, 0, 0, 0, mWidth, mHeight, mFormat, mType, directPtr);
@@ -141,7 +141,7 @@ void GLBitmapImage::updateFromBitmap(int texid)
     }
     if (mIsBuffer)
     {
-        mFormat = updateFromBuffer(env, mGLTarget, mBitmap);
+        updateFromBuffer(env, mGLTarget, mBitmap);
     } else {
         mFormat = updateFromBitmap(env, mGLTarget, mBitmap);
     }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.h
@@ -54,7 +54,7 @@ namespace gvr {
         void loadCompressedMipMaps(jbyte *data, int format);
 
     private:
-        int updateFromBuffer(JNIEnv *env, int target, jobject bitmap);
+        void updateFromBuffer(JNIEnv *env, int target, jobject bitmap);
     };
 
 }


### PR DESCRIPTION
Fix for: update texture from NIO buffer #1316, #1173
Problem: GLBitmapImeage::updateFromBuffer() return type is int,
but method body doesn't have return statement
Solution: Don't update mFormat.
For buffers, format is a parameter to the update() method
- - -
GearVRf-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com