### PR TITLE
framework: create a new main scene only if necessary

### DIFF
--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -7,6 +7,7 @@ repositories {
 }
 
 android {
+    //defaultPublishConfig "debug"
     publishNonDefault !gradle.getStartParameter().taskNames.contains('uploadArchives')
     compileSdkVersion 24
     buildToolsVersion '25.0.2'

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -199,7 +199,8 @@ abstract class GVRViewManager extends GVRContext {
         final DepthFormat depthFormat = getActivity().getAppSettings().getEyeBufferParams().getDepthFormat();
         getActivity().getConfigurationManager().configureRendering(DepthFormat.DEPTH_24_STENCIL_8 == depthFormat);
 
-        setMainSceneImpl(new GVRScene(GVRViewManager.this));
+        final GVRScene scene = null == mMainScene ? new GVRScene(GVRViewManager.this) : mMainScene;
+        setMainSceneImpl(scene);
     }
 
     private void createMainScene() {


### PR DESCRIPTION
- one of the backends has different pause/resume sequence and this accomodates it
- shows that the lifecycle events handling in the view manager needs refactoring to become more flexible; future task

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>