### PR TITLE
Vulkan merge: fixes for PickerTests

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -135,6 +135,7 @@ RenderTexture*  GVRActivity::createRenderTexture(int eye, int index){
             }
 
             oculusPerformanceParms_ = vrapi_DefaultPerformanceParms();
+        env.ExceptionClear(); //clear a weird GearVrRemoteForBatteryWorkAround raised by Oculus
             configurationHelper_.getPerformanceConfiguration(env, oculusPerformanceParms_);
             oculusPerformanceParms_.MainThreadTid = mainThreadId_;
             oculusPerformanceParms_.RenderThreadTid = gettid();

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCollider.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCollider.java
@@ -44,7 +44,9 @@ public class GVRCollider extends GVRComponent
 
             @Override
             public void nativeCleanup(long nativePointer) {
+                synchronized (sColliders) {
                 sColliders.remove(nativePointer);
+            }
             }
         });
         sConcatenations = new CleanupHandlerListManager(sCleanup);
@@ -56,7 +58,9 @@ public class GVRCollider extends GVRComponent
      * @see GVRCollider#lookup(long)
      */
     protected void registerNativePointer(long nativePointer) {
+        synchronized (sColliders) {
         sColliders.put(nativePointer, new WeakReference<GVRCollider>(this));
+    }
     }
 
     /**
@@ -82,8 +86,10 @@ public class GVRCollider extends GVRComponent
      */
     static GVRCollider lookup(long nativePointer)
     {
+        synchronized (sColliders) {
         WeakReference<GVRCollider> weakReference = sColliders.get(nativePointer);
         return weakReference == null ? null : weakReference.get();
+    }
     }
     
     /**

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshCollider.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshCollider.java
@@ -67,6 +67,7 @@ public class GVRMeshCollider extends GVRCollider {
      */
     public GVRMeshCollider(GVRContext gvrContext, GVRMesh mesh, boolean pickCoordinates) {
         super(gvrContext, NativeMeshCollider.ctorMeshPicking(mesh.getNative(), pickCoordinates));
+        mMesh = mesh;
     }
 
     /**


### PR DESCRIPTION
Auto merge (ignoring white space)
	framework, backend_oculus: fixes for PickerTests (#1411)