### PR TITLE
Vulkan:  	Add loadModel, loadScene variants with import settings

### DIFF
--- a/GVRf/Extensions/build.gradle
+++ b/GVRf/Extensions/build.gradle
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+if(file("../../../extra_properties.gradle").exists()) {
+    apply from: '../../../extra_properties.gradle'
+}
+ 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRAssetLoader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRAssetLoader.java
@@ -1155,6 +1155,57 @@ public final class GVRAssetLoader {
     }
 
     /**
+     * Loads a hierarchy of scene objects {@link GVRSceneObject} from a 3D model
+     * replaces the current scene with it.
+     * <p>
+     * This function loads the model and its textures asynchronously in the background
+     * and will return before the model is loaded.
+     * IAssetEvents are emitted to event listener attached to the context.
+     *
+     * @param model
+     *          Scene object to become the root of the loaded model.
+     *          This scene object will be named with the base filename of the loaded asset.
+     * @param volume
+     *            A GVRResourceVolume based on the asset path to load.
+     *            This volume will be used as the base for loading textures
+     *            and other models contained within the model.
+     *            You can subclass GVRResourceVolume to provide custom IO.
+     * @param settings
+     *            Import settings controlling how assets are imported
+     * @param scene
+     *            Scene to be replaced with the model.
+     * @param handler
+     *            IAssetEvents handler to process asset loading events
+     * @see #loadModel(GVRSceneObject, GVRResourceVolume, GVRScene)
+     */
+    public void loadScene(final GVRSceneObject model, final GVRResourceVolume volume, final EnumSet<GVRImportSettings> settings, final GVRScene scene, final IAssetEvents handler)
+    {
+        Threads.spawn(new Runnable()
+        {
+            public void run()
+            {
+                AssetRequest assetRequest = new AssetRequest(model, volume, scene, handler, true);
+                String filePath = volume.getFileName();
+                String ext = filePath.substring(filePath.length() - 3).toLowerCase();
+
+                assetRequest.setImportSettings(settings);
+                model.setName(assetRequest.getBaseName());
+                try
+                {
+                    if (ext.equals("x3d"))
+                        loadX3DModel(assetRequest, model);
+                    else
+                        loadJassimpModel(assetRequest, model);
+                }
+                catch (IOException ex)
+                {
+                    // onModelError is generated in this case
+                }
+            }
+        });
+    }
+
+    /**
      * Loads a hierarchy of scene objects {@link GVRSceneObject} asymchronously from a 3D model
      * on the volume provided and adds it to the specified scene.
      * <p>
@@ -1203,7 +1254,60 @@ public final class GVRAssetLoader {
                 }
             }
         });
-     }
+    }
+
+    /**
+     * Loads a hierarchy of scene objects {@link GVRSceneObject} asymchronously from a 3D model
+     * on the volume provided and adds it to the specified scene.
+     * <p>
+     * and will return before the model is loaded.
+     * IAssetEvents are emitted to event listeners attached to the context.
+     * The resource volume may reference res/raw in which case all textures
+     * and other referenced assets must also come from res/raw. The asset loader
+     * cannot load textures from the drawable directory.
+     *
+     * @param model
+     *            A GVRSceneObject to become the root of the loaded model.
+     * @param volume
+     *            A GVRResourceVolume based on the asset path to load.
+     *            This volume will be used as the base for loading textures
+     *            and other models contained within the model.
+     *            You can subclass GVRResourceVolume to provide custom IO.
+     * @param settings
+     *            Import settings controlling how assets are imported
+     * @param scene
+     *            If present, this asset loader will wait until all of the textures have been
+     *            loaded and then it will add the model to the scene.
+     *
+     * @see #loadMesh(GVRAndroidResource.MeshCallback, GVRAndroidResource, int)
+     * @see #loadScene(GVRSceneObject, GVRResourceVolume, EnumSet, GVRScene, IAssetEvents)
+     */
+    public void loadModel(final GVRSceneObject model, final GVRResourceVolume volume, final EnumSet<GVRImportSettings> settings, final GVRScene scene)
+    {
+        Threads.spawn(new Runnable()
+        {
+            public void run()
+            {
+                String filePath = volume.getFileName();
+                AssetRequest assetRequest = new AssetRequest(model, volume, scene, null, false);
+                String ext = filePath.substring(filePath.length() - 3).toLowerCase();
+
+                model.setName(assetRequest.getBaseName());
+                assetRequest.setImportSettings(settings);
+                try
+                {
+                    if (ext.equals("x3d"))
+                        loadX3DModel(assetRequest, model);
+                    else
+                        loadJassimpModel(assetRequest, model);
+                }
+                catch (IOException ex)
+                {
+                    // onModelError is generated in this case.
+                }
+            }
+        });
+    }
 
     /**
      * Loads a hierarchy of scene objects {@link GVRSceneObject} from a 3D model.

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRExternalScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRExternalScene.java
@@ -8,6 +8,7 @@ import org.gearvrf.GVRContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -22,6 +23,7 @@ public class GVRExternalScene extends GVRBehavior
     static private long TYPE_EXTERNALSCENE = newComponentType(GVRExternalScene.class);
     private String mFilePath;
     private boolean mReplaceScene;
+    private EnumSet<GVRImportSettings> mImportSettings = null;
     public final GVRResourceVolume mVolume;
 
     /**
@@ -37,6 +39,7 @@ public class GVRExternalScene extends GVRBehavior
         mVolume = new GVRResourceVolume(ctx, filePath);
         mFilePath = filePath;
         mReplaceScene = replaceScene;
+        mImportSettings = GVRImportSettings.getRecommendedSettings();
     }
 
     /**
@@ -47,6 +50,23 @@ public class GVRExternalScene extends GVRBehavior
     public GVRExternalScene(GVRResourceVolume volume, boolean replaceScene)
     {
         super(volume.gvrContext);
+        mType = getComponentType();
+        mVolume = volume;
+        mFilePath = volume.getFullPath();
+        mReplaceScene = replaceScene;
+        mImportSettings = GVRImportSettings.getRecommendedSettings();
+    }
+
+    /**
+     * Constructs an external scene component to load the given asset file.
+     * @param volume        GVRResourceVolume containing the path of the asset.
+     * @param settings      import settings
+     * @param replaceScene  true to replace the current scene, false to just add the model
+     */
+    public GVRExternalScene(GVRResourceVolume volume, EnumSet<GVRImportSettings> settings, boolean replaceScene)
+    {
+        super(volume.gvrContext);
+        mImportSettings = settings;
         mType = getComponentType();
         mVolume = volume;
         mFilePath = volume.getFullPath();
@@ -120,11 +140,11 @@ public class GVRExternalScene extends GVRBehavior
         }
         if (mReplaceScene)
         {
-            loader.loadScene(getOwnerObject(), mVolume, scene, null);
+            loader.loadScene(getOwnerObject(), mVolume, mImportSettings, scene, null);
         }
         else
         {
-            loader.loadModel(getOwnerObject(), mVolume, scene);
+            loader.loadModel(getOwnerObject(), mVolume, mImportSettings, scene);
         }
         return true;
     }
@@ -152,11 +172,11 @@ public class GVRExternalScene extends GVRBehavior
 
         if (mReplaceScene)
         {
-            loader.loadScene(getOwnerObject(), mVolume, getGVRContext().getMainScene(), handler);
+            loader.loadScene(getOwnerObject(), mVolume, mImportSettings, getGVRContext().getMainScene(), handler);
         }
         else
         {
-            loader.loadModel(mVolume, getOwnerObject(), GVRImportSettings.getRecommendedSettings(), true, handler);
+            loader.loadModel(mVolume, getOwnerObject(), mImportSettings, true, handler);
         }
     }
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRJassimpAdapter.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRJassimpAdapter.java
@@ -427,6 +427,8 @@ class GVRJassimpAdapter {
                 return AiPostProcessSteps.OPTIMIZE_GRAPH;
             case FLIP_UV:
                 return AiPostProcessSteps.FLIP_UVS;
+            case START_ANIMATIONS:
+                return null;
             case NO_ANIMATION:
             case NO_LIGHTING:
             case NO_TEXTURING:


### PR DESCRIPTION
Vulkan manual merge of
**Add loadModel, loadScene variants with import settings (#1263)**

**Add the ability to specify import settings for loading scene and models
asynchronously.**
 
_This PR shall be 'merged'_
- - -
GearVRf-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com