### PR TITLE
Do not change rendering order to 'geometry' for opaque objects.

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderData.java
@@ -316,10 +316,6 @@ public class GVRRenderData extends GVRComponent implements PrettyPrint {
 
         if((mainTexture != null && !mainTexture.hasTransparency()) ||
             diffuseTexture != null && !diffuseTexture.hasTransparency()) {
-            // had transparency before, but is now opaque
-            if(renderingOrder > GVRRenderingOrder.GEOMETRY) {
-                setRenderingOrder(GVRRenderingOrder.GEOMETRY);
-            }
             return;
         }
 


### PR DESCRIPTION
Fixes gearvrf/GearVRf-Tests#126