### PR TITLE
Vulkan transparency

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBitmapTexture.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBitmapTexture.java
@@ -116,7 +116,7 @@ public class GVRBitmapTexture extends GVRImage
      */
     public void setBitmap(Bitmap bmap)
     {
-        NativeBitmapImage.updateFromBitmap(getNative(), bmap);
+        NativeBitmapImage.updateFromBitmap(getNative(), bmap, bmap.hasAlpha());
     }
 
     /**
@@ -188,7 +188,7 @@ class NativeBitmapImage {
     static native void setFileName(long pointer, String fname);
     static native String getFileName(long pointer);
     static native void updateFromMemory(long pointer, int width, int height, byte[] data);
-    static native void updateFromBitmap(long pointer, Bitmap bitmap);
+    static native void updateFromBitmap(long pointer, Bitmap bitmap, boolean hasAlpha);
     static native void updateFromBuffer(long pointer, int width, int height, int format, int type, Buffer pixels);
     static native void updateCompressed(long pointer, int width, int height, int imageSize, byte[] data, int levels, int[] offsets);
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/asynchronous/AsyncBitmapTexture.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/asynchronous/AsyncBitmapTexture.java
@@ -596,6 +596,9 @@ class AsyncBitmapTexture {
         }
         bitmap = Bitmap.createBitmap(width, height, Config.ARGB_8888);
         bitmap.copyPixelsFromBuffer(ByteBuffer.wrap(rgb));
+        if(depth == 24) {
+            bitmap.setHasAlpha(false);
+        }
         return bitmap;
     }
 

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -258,6 +258,7 @@ void Renderer::addRenderData(RenderData *render_data, Scene* scene) {
     if (render_data->render_mask() == 0) {
         return;
     }
+    render_data->adjustRenderingOrderForTransparency();
     render_data_vector.push_back(render_data);
     return;
 }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
@@ -162,4 +162,5 @@ void GLBitmapImage::loadCompressedMipMaps(jbyte *data, int format)
                                data);
     }
 }
+
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
@@ -350,6 +350,8 @@ public:
         render_pass_list_[pass]->set_shader(shaderid);
     }
 
+    void adjustRenderingOrderForTransparency();
+
     int             get_shader(int pass =0) const { return render_pass_list_[pass]->get_shader(); }
     std::string     getHashCode();
     void            setCameraDistanceLambda(std::function<float()> func);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data_jni.cpp
@@ -25,7 +25,7 @@ namespace gvr {
 
 extern "C" {
     JNIEXPORT jlong JNICALL
-Java_org_gearvrf_NativeRenderData_ctor(JNIEnv * env, jobject obj);
+    Java_org_gearvrf_NativeRenderData_ctor(JNIEnv * env, jobject obj);
 
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_NativeRenderData_getComponentType(JNIEnv * env, jobject obj);
@@ -254,6 +254,7 @@ JNIEXPORT jint JNICALL
 Java_org_gearvrf_NativeRenderData_getRenderingOrder(
     JNIEnv * env, jobject obj, jlong jrender_data) {
 RenderData* render_data = reinterpret_cast<RenderData*>(jrender_data);
+render_data->adjustRenderingOrderForTransparency();
 return render_data->rendering_order();
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.h
@@ -36,10 +36,19 @@ namespace gvr {
         explicit BitmapImage(int format);
         virtual ~BitmapImage();
         void update(JNIEnv* env, int width, int height, jbyteArray data);
-        void update(JNIEnv* env, jobject bitmap);
+        void update(JNIEnv* env, jobject bitmap, bool hasAlpha);
         void update(JNIEnv* env, int width, int height, int format, int type, jobject bitmap);
         void update(JNIEnv *env, int width, int height, int imageSize,
                     jbyteArray bytes, int levels, const int* dataOffsets);
+
+        void set_transparency(bool hasTransparency) {
+            mHasTransparency = hasTransparency;
+        }
+
+        virtual bool transparency() {
+            return mHasTransparency;
+        }
+
     protected:
         void clearData(JNIEnv* env);
 
@@ -48,7 +57,7 @@ namespace gvr {
         BitmapImage(BitmapImage&& texture) = delete;
         BitmapImage& operator=(const BitmapImage& texture) = delete;
         BitmapImage& operator=(BitmapImage&& texture) = delete;
-
+        bool hasAlpha(int format);
 
     protected:
         JavaVM* mJava;
@@ -56,6 +65,7 @@ namespace gvr {
         jobject mBitmap;
         bool mIsBuffer;
         bool mIsCompressed;
+        bool mHasTransparency;
     };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image_jni.cpp
@@ -50,7 +50,7 @@ namespace gvr
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_NativeBitmapImage_updateFromBitmap(JNIEnv *env, jobject obj,
-                                                        jlong jtexture, jobject jbitmap);
+                                                        jlong jtexture, jobject jbitmap, jboolean hasAlpha);
     }
 
     JNIEXPORT jlong JNICALL
@@ -75,10 +75,10 @@ namespace gvr
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_NativeBitmapImage_updateFromBitmap(JNIEnv *env, jobject obj,
-                                                        jlong jtexture, jobject jbitmap)
+                                                        jlong jtexture, jobject jbitmap, jboolean hasAlpha)
     {
         BitmapImage *texture = reinterpret_cast<BitmapImage *>(jtexture);
-        texture->update(env, jbitmap);
+        texture->update(env, jbitmap, static_cast<bool>(hasAlpha) );
     }
 
     JNIEXPORT void JNICALL

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_transparency.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_transparency.cpp
@@ -1,0 +1,97 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/***************************************************************************
+ * JNI
+ ***************************************************************************/
+
+#include "bitmap_transparency.h"
+
+namespace gvr {
+
+bool bitmap_has_transparency(JNIEnv *env, jobject jbitmap) {
+    int result = -4;
+    bool transparency = false;
+	AndroidBitmapInfo info;
+    void *addrPtr = NULL;
+
+    result = AndroidBitmap_getInfo(env, jbitmap, &info);
+    if(result != ANDROID_BITMAP_RESUT_SUCCESS) {
+        LOGE("GVRBitmapTexture: unable to determine bitmap format in bitmap_transparency.cpp");
+        return false;
+    }
+
+    result = AndroidBitmap_lockPixels(env, jbitmap, &addrPtr);
+    if(result != ANDROID_BITMAP_RESUT_SUCCESS) {
+        LOGE("GVRBitmapTexture: unable to lock bitmap in bitmap_transparency.cpp");
+        return false;
+    }
+
+    uint32_t width = info.width;
+    uint32_t height = info.height;
+    uint32_t stride = info.stride;
+    int32_t format = info.format;
+    bool done = false;
+
+    if(format == ANDROID_BITMAP_FORMAT_A_8) {
+        const uint8_t *ptr = (uint8_t *)addrPtr;
+        while(height > 0 && !done) {
+            if(*ptr < 255) {
+                transparency = true;
+                done = true;
+            }
+            ptr += stride;
+            height--;
+        }
+    } else if(format == ANDROID_BITMAP_FORMAT_RGBA_8888) {
+        const uint32_t *ptr = (uint32_t *)addrPtr; 
+        while(height > 0 && !done) {
+            for(int x = 0; x < width && !done; x++) {
+                uint8_t alpha = ptr[x] >> 24;
+                if(alpha < 255) {
+                    transparency = true;
+                    done = true;
+                }
+            }
+            ptr = (const uint32_t*)((const char*)ptr + stride);
+            height--;
+        }
+    } else if(format == ANDROID_BITMAP_FORMAT_RGBA_4444) {
+        const uint16_t *ptr = (uint16_t *)addrPtr; 
+        while(height > 0 && !done) {
+            for (int x = 0; x < width && !done; x++) {
+                uint8_t alpha = ptr[x] & 0x7;
+                if(alpha < 128) {
+                    transparency = true;
+                    done = true;
+                }
+            }
+            ptr = (const uint16_t*)((const char*)ptr + stride);
+            height--;
+        }
+    } 
+
+    result = AndroidBitmap_unlockPixels(env, jbitmap);
+    if(result != ANDROID_BITMAP_RESUT_SUCCESS) {
+        LOGE("GVRBitmapTexture: unable to unlock bitmap in bitmap_transparency.cpp");
+        return transparency;
+    }
+
+    return transparency;
+}
+
+
+
+}

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_transparency.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_transparency.h
@@ -1,0 +1,29 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/***************************************************************************
+ * JNI
+ ***************************************************************************/
+
+#include "android/bitmap.h"
+#include "util/gvr_jni.h"
+#include "util/gvr_log.h"
+
+
+namespace gvr {
+
+bool bitmap_has_transparency(JNIEnv *env, jobject jbitmap);
+
+}

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
@@ -84,6 +84,7 @@ public:
     virtual int getId() = 0;
     virtual bool isReady() = 0;
     virtual void texParamsChanged(const TextureParameters&) = 0;
+    virtual bool transparency() { return false; }
 
     bool hasData() const { return mState == HAS_DATA; }
     short getWidth() const { return mWidth; }

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
@@ -141,6 +141,11 @@ public:
         return mTexParams;
     }
 
+    bool transparency() {
+        Image* image = getImage();
+        return image && image->transparency();
+    }
+
 protected:
     JavaVM* mJava;
     jobject mJavaImage;


### PR DESCRIPTION
Creatively reworked "Try to automatically detect transparency #1212"

- Change state_sort() compare function: check transparency depth right after rendering order
- Implement all transparency bookkeeping in the native code
- Adjust render order during every cull pass, and when Java asks Native for render order (that may happen before the cull pass). 

We can make it more efficient in two ways: 

- optimize adjust RenderOrderForTransparency() by reducing by-name lookups: either get the first texture and assume it's either main texture or diffuse texture; or, more robustly, look for main texture, and if it is null, then look for the diffuse texture.
- check dirty state before adjusting: this may need a new dirty flag.

@NolaDonato, @thomasflynn, @roshanch Please let me know if we want to implement efficiency improvements right now.
 
_This PR shall be 'merged'_
- - -
GearVRf-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com