### PR TITLE
framework: have bitmap textures created by the asset loader tested for alpha too

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRAssetLoader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRAssetLoader.java
@@ -656,21 +656,16 @@ public final class GVRAssetLoader {
             {
                 return texture;
             }
-            bmapTex = new GVRBitmapTexture(mContext, (Bitmap) null, textureParameters);
-            mTextureCache.put(resource, bmapTex);
-        }
-        try
-        {
-            Bitmap bitmap = GVRAsynchronousResourceLoader.decodeStream(resource.getStream(), false);
-            resource.closeStream();
-            if (bitmap != null)
-            {
-                bmapTex.update(bitmap);
+
+            try {
+                Bitmap bitmap = GVRAsynchronousResourceLoader.decodeStream(resource.getStream(), false);
+                bmapTex = new GVRBitmapTexture(mContext, bitmap, textureParameters);
+                mTextureCache.put(resource, bmapTex);
+            } catch (IOException e) {
+                return null;
+            } finally {
+                resource.closeStream();
             }
-        }
-        catch (IOException ex)
-        {
-            return null;
         }
         return bmapTex;
     }


### PR DESCRIPTION
Related to https://github.com/gearvrf/GearVRf-Tests/issues/126 and https://github.com/Samsung/GearVRf/pull/1433

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>