### PR TITLE
Fix billboard resetting scale to 1

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBillboard.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBillboard.java
@@ -1,4 +1,5 @@
 package org.gearvrf;
+import org.joml.Matrix4f;
 import org.joml.Vector3f;
 
 /**
@@ -18,6 +19,8 @@ public class GVRBillboard extends GVRBehavior
     private Vector3f ownerXaxis = new Vector3f(0, 0, 0);
     private Vector3f ownerYaxis = new Vector3f(0, 0, 0);
     private Vector3f ownerZaxis = new Vector3f(0, 0, 0);
+    private Matrix4f scaleMatrix = new Matrix4f();
+    private Matrix4f rotationMatrix = new Matrix4f();
 
     private boolean isCustomUpPresent = false;
     private Vector3f customUp;
@@ -75,15 +78,15 @@ public class GVRBillboard extends GVRBehavior
 
     private void faceObjectToCamera()
     {
-        GVRSceneObject ownerObject = getOwnerObject();
+        GVRTransform ownerTransform = getOwnerObject().getTransform();
 
         float camX = mMainCameraRig.getTransform().getPositionX();
         float camY = mMainCameraRig.getTransform().getPositionY();
         float camZ = mMainCameraRig.getTransform().getPositionZ();
 
-        float ownerX = ownerObject.getTransform().getPositionX();
-        float ownerY = ownerObject.getTransform().getPositionY();
-        float ownerZ = ownerObject.getTransform().getPositionZ();
+        float ownerX = ownerTransform.getPositionX();
+        float ownerY = ownerTransform.getPositionY();
+        float ownerZ = ownerTransform.getPositionZ();
 
         lookat.set(camX - ownerX, camY - ownerY, camZ - ownerZ);
         lookat = lookat.normalize();
@@ -94,10 +97,19 @@ public class GVRBillboard extends GVRBehavior
         lookat.cross(ownerXaxis.x, ownerXaxis.y, ownerXaxis.z, ownerYaxis);
         ownerYaxis = ownerYaxis.normalize();
 
-        ownerObject.getTransform().setModelMatrix(new float[]{ownerXaxis.x, ownerXaxis.y, ownerXaxis.z, 0.0f,
+        scaleMatrix.set(ownerTransform.getScaleX(), 0.0f, 0.0f, 0.0f,
+                0.0f, ownerTransform.getScaleY(), 0.0f, 0.0f,
+                0.0f, 0.0f, ownerTransform.getScaleZ(), 0.0f,
+                0.0f, 0.0f, 0.0f, 1.0f);
+
+        rotationMatrix.set(ownerXaxis.x, ownerXaxis.y, ownerXaxis.z, 0.0f,
                 ownerYaxis.x, ownerYaxis.y, ownerYaxis.z, 0.0f,
                 lookat.x, lookat.y, lookat.z, 0.0f,
-                ownerX, ownerY, ownerZ, 1.0f});
+                ownerX, ownerY, ownerZ, 1.0f);
+
+        rotationMatrix.mul(scaleMatrix);
+
+        ownerTransform.setModelMatrix(rotationMatrix);
     }
 
     /**
@@ -109,15 +121,15 @@ public class GVRBillboard extends GVRBehavior
     private void faceObjectToCameraWithCustomUp()
     {
         customUp = customUp.normalize();
-        GVRSceneObject ownerObject = getOwnerObject();
+        GVRTransform ownerTransform = getOwnerObject().getTransform();
 
         float camX = mMainCameraRig.getTransform().getPositionX();
         float camY = mMainCameraRig.getTransform().getPositionY();
         float camZ = mMainCameraRig.getTransform().getPositionZ();
 
-        float ownerX = ownerObject.getTransform().getPositionX();
-        float ownerY = ownerObject.getTransform().getPositionY();
-        float ownerZ = ownerObject.getTransform().getPositionZ();
+        float ownerX = ownerTransform.getPositionX();
+        float ownerY = ownerTransform.getPositionY();
+        float ownerZ = ownerTransform.getPositionZ();
 
         lookat.set(camX - ownerX, camY - ownerY, camZ - ownerZ);
         lookat = lookat.normalize();
@@ -127,10 +139,19 @@ public class GVRBillboard extends GVRBehavior
 
         ownerXaxis.cross(customUp.x, customUp.y, customUp.z, ownerZaxis);
 
-        ownerObject.getTransform().setModelMatrix(new float[]{ownerXaxis.x, ownerXaxis.y, ownerXaxis.z, 0.0f,
+        scaleMatrix.set(ownerTransform.getScaleX(), 0.0f, 0.0f, 0.0f,
+                0.0f, ownerTransform.getScaleY(), 0.0f, 0.0f,
+                0.0f, 0.0f, ownerTransform.getScaleZ(), 0.0f,
+                0.0f, 0.0f, 0.0f, 1.0f);
+
+        rotationMatrix.set(ownerXaxis.x, ownerXaxis.y, ownerXaxis.z, 0.0f,
                 customUp.x, customUp.y, customUp.z, 0.0f,
                 ownerZaxis.x, ownerZaxis.y, ownerZaxis.z, 0.0f,
-                ownerX, ownerY, ownerZ, 1.0f});
+                ownerX, ownerY, ownerZ, 1.0f);
+
+        rotationMatrix.mul(scaleMatrix);
+
+        ownerTransform.setModelMatrix(rotationMatrix);
 
     }
 }


### PR DESCRIPTION
* Current implementation is always resetting the owner's scale to 1
this patch fix this issue.

GearVRf-DCO-1.0-Signed-off-by: Ragner Magalhaes <ragner.n@samsung.com>