### PR TITLE
framework: make the one and only non-public GVRAndroidResource ctor public

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRAndroidResource.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRAndroidResource.java
@@ -205,7 +205,7 @@ public class GVRAndroidResource {
      * @param name        a String for uniquely identifying this resource
      * @param inputStream an already open {@link InputStream} for this resource
      */
-    GVRAndroidResource(String name, InputStream inputStream) {
+    public GVRAndroidResource(String name, InputStream inputStream) {
         inputStreamName = name;
         stream = inputStream;
         streamState = StreamStates.NEW;


### PR DESCRIPTION
Came out of issue #1391

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>