### PR TITLE
fix multiview rendering for render-mask

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
@@ -69,10 +69,13 @@ namespace gvr
         rstate.shader_manager = shader_manager;
         rstate.scene = scene;
         rstate.render_mask = camera->render_mask();
+
+        if(is_multiview)
+            rstate.render_mask = RenderData::RenderMaskBit::Right | RenderData::RenderMaskBit::Left;
+
         rstate.uniforms.u_right = rstate.render_mask & RenderData::RenderMaskBit::Right;
 
         std::vector<PostEffectData*> post_effects = camera->post_effect_data();
-
         GL(glDepthMask(GL_TRUE));
         GL(glEnable(GL_DEPTH_TEST));
         GL(glDepthFunc(GL_LEQUAL));

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/assimp_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/assimp_shader.h
@@ -63,17 +63,17 @@ private:
 private:
     GLProgram** program_list_;
 
-    GLuint u_mvp_;
-    GLuint u_texture_;
-    GLuint u_diffuse_color_;
-    GLuint u_ambient_color_;
-    GLuint u_color_;
-    GLuint u_opacity_;
+    GLint u_mvp_;
+    GLint u_texture_;
+    GLint u_diffuse_color_;
+    GLint u_ambient_color_;
+    GLint u_color_;
+    GLint u_opacity_;
 
     // Bones
-    GLuint a_bone_indices_;
-    GLuint a_bone_weights_;
-    GLuint u_bone_matrices_;
+    GLint a_bone_indices_;
+    GLint a_bone_weights_;
+    GLint u_bone_matrices_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/bounding_box_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/bounding_box_shader.h
@@ -48,7 +48,7 @@ private:
 
 private:
     GLProgram* program_;
-    GLuint u_mvp_;
+    GLint u_mvp_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/cubemap_reflection_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/cubemap_reflection_shader.h
@@ -39,13 +39,13 @@ private:
     CubemapReflectionShader& operator=(CubemapReflectionShader&& cubemap_shader);
 
 private:
-    GLuint u_mv_;
-    GLuint u_mv_it_;
-    GLuint u_mvp_;
-    GLuint u_view_i_;
-    GLuint u_texture_;
-    GLuint u_color_;
-    GLuint u_opacity_;
+    GLint u_mv_;
+    GLint u_mv_it_;
+    GLint u_mvp_;
+    GLint u_view_i_;
+    GLint u_texture_;
+    GLint u_color_;
+    GLint u_opacity_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/cubemap_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/cubemap_shader.h
@@ -40,11 +40,12 @@ private:
     CubemapShader& operator=(CubemapShader&& cubemap_shader);
 
 private:
-    GLuint u_model_;
-    GLuint u_mvp_;
-    GLuint u_texture_;
-    GLuint u_color_;
-    GLuint u_opacity_;
+    GLint  u_render_mask_;
+    GLint u_model_;
+    GLint u_mvp_;
+    GLint u_texture_;
+    GLint u_color_;
+    GLint u_opacity_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/custom_shader.cpp
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/custom_shader.cpp
@@ -43,6 +43,7 @@ void CustomShader::initializeOnDemand(RenderState* rstate) {
             u_view_ = glGetUniformLocation(program_->id(), "u_view_[0]");
             u_mv_ = glGetUniformLocation(program_->id(), "u_mv_[0]");
             u_mv_it_ = glGetUniformLocation(program_->id(), "u_mv_it_[0]");
+            u_render_mask_ = glGetUniformLocation(program_->id(), "u_render_mask");
         }
         else {
             u_mvp_ = glGetUniformLocation(program_->id(), "u_mvp");
@@ -301,6 +302,8 @@ void CustomShader::render(RenderState* rstate, RenderData* render_data, Material
             }
         }
     }
+    if( u_render_mask_!= -1)
+        glUniform1ui(u_render_mask_,render_data->render_mask());
 
     if (u_model_ != -1){
     	glUniformMatrix4fv(u_model_, 1, GL_FALSE, glm::value_ptr(rstate->uniforms.u_model));

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/custom_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/custom_shader.h
@@ -108,12 +108,13 @@ private:
     };
 
 private:
-    GLuint u_mvp_;
-    GLuint u_mv_;
-    GLuint u_view_;
-    GLuint u_mv_it_;
-    GLuint u_right_;
-    GLuint u_model_;
+    GLint u_render_mask_;
+    GLint u_mvp_;
+    GLint u_mv_;
+    GLint u_view_;
+    GLint u_mv_it_;
+    GLint u_right_;
+    GLint u_model_;
     bool textureVariablesDirty_ = false;
     std::mutex textureVariablesLock_;
     std::set<Descriptor<TextureVariable>, DescriptorComparator<TextureVariable>> textureVariables_;

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/error_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/error_shader.h
@@ -43,8 +43,8 @@ private:
 
 private:
     GLProgram* program_;
-    GLuint u_mvp_;
-    GLuint u_color_;
+    GLint u_mvp_;
+    GLint u_color_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/lightmap_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/lightmap_shader.h
@@ -38,11 +38,11 @@ private:
     LightMapShader& operator=(LightMapShader&& lightmap_shader);
 
 private:
-    GLuint u_mvp_;
-    GLuint u_texture_;
-    GLuint u_lightmap_texture_;
-    GLuint u_lightmap_offset_;
-    GLuint u_lightmap_scale_;
+    GLint u_mvp_;
+    GLint u_texture_;
+    GLint u_lightmap_texture_;
+    GLint u_lightmap_offset_;
+    GLint u_lightmap_scale_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/oes_horizontal_stereo_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/oes_horizontal_stereo_shader.h
@@ -49,11 +49,11 @@ private:
             OESHorizontalStereoShader&& oes_horizontal_stereo_shader);
 
 private:
-    GLuint u_mvp_;
-    GLuint u_texture_;
-    GLuint u_color_;
-    GLuint u_opacity_;
-    GLuint u_right_;
+    GLint u_mvp_;
+    GLint u_texture_;
+    GLint u_color_;
+    GLint u_opacity_;
+    GLint u_right_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/oes_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/oes_shader.h
@@ -42,6 +42,7 @@ private:
     void programInit(RenderState*);
 
 private:
+    GLint u_render_mask_;
     GLint u_mvp_;
     GLint u_texture_;
     GLint u_color_;

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/texture_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/texture_shader.h
@@ -45,20 +45,21 @@ private:
 
     std::unordered_map<int, GLProgram*>program_object_map_;
     struct uniforms{
-        GLuint u_model;
-        GLuint u_texture;
-        GLuint u_color;
-        GLuint u_opacity;
-        GLuint u_view;
-        GLuint u_proj;
-        GLuint u_light_pos;
-        GLuint u_material_ambient_color_;
-        GLuint u_material_diffuse_color_;
-        GLuint u_material_specular_color_;
-        GLuint u_material_specular_exponent_;
-        GLuint u_light_ambient_intensity_;
-        GLuint u_light_diffuse_intensity_;
-        GLuint u_light_specular_intensity_;
+        GLint u_render_mask;
+        GLint u_model;
+        GLint u_texture;
+        GLint u_color;
+        GLint u_opacity;
+        GLint u_view;
+        GLint u_proj;
+        GLint u_light_pos;
+        GLint u_material_ambient_color_;
+        GLint u_material_diffuse_color_;
+        GLint u_material_specular_color_;
+        GLint u_material_specular_exponent_;
+        GLint u_light_ambient_intensity_;
+        GLint u_light_diffuse_intensity_;
+        GLint u_light_specular_intensity_;
     };
     std::unordered_map<int,uniforms> uniform_loc;
 

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_fbo_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_fbo_shader.h
@@ -37,10 +37,10 @@ private:
     UnlitFboShader& operator=(UnlitFboShader&& fbo_shader);
 
 private:
-    GLuint u_mvp_;
-    GLuint u_texture_;
-    GLuint u_color_;
-    GLuint u_opacity_;
+    GLint u_mvp_;
+    GLint u_texture_;
+    GLint u_color_;
+    GLint u_opacity_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_horizontal_stereo_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_horizontal_stereo_shader.h
@@ -44,11 +44,11 @@ private:
             UnlitHorizontalStereoShader&& unlit_shader);
 
 private:
-    GLuint u_mvp_;
-    GLuint u_texture_;
-    GLuint u_color_;
-    GLuint u_opacity_;
-    GLuint u_right_;
+    GLint u_mvp_;
+    GLint u_texture_;
+    GLint u_color_;
+    GLint u_opacity_;
+    GLint u_right_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_vertical_stereo_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/unlit_vertical_stereo_shader.h
@@ -43,11 +43,11 @@ private:
             UnlitVerticalStereoShader&& unlit_shader);
 
 private:
-    GLuint u_mvp_;
-    GLuint u_texture_;
-    GLuint u_color_;
-    GLuint u_opacity_;
-    GLuint u_right_;
+    GLint u_mvp_;
+    GLint u_texture_;
+    GLint u_color_;
+    GLint u_opacity_;
+    GLint u_right_;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
@@ -5,6 +5,7 @@ uniform mat4 u_view_[2];
 uniform mat4 u_mvp_[2];
 uniform mat4 u_mv_[2];
 uniform mat4 u_mv_it_[2];
+uniform uint u_render_mask;
 #else
 uniform mat4 u_view;
 uniform mat4 u_mvp;
@@ -120,7 +121,11 @@ void main() {
 	viewspace_normal = vertex.viewspace_normal;
 	view_direction = vertex.view_direction;
 #ifdef HAS_MULTIVIEW
-	gl_Position = u_mvp_[gl_ViewID_OVR] * vertex.local_position;
+    bool render_mask = (u_render_mask & (gl_ViewID_OVR + uint(1))) > uint(0) ? true : false;
+    mat4 mvp = u_mvp_[gl_ViewID_OVR];
+    if(!render_mask)
+        mvp = mat4(0.0);
+	gl_Position = mvp * vertex.local_position;
 #else
 	gl_Position = u_mvp * vertex.local_position;	
 #endif	


### PR DESCRIPTION
this fixes multiview rendering if one of the eye rendering is disabled. Changed uniform locations from GLuint to GLint. 
For testing change the rendermask of scene-object with multiview enabled.

GearVRf-DCO-1.0-Signed-off-by: Roshan Chaudhari roshan.c@samsung.com