### PR TITLE
Final Vulkan merge

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrMonoscopicRenderer.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrMonoscopicRenderer.java
@@ -49,14 +49,9 @@ abstract class OvrMonoscopicRenderer {
                         renderBundle.getPostEffectRenderTextureA().getNative(),
                         renderBundle.getPostEffectRenderTextureB().getNative());
     }
-
-    static void cull(GVRScene scene, GVRCamera camera, IRenderBundle renderBundle) {
-        OvrNativeMonoscopicRenderer.cull(scene.getNative(), camera.getNative(), renderBundle.getMaterialShaderManager().getNative());
-    }
 }
 
 class OvrNativeMonoscopicRenderer {
-    static native void cull(long scene, long camera, long shader_manager);
     static native void renderCamera(long scene, long camera, int viewportX,
             int viewportY, int viewportWidth, int viewportHeight,
             long shaderManager, long postEffectShaderManager,

--- a/GVRf/Framework/backend_oculus/src/main/jni/monoscopic/monoscopic_renderer_jni.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/monoscopic/monoscopic_renderer_jni.cpp
@@ -25,9 +25,6 @@ void Java_org_gearvrf_OvrNativeMonoscopicRenderer_renderCamera(JNIEnv * env,
         jlong jshader_manager, jlong jpost_effect_shader_manager,
         jlong jpost_effect_render_texture_a,
         jlong jpost_effect_render_texture_b);
-
-void Java_org_gearvrf_OvrNativeMonoscopicRenderer_cull(JNIEnv * env,
-        jobject obj, jlong jscene, jlong jcamera, jlong shader_manager);
 }
 
 void Java_org_gearvrf_OvrNativeMonoscopicRenderer_renderCamera(JNIEnv * env,
@@ -50,16 +47,6 @@ void Java_org_gearvrf_OvrNativeMonoscopicRenderer_renderCamera(JNIEnv * env,
                viewportHeight, shader_manager,
                post_effect_render_texture_a, post_effect_render_texture_b);
 
-
-}
-
-void Java_org_gearvrf_OvrNativeMonoscopicRenderer_cull(JNIEnv * env,
-        jobject obj, jlong jscene, jlong jcamera, jlong jshader_manager) {
-    Scene* scene = reinterpret_cast<Scene*>(jscene);
-    Camera* camera = reinterpret_cast<Camera*>(jcamera);
-    ShaderManager* shader_manager = reinterpret_cast<ShaderManager*>(jshader_manager);
-    gRenderer = Renderer::getInstance();
-    gRenderer->cull(scene, camera, shader_manager);
 
 }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMesh.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMesh.java
@@ -528,6 +528,102 @@ public class GVRMesh extends GVRHybridObject implements PrettyPrint {
         }
     }
 
+    /**
+     * A static method to generate a curved mesh along an arc.
+     *
+     * Note the width and height arguments are used only as a means to
+     * get the width:height ratio.
+     *
+     * @param gvrContext    the current context
+     * @param width         a number representing the width
+     * @param height        a number representing the height
+     * @param centralAngle  the central angle of the arc
+     * @param radius        the radius of the circle
+     * @return
+     */
+    public static GVRMesh createCurvedMesh(GVRContext gvrContext, int width, int height, float centralAngle, float radius){
+        GVRMesh mesh = new GVRMesh(gvrContext);
+        final float MAX_DEGREES_PER_SUBDIVISION = 10f;
+
+        float ratio = (float)width/(float)height;
+        int subdivisions = (int) Math.ceil(centralAngle / MAX_DEGREES_PER_SUBDIVISION);
+        float degreesPerSubdivision = centralAngle/subdivisions;
+        // Scale the number of subdivisions with the central angle size
+        // Let each subdivision represent a constant number of degrees on the arc
+        double startDegree = -centralAngle/2.0;
+
+        float h = (float) (radius * Math.toRadians(centralAngle))/ratio;
+
+        float yTop = h/2;
+        float yBottom = -yTop;
+
+        float[] vertices = new float[(subdivisions+1)*6];
+        float[] normals = new float[(subdivisions+1)*6];
+        float[] texCoords= new float[(subdivisions+1)*4];
+        char[] triangles = new char[subdivisions*6];
+
+        /*
+         * The following diagram illustrates the construction method
+         * Let s be the number of subdivisions, then we create s pairs of vertices
+         * like so
+         *
+         * {0}  {2}  {4} ... {2s-1}
+         *                             |y+
+         * {1}  {3}  {5} ... {2s}      |___x+
+         *                          z+/
+         */
+        for(int i = 0; i <= subdivisions; i++){
+            double angle = Math.toRadians(-90+startDegree + degreesPerSubdivision*i);
+            double cos = Math.cos(angle);
+            double sin = Math.sin(angle);
+            float x = (float) (radius * cos);
+            float z = (float) ((radius * sin) + radius);
+            vertices[6*i] = x;
+            vertices[6*i + 1] = yTop;
+            vertices[6*i + 2] = z;
+            normals[6*i] = (float)-cos;
+            normals[6*i + 1] = 0.0f;
+            normals[6*i + 2] = (float)-sin;
+            texCoords[4*i] = (float)i/subdivisions;
+            texCoords[4*i + 1] = 0.0f;
+
+            vertices[6*i + 3] = x;
+            vertices[6*i + 4] = yBottom;
+            vertices[6*i + 5] = z;
+            normals[6*i + 3] = (float)-cos;
+            normals[6*i + 4] = 0.0f;
+            normals[6*i + 5] = (float)-sin;
+            texCoords[4*i + 2] = (float)i/subdivisions;
+            texCoords[4*i + 3] = 1.0f;
+        }
+
+        /*
+         * Referring to the diagram above, we create two triangles
+         * for each pair of consecutive pairs of vertices
+         * (e.g. we create two triangles with {0, 1} and {2, 3}
+         *  and two triangles with {2, 3} and {4, 5})
+         *
+         * {0}--{2}--{4}-...-{2s-1}
+         *  | ＼  | ＼ |        |       |y+
+         * {1}--{3}--{5}-...-{2s}      |___x+
+         *                          z+/
+         */
+        for(int i = 0; i < subdivisions; i++){
+            triangles[6*i] = (char)(2*(i+1)+1);
+            triangles[6*i+1] = (char) (2*(i));
+            triangles[6*i+2] = (char) (2*(i)+1);
+            triangles[6*i+3] = (char) (2*(i+1)+1);
+            triangles[6*i+4] = (char) (2*(i+1));
+            triangles[6*i+5] = (char) (2*(i));
+        }
+
+        mesh.setVertices(vertices);
+        mesh.setNormals(normals);
+        mesh.setTexCoords(texCoords);
+        mesh.setIndices(triangles);
+        return mesh;
+    }
+
     @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GearCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GearCursorController.java
@@ -318,7 +318,7 @@ final class GearCursorController extends GVRCursorController {
             quaternionf.transform(FORWARD, result);
 
             pivot.getTransform().setPosition(position.x, position.y, position.z);
-            setOrigin(position.x, position.y, position.z);
+            setOrigin(position.x + result.x, position.y + result.y, position.z + result.z);
 
             int handleResult = handleButton(key, OVR_BUTTON_ENTER, prevButtonEnter, KeyEvent
                     .KEYCODE_ENTER);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRGUISceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRGUISceneObject.java
@@ -1,0 +1,191 @@
+package org.gearvrf.scene_objects;
+
+import android.os.Handler;
+import android.os.Message;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+
+import org.gearvrf.GVRBaseSensor;
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRMesh;
+import org.gearvrf.GVRMeshCollider;
+import org.gearvrf.GVRPicker;
+import org.gearvrf.ISensorEvents;
+import org.gearvrf.SensorEvent;
+import org.gearvrf.scene_objects.view.GVRView;
+
+import java.util.List;
+
+
+/**
+ * This class extends the {@link GVRViewSceneObject} to make interaction with Android
+ * Views simple. This class achieves the following:
+ *
+ * 1.  Allows any {@link org.gearvrf.GVRCursorController} to be used for interactions
+ * with the {@link GVRView} displayed. This is achieved with an {@link ISensorEvents} listener
+ * that uses the motion events set in {@link org.gearvrf.GVRCursorController}s to dispatch
+ * appropriate touch events to the Android View contained in the {@link GVRView}.
+ *
+ * 2. Generates an appropriate mesh for displaying the {@link GVRView} passed to the
+ * constructor. The mesh will always have the correct aspect ratio, and the user can
+ * specify the curvature of the mesh if desired.
+ *
+ * To use this class, simply instantiate a new {@link GVRGUISceneObject} with the appropriate
+ * arguments, and add the instance to the current {@link org.gearvrf.GVRScene} using
+ * {@link org.gearvrf.GVRScene#addSceneObject}. Then use the application's
+ * {@link org.gearvrf.GVRCursorController}(s) to interact with the {@link GVRGUISceneObject}
+ * instance.
+ */
+
+public class GVRGUISceneObject extends GVRViewSceneObject {
+    private static final String TAG = GVRGUISceneObject.class.getSimpleName();;
+
+    private static final int MOTION_EVENT = 1;
+
+    private int frameWidth;
+    private int frameHeight;
+
+    private final MotionEvent.PointerProperties[] pointerProperties;
+    private final MotionEvent.PointerCoords pointerCoords = new MotionEvent.PointerCoords();;
+    private final MotionEvent.PointerCoords[] pointerCoordsArray = new MotionEvent.PointerCoords[]{pointerCoords};;
+    private Handler mainThreadHandler;
+
+    static {
+    }
+
+    /**
+     * Constructor for GVRGUISceneObject
+     *
+     * This constructor will generate a planar {@link GVRMesh} for you.
+     *
+     * @param gvrContext    current {@link GVRContext}
+     * @param gvrView       the {@link GVRView} to be displayed on the GVRGUISceneObject
+     */
+    public <T extends View & GVRView> GVRGUISceneObject(GVRContext gvrContext, T gvrView) {
+        this(gvrContext, gvrView, planarMesh(gvrContext, gvrView));
+    }
+
+    /**
+     * Constructor for GVRGUISceneObject
+     *
+     * This constructor will generate a curved {@link GVRMesh} for you based on the
+     * arguments passed.
+     *
+     * @param gvrContext    current {@link GVRContext}
+     * @param gvrView       the {@link GVRView} to be displayed on the GVRGUISceneObject
+     * @param radius        the radius of the circle to use to create the arc
+     * @param centralAngle  the central angle of the arc
+     */
+    public <T extends View & GVRView> GVRGUISceneObject(GVRContext gvrContext, T gvrView, float radius, float centralAngle) {
+        this(gvrContext, gvrView, curvedMesh(gvrContext, gvrView, radius, centralAngle));
+    }
+
+    /**
+     * Constructor for GVRGUISceneObject
+     *
+     * This constructor will generate a curved {@link GVRMesh} for you based on the
+     * arguments passed. The central angle of the arc of the curve will be 45 degrees.
+     *
+     * @param gvrContext    current {@link GVRContext}
+     * @param gvrView       the {@link GVRView} to be displayed on the GVRGUISceneObject
+     * @param radius        the radius of the circle to use to create the arc
+     */
+    public <T extends View & GVRView> GVRGUISceneObject(GVRContext gvrContext, T gvrView, float radius) {
+        this(gvrContext, gvrView, curvedMesh(gvrContext, gvrView, radius, 45f));
+    }
+
+    /**
+     * Constructor for GVRGUISceneObject
+     *
+     * @param gvrContext    current {@link GVRContext}
+     * @param gvrView       the {@link GVRView} to be displayed on the GVRGUISceneObject
+     * @param mesh          the mesh that the {@link GVRView} will be displayed on
+     */
+    public <T extends View & GVRView> GVRGUISceneObject(GVRContext gvrContext, final T gvrView, GVRMesh mesh) {
+        super(gvrContext, gvrView, mesh);
+        this.frameWidth = gvrView.getView().getWidth();
+        this.frameHeight = gvrView.getView().getHeight();
+        this.attachCollider(new GVRMeshCollider(gvrContext, mesh, true));
+        this.mainThreadHandler = new Handler(gvrContext.getActivity().getMainLooper()){
+            @Override
+            public void handleMessage(Message msg) {
+                // Dispatch motion event
+                if (msg.what == MOTION_EVENT) {
+                    MotionEvent motionEvent = (MotionEvent) msg.obj;
+                    gvrView.dispatchTouchEvent(motionEvent);
+                    gvrView.invalidate();
+                    motionEvent.recycle();
+                }
+            }
+        };
+        this.getEventReceiver().addListener(GUIEventListener);
+        this.setSensor(new GVRBaseSensor(gvrContext));
+
+        MotionEvent.PointerProperties properties = new MotionEvent.PointerProperties();
+        properties.id = 0;
+        properties.toolType = MotionEvent.TOOL_TYPE_MOUSE;
+        pointerProperties = new MotionEvent.PointerProperties[]{properties};
+    }
+
+    private static GVRMesh planarMesh(GVRContext gvrContext, GVRView gvrView){
+        View view = gvrView.getView();
+        int w = view.getWidth();
+        int h = view.getHeight();
+        int largest = w > h ? w : h;
+        return gvrContext.createQuad((float)w/largest*1.0f, (float)h/largest*1.0f);
+    }
+
+    private static GVRMesh curvedMesh(GVRContext gvrContext, GVRView gvrView, float radius, float centralAngle){
+        View view = gvrView.getView();
+        int w = view.getWidth();
+        int h = view.getHeight();
+        return GVRMesh.createCurvedMesh(gvrContext, w, h, centralAngle, radius);
+    }
+
+    private ISensorEvents GUIEventListener = new ISensorEvents() {
+        private static final float SCALE = 5.0f;
+        private float savedMotionEventX, savedMotionEventY, savedHitPointX,
+                savedHitPointY;
+
+        @Override
+        public void onSensorEvent(SensorEvent event) {
+            List<MotionEvent> motionEvents = event.getCursorController().getMotionEvents();
+
+            for (MotionEvent motionEvent : motionEvents) {
+                if (motionEvent.getAction() == MotionEvent.ACTION_MOVE) {
+                    pointerCoords.x = savedHitPointX
+                            + ((motionEvent.getX() - savedMotionEventX) * SCALE);
+                    pointerCoords.y = savedHitPointY
+                            + ((motionEvent.getY() - savedMotionEventY) * SCALE);
+                } else {
+                    GVRPicker.GVRPickedObject pickedObject = event.getPickedObject();
+                    pointerCoords.x = pickedObject.getTextureU() * frameWidth;
+                    pointerCoords.y = pickedObject.getTextureV() * frameHeight;
+
+
+                    if (motionEvent.getAction() == KeyEvent.ACTION_DOWN) {
+                        // save the coordinates on down
+                        savedMotionEventX = motionEvent.getX();
+                        savedMotionEventY = motionEvent.getY();
+
+                        savedHitPointX = pointerCoords.x;
+                        savedHitPointY = pointerCoords.y;
+                    }
+                }
+
+                final MotionEvent clone = MotionEvent.obtain(
+                        motionEvent.getDownTime(), motionEvent.getEventTime(),
+                        motionEvent.getAction(), 1, pointerProperties,
+                        pointerCoordsArray, 0, 0, 1f, 1f, 0, 0,
+                        InputDevice.SOURCE_TOUCHSCREEN, 0);
+
+                Message message = Message.obtain(mainThreadHandler, MOTION_EVENT, 0, 0,
+                        clone);
+                mainThreadHandler.sendMessage(message);
+            }
+        }
+    };
+
+}

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
@@ -17,7 +17,6 @@ package org.gearvrf.x3d;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.graphics.Typeface;
 
 import org.gearvrf.GVRCursorController;
 import org.gearvrf.io.GVRControllerType;
@@ -1354,9 +1353,7 @@ public class X3Dobject {
                         }
                         if (useItem != null) {
                             // GVRRenderingData doesn't seem to be shared, but instead has an
-
                             // owner.  Thus share the GVRMesh and GVRMaterial attached to
-
                             // GVRRenderingData.
                             GVRRenderData gvrRenderDataDEFined = useItem.getGVRRenderData();
                             gvrRenderData.setMaterial(gvrRenderDataDEFined.getMaterial());
@@ -1449,16 +1446,12 @@ public class X3Dobject {
                                 .getValue("ambientIntensity");
                         if (ambientIntensityAttribute != null) {
                             Log.e(TAG, "ambientIntensity currently not implemented.");
-
-
                             shaderSettings
                                     .setAmbientIntensity(parseSingleFloatString(ambientIntensityAttribute,
                                                                                 true, false));
                         }
                         String shininessAttribute = attributes.getValue("shininess");
                         if (shininessAttribute != null) {
-
-
                             shaderSettings
                                     .setShininess(parseSingleFloatString(shininessAttribute, true,
                                                                          false));
@@ -1535,6 +1528,7 @@ public class X3Dobject {
 
             /********** TextureTransform **********/
             else if (qName.equalsIgnoreCase("TextureTransform")) {
+                    Log.e(TAG, "X3D TextureTransform not currently implemented");
                     attributeValue = attributes.getValue("DEF");
                     if (attributeValue != null) {
                         Log.e(TAG,
@@ -2749,7 +2743,7 @@ public class X3Dobject {
 
             /********** Billboard **********/
             else if (qName.equalsIgnoreCase("Billboard")) {
-                    Log.e(TAG, "Billboard currently not implemented. ");
+                    Log.e(TAG, "X3D Billboard currently not implemented. ");
                     //TODO: Billboard not currently implemented
                     String name = "";
                     float[] axisOfRotation =
@@ -3023,6 +3017,7 @@ public class X3Dobject {
 
             /********** ElevationGrid **********/
             else if (qName.equalsIgnoreCase("ElevationGrid")) {
+                    Log.e(TAG, "X3D ElevationGrid not currently implemented. ");
                     String name = "";
                     float creaseAngle = 0;
                     float[] height = null;

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
@@ -713,6 +713,11 @@ public class X3Dobject {
     // holds complete JavaScript code per <SCRIPT> tag
     private String javaScriptCode = "";
 
+    // contains the directory structure for inlines to be appended in front of
+    // references to texture map file names (plus their own sub-directory.
+    private String inlineSubdirectory = "";
+
+
 
     // The Text_Font Params class and Reset() function handle
     // the values set in the <Text> and <FontStyle> nodes, which are
@@ -1318,10 +1323,10 @@ public class X3Dobject {
 
 
             /********** Shape **********/
-            else if (qName.equalsIgnoreCase("shape")) {
+            else if (qName.equalsIgnoreCase("Shape")) {
 
                 gvrRenderData = new GVRRenderData(gvrContext);
-               // gvrRenderData.setAlphaToCoverage(true);
+                gvrRenderData.setAlphaToCoverage(true);
                 gvrRenderData.setRenderingOrder(GVRRenderingOrder.TRANSPARENT);
                 gvrRenderData.setCullFace(GVRCullFaceEnum.Back);
                 shaderSettings.initializeTextureMaterial(new GVRMaterial(gvrContext, GVRMaterial.GVRShaderType.Phong.ID));
@@ -1373,9 +1378,8 @@ public class X3Dobject {
 
 
             /********** Appearance **********/
-            else if (qName.equalsIgnoreCase("appearance")) {
+            else if (qName.equalsIgnoreCase("Appearance")) {
                     /* This gives the X3D-only Shader */
-                    if (!UNIVERSAL_LIGHTS)
                     attributeValue = attributes.getValue("USE");
                     if (attributeValue != null) { // shared Appearance node, GVRMaterial
                         DefinedItem useItem = null;
@@ -1497,7 +1501,6 @@ public class X3Dobject {
                             urlAttribute = urlAttribute.replace("\"", ""); // remove double and
                             // single quotes
                             urlAttribute = urlAttribute.replace("\'", "");
-                            urlAttribute = urlAttribute.toLowerCase();
 
                             final String filename = urlAttribute;
                             String repeatSAttribute = attributes.getValue("repeatS");
@@ -1517,7 +1520,7 @@ public class X3Dobject {
 
                             final String defValue = attributes.getValue("DEF");
                             gvrTexture = new GVRTexture(gvrContext, gvrTextureParameters);
-                            GVRAssetLoader.TextureRequest request = new GVRAssetLoader.TextureRequest(assetRequest, gvrTexture, filename);
+                            GVRAssetLoader.TextureRequest request = new GVRAssetLoader.TextureRequest(assetRequest, gvrTexture, (inlineSubdirectory + filename));
                             assetRequest.loadTexture(request);
                             shaderSettings.setTexture(gvrTexture);
                             if (defValue != null) {
@@ -1591,11 +1594,15 @@ public class X3Dobject {
                         }
                         attributeValue = attributes.getValue("solid");
                         if (attributeValue != null) {
-                            Log.e(TAG, "IndexedFaceSet solid attribute not implemented. ");
+                            if (parseBooleanString(attributeValue)) {
+                                Log.e(TAG, "IndexedFaceSet solid=true attribute not implemented. ");
+                            }
                         }
                         attributeValue = attributes.getValue("ccw");
                         if (attributeValue != null) {
-                            Log.e(TAG, "IndexedFaceSet ccw attribute not implemented. ");
+                            if (!parseBooleanString(attributeValue)) {
+                                Log.e(TAG, "IndexedFaceSet ccw=false attribute not implemented. ");
+                            }
                         }
                         attributeValue = attributes.getValue("colorPerVertex");
                         if (attributeValue != null) {
@@ -1607,8 +1614,10 @@ public class X3Dobject {
                         attributeValue = attributes.getValue("normalPerVertex");
                         if (attributeValue != null) {
 
-                            Log.e(TAG,
-                                  "IndexedFaceSet normalPerVertex attribute not implemented. ");
+                            if ( !parseBooleanString(attributeValue)) {
+                                Log.e(TAG,
+                                        "IndexedFaceSet normalPerVertex=false attribute not implemented. ");
+                            }
 
                         }
                         String coordIndexAttribute = attributes.getValue("coordIndex");
@@ -2764,14 +2773,15 @@ public class X3Dobject {
             else if (qName.equalsIgnoreCase("Inline")) {
                 // Inline data saved, and added after the inital .x3d program is parsed
                 String name = "";
-                String[] url = {};
+                String[] url = new String[1];
                 attributeValue = attributes.getValue("DEF");
                 if (attributeValue != null) {
                     name = attributeValue;
                 }
                 attributeValue = attributes.getValue("url");
                 if (attributeValue != null) {
-                    url = parseMFString(attributeValue);
+                    //url = parseMFString(attributeValue);
+                    url[0] = attributeValue;
                     GVRSceneObject inlineGVRSceneObject = currentSceneObject; // preserve
                     // the
                     // currentSceneObject
@@ -3778,21 +3788,25 @@ public class X3Dobject {
                     for (int j = 0; j < urls.length; j++) {
                         GVRAndroidResource gvrAndroidResource = null;
                         try {
+                            inlineSubdirectory = "";
+                            int lastIndex = urls[j].lastIndexOf('/');
+                            if (lastIndex != -1) {
+                                inlineSubdirectory = urls[j].substring(0, urls[j].lastIndexOf('/')+1);
+                            }
                             gvrAndroidResource = new GVRAndroidResource(gvrContext, urls[j]);
                             inputStream = gvrAndroidResource.getStream();
                             currentSceneObject = inlineObject.getInlineGVRSceneObject();
                             saxParser.parse(inputStream, userhandler);
                         } catch (FileNotFoundException e) {
                             Log.e(TAG,
-                                  "Inline file reading: GVRAndroidResource File Not Found Exception: "
+                                  "Inline file reading: File Not Found: url " + urls[j] + ", Exception "
                                   + e);
                         } catch (IOException ioException) {
                             Log.e(TAG,
-                                  "Inline file reading: GVRAndroidResource IOException url["
-                                  + j + "] url " + urls[j]);
-                            Log.e(TAG, "Inline file reading: " + ioException.toString());
+                                  "Inline file reading url " + urls[j]);
+                            Log.e(TAG, "IOException: " + ioException.toString());
                         } catch (Exception exception) {
-                            Log.e(TAG, "Inline file reading: GVRAndroidResource Exception: "
+                            Log.e(TAG, "Inline file reading error: Exception "
                                        + exception);
                         }
                     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/x3d/X3Dobject.java
@@ -3494,11 +3494,11 @@ public class X3Dobject {
                             }
                             // X3D doesn't have an ambient color so need to do color
                             // calibration tests on how to set this.
-                            // gvrMaterial.setVec4("ambient_color", 1.0f, 1.0f, 1.0f, 1.0f);
                             gvrMaterial.setVec4("diffuse_color",
                                                 shaderSettings.diffuseColor[0],
                                                 shaderSettings.diffuseColor[1],
-                                                shaderSettings.diffuseColor[2], 1.0f);
+                                                shaderSettings.diffuseColor[2],
+                                                (1.0f - shaderSettings.getTransparency()) );
                             gvrMaterial.setVec4("specular_color",
                                                 shaderSettings.specularColor[0],
                                                 shaderSettings.specularColor[1],
@@ -3530,14 +3530,13 @@ public class X3Dobject {
                                 DefinedItem definedItem = new DefinedItem(
                                         shaderSettings.getAppearanceName());
                                 definedItem.setGVRMaterial(gvrMaterial);
-                                mDefinedItems.add(definedItem); // Add gvrMaterial to Array list
+                                mDefinedItems.add(definedItem);
+                                // Add gvrMaterial to Array list
                                 // of DEFined items Clones
                                 // objects with USE
                             }
 
-                            float transparency = shaderSettings.getTransparency();
-                            gvrMaterial.setOpacity(transparency);
-                            if ((transparency != 0) && (transparency != 1)) {
+                            if ((shaderSettings.getTransparency() != 0) && (shaderSettings.getTransparency() != 1)) {
                                 gvrRenderData.setRenderingOrder(GVRRenderingOrder.TRANSPARENT);
                             }
 


### PR DESCRIPTION
Finally vulkan branch has all the fixes from master

Manual merge
- Fixed transparency settings in GVRMaterial when receiving a transparency float in X3D's Material node.
- Fixed issues related to directory stucture with Inline, Issue #1261.
- Added back setAlpahToCoverage(true) to fix rendering order.

Automatic merge
- Set GearCursorController origin to scene object position, not pivot position
- clean up monoscopic renderer, delete redundant culling calls
- [DockListener] separated addDockListener from the constructor
- Create GVRGUISceneObject (#1257)

Already merged
- Update SensorEvents API to supply new picking information (#1256)
- Add surface normals to picking information
- backend_oculus: elevate the render and main thread's priority
- backend_oculus: enable onBack handling regardless presence of a home key on the headset
- framework, backend_oculus: add support for building with clang
- framework: propagate all exceptions openStream might throw
- particle-system extension (#1277)
- set rendering order to transparent only if texture is not null

_This PR shall be 'merged'_
- - -
GearVRf-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com