### PR TITLE
framework, backend_oculus: fix some memory leaks

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityNative.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityNative.java
@@ -18,6 +18,7 @@ package org.gearvrf;
 import org.gearvrf.utility.VrAppSettings;
 
 import android.app.Activity;
+import android.content.Context;
 
 class OvrActivityNative implements IActivityNative {
     static {
@@ -27,7 +28,10 @@ class OvrActivityNative implements IActivityNative {
     private final long mPtr;
 
     OvrActivityNative(Activity act, VrAppSettings vrAppSettings) {
-        mPtr = onCreate(act, vrAppSettings);
+        //vrapi leaks a global reference to the activity; passing an application context
+        //instead as it is much cheaper to leak; calling only vrapi_Initialize and vrapi_Shutdown
+        //leads to the leak
+        mPtr = onCreate(act.getApplicationContext(), vrAppSettings);
     }
 
     public void onDestroy() {
@@ -58,5 +62,5 @@ class OvrActivityNative implements IActivityNative {
 
     private static native void onDestroy(long appPtr);
 
-    private static native long onCreate(Activity act, VrAppSettings vrAppSettings);
+    private static native long onCreate(Context act, VrAppSettings vrAppSettings);
 }

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
@@ -177,8 +177,8 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
 
         mSurfaceView.setPreserveEGLContextOnPause(true);
         mSurfaceView.setEGLContextClientVersion(3);
-        mSurfaceView.setEGLContextFactory(mContextFactory);
-        mSurfaceView.setEGLConfigChooser(mConfigChooser);
+        mSurfaceView.setEGLContextFactory(new AEGLContextFactory());
+        mSurfaceView.setEGLConfigChooser(new AEGLConfigChooser());
         mSurfaceView.setEGLWindowSurfaceFactory(mWindowSurfaceFactory);
         mSurfaceView.setRenderer(mRenderer);
         mSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
@@ -186,7 +186,7 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
         mActivity.setContentView(mSurfaceView);
     }
 
-    private final EGLContextFactory mContextFactory = new EGLContextFactory() {
+    private final static class AEGLContextFactory implements EGLContextFactory {
         @Override
         public void destroyContext(final EGL10 egl, final EGLDisplay display, final EGLContext context) {
             Log.v(TAG, "EGLContextFactory.destroyContext 0x%X", context.hashCode());
@@ -210,7 +210,7 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
             Log.v(TAG, "EGLContextFactory.createContext 0x%X", context.hashCode());
             return context;
         }
-    };
+    }
 
     private final EGLWindowSurfaceFactory mWindowSurfaceFactory = new EGLWindowSurfaceFactory() {
         @Override
@@ -239,7 +239,7 @@ class OvrVrapiActivityHandler implements OvrActivityHandler {
         }
     };
 
-    private final EGLConfigChooser mConfigChooser = new EGLConfigChooser() {
+    private final static class AEGLConfigChooser implements EGLConfigChooser {
         @Override
         public EGLConfig chooseConfig(final EGL10 egl, final EGLDisplay display) {
             final int[] numberConfigs = new int[1];

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -48,7 +48,6 @@ GVRActivity::GVRActivity(JNIEnv& env, jobject activity, jobject vrAppSettings,
 
 GVRActivity::~GVRActivity() {
     LOGV("GVRActivity::~GVRActivity");
-    uninitializeVrApi();
 
     envMainThread_->DeleteGlobalRef(activityClass_);
     envMainThread_->DeleteGlobalRef(activity_);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -218,10 +218,14 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         }
         if (null != mDockEventReceiver) {
             mDockEventReceiver.stop();
+            mDockEventReceiver = null;
         }
 
-        if (null != mConfigurationManager && !mConfigurationManager.isDockListenerRequired()) {
-            handleOnUndock();
+        if (null != mConfigurationManager) {
+            if (!mConfigurationManager.isDockListenerRequired()) {
+                handleOnUndock();
+            }
+            mConfigurationManager.onDestroy();
         }
 
         if (null != mActivityNative) {
@@ -235,6 +239,7 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         mAppSettings = null;
         mRenderableViewGroup = null;
         mConfigurationManager = null;
+        mEventReceiver = null;
 
         super.onDestroy();
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRConfigurationManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRConfigurationManager.java
@@ -230,6 +230,8 @@ abstract class GVRConfigurationManager {
         }
     }
 
+    public void onDestroy() { }
+
     @Override
     protected void finalize() throws Throwable {
         NativeConfigurationManager.delete(mPtr);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContext.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContext.java
@@ -812,6 +812,7 @@ public abstract class GVRContext implements IEventReceiver {
     }
 
     void onDestroy() {
+        mImporter = null;
         if (null != mHandlerThread) {
             mHandlerThread.getLooper().quitSafely();
         }
@@ -856,20 +857,5 @@ public abstract class GVRContext implements IEventReceiver {
         synchronized (mReferenceSet) {
             mReferenceSet.add(new GVRReference(gvrHybridObject, nativePointer, cleanupHandlers));
         }
-    }
-
-    /**
-     * Explicitly close()ing an object is going to be relatively rare - most
-     * native memory will be freed when the owner-objects are garbage collected.
-     * Doing a lookup in these rare cases means that we can avoid giving every @link
-     * {@link GVRHybridObject} a hard reference to its {@link GVRReference}.
-     */
-    final GVRReference findReference(long nativePointer) {
-        for (GVRReference reference : mReferenceSet) {
-            if (reference.mNativePointer == nativePointer) {
-                return reference;
-            }
-        }
-        return null;
     }
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRHybridObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRHybridObject.java
@@ -89,7 +89,9 @@ public abstract class GVRHybridObject {
         mGVRContext = gvrContext;
         mNativePointer = nativePointer;
 
-        gvrContext.registerHybridObject(this,nativePointer, cleanupHandlers);
+        if (0 != mNativePointer) {
+            gvrContext.registerHybridObject(this, nativePointer, cleanupHandlers);
+        }
     }
 
     /*


### PR DESCRIPTION
Most changes are precautions and/or minimizing the cost of frequently leaked entities. The notable one is the activity leak by VrApi. Not seeing it with the Oculus samples but I am pretty sure calling Initialize leads to the leak in our case.