### PR TITLE
 Vulkan: Allow for variable size and offset subimage texture uploads

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBitmapTexture.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBitmapTexture.java
@@ -132,9 +132,9 @@ public class GVRBitmapTexture extends GVRImage
      * (and/or post effects that use the texture!
      *
      * @param width
-     *            Texture width, in pixels
+     *            Texture width, in texels
      * @param height
-     *            Texture height, in pixels
+     *            Texture height, in texels
      * @param format
      *            Texture format
      * @param type
@@ -145,7 +145,41 @@ public class GVRBitmapTexture extends GVRImage
      */
     public void setBuffer(final int width, final int height, final int format, final int type, final Buffer pixels)
     {
-        NativeBitmapImage.updateFromBuffer(getNative(), width, height, format, type, pixels);
+        NativeBitmapImage.updateFromBuffer(getNative(), 0, 0, width, height, format, type, pixels);
+    }
+
+    /**
+     * Copy a new texture subimage from a {@link Buffer} to the GPU texture. This one is also safe even
+     * in a non-GL thread. An updateGPU request on a non-GL thread will
+     * be forwarded to the GL thread and be executed before main rendering happens.
+     *
+     * Creating a new {@link GVRImage} is pretty cheap, but it's still not a
+     * totally trivial operation: it does involve some memory management and
+     * some GL hardware handshaking. Reusing the texture reduces this overhead
+     * (primarily by delaying garbage collection). Do be aware that updating a
+     * texture will affect any and all {@linkplain GVRMaterial materials}
+     * (and/or post effects that use the texture!
+     *
+     * @param xoffset
+     *            Subimage texel offset in X direction
+     * @param yoffset
+     *            Subimage texel offset in Y direction
+     * @param width
+     *            Texture subimage width, in texels
+     * @param height
+     *            Texture subimage height, in texels
+     * @param format
+     *            Texture format
+     * @param type
+     *            Texture type
+     * @param pixels
+     *            A NIO Buffer with the texture
+     *
+     */
+    public void setBuffer(final int xoffset, final int yoffset, final int width, final int height,
+                          final int format, final int type, final Buffer pixels)
+    {
+        NativeBitmapImage.updateFromBuffer(getNative(), xoffset, yoffset, width, height, format, type, pixels);
     }
 
     /**
@@ -189,7 +223,7 @@ class NativeBitmapImage {
     static native String getFileName(long pointer);
     static native void updateFromMemory(long pointer, int width, int height, byte[] data);
     static native void updateFromBitmap(long pointer, Bitmap bitmap, boolean hasAlpha);
-    static native void updateFromBuffer(long pointer, int width, int height, int format, int type, Buffer pixels);
+    static native void updateFromBuffer(long pointer, int xoffset, int yoffset, int width, int height, int format, int type, Buffer pixels);
     static native void updateCompressed(long pointer, int width, int height, int imageSize, byte[] data, int levels, int[] offsets);
 
 }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
@@ -74,7 +74,7 @@ int GLBitmapImage::updateFromBitmap(JNIEnv *env, int target, jobject bitmap)
 void GLBitmapImage::updateFromBuffer(JNIEnv *env, int target, jobject pixels)
 {
     void* directPtr = env->GetDirectBufferAddress(pixels);
-    glTexSubImage2D(target, 0, 0, 0, mWidth, mHeight, mFormat, mType, directPtr);
+    glTexSubImage2D(target, 0, mXOffset, mYOffset, mWidth, mHeight, mFormat, mType, directPtr);
 }
 
 void GLBitmapImage::update(int texid)

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.cpp
@@ -71,13 +71,15 @@ void BitmapImage::update(JNIEnv* env, jobject bitmap, bool hasAlpha)
     }
 }
 
-void BitmapImage::update(JNIEnv* env, int width, int height, int format, int type, jobject buffer)
+void BitmapImage::update(JNIEnv* env, int xoffset, int yoffset, int width, int height, int format, int type, jobject buffer)
 {
     std::lock_guard<std::mutex> lock(mUpdateLock);
     env->GetJavaVM(&mJava);
     clearData(env);
     if (buffer != NULL)
     {
+        mXOffset = xoffset;
+        mYOffset = yoffset;
         mWidth = width;
         mHeight = height;
         mFormat = format;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.h
@@ -37,7 +37,8 @@ namespace gvr {
         virtual ~BitmapImage();
         void update(JNIEnv* env, int width, int height, jbyteArray data);
         void update(JNIEnv* env, jobject bitmap, bool hasAlpha);
-        void update(JNIEnv* env, int width, int height, int format, int type, jobject bitmap);
+        void update(JNIEnv* env, int xoffset, int yoffset, int width, int height,
+                    int format, int type, jobject bitmap);
         void update(JNIEnv *env, int width, int height, int imageSize,
                     jbyteArray bytes, int levels, const int* dataOffsets);
 

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image_jni.cpp
@@ -83,11 +83,12 @@ namespace gvr
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_NativeBitmapImage_updateFromBuffer(JNIEnv *env, jobject obj,
-                                                        jlong jtexture, jint width, jint height,
+                                                        jlong jtexture, jint xoffset, jint yoffset,
+                                                        jint width, jint height,
                                                         jint format, jint type, jobject jbuffer)
     {
         BitmapImage *texture = reinterpret_cast<BitmapImage *>(jtexture);
-        texture->update(env, width, height, format, type, jbuffer);
+        texture->update(env, xoffset, yoffset, width, height, format, type, jbuffer);
     }
 
     JNIEXPORT void JNICALL

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
@@ -160,6 +160,8 @@ protected:
     std::mutex mUpdateLock;
     short   mType;
     short   mLevels;
+    int   mXOffset;
+    int   mYOffset;
     int   mWidth;
     int   mHeight;
     short   mDepth;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
@@ -59,7 +59,7 @@ public:
 
     Image() :
             HybridObject(), mState(UNINITIALIZED), mType(NONE), mFormat(0),
-            mWidth(0), mHeight(0), mDepth(1), mImageSize(0), mUpdateLock(),
+            mXOffset(0), mYOffset(0), mWidth(0), mHeight(0), mDepth(1), mImageSize(0), mUpdateLock(),
             mLevels(0)
     {
         mFileName[0] = 0;
@@ -67,7 +67,7 @@ public:
 
     Image(ImageType type, int format) :
             HybridObject(), mState(UNINITIALIZED), mType(type), mFormat(format),
-            mWidth(0), mHeight(0), mDepth(1), mImageSize(0), mUpdateLock(),
+            mXOffset(0), mYOffset(0), mWidth(0), mHeight(0), mDepth(1), mImageSize(0), mUpdateLock(),
             mLevels(0)
     {
         mFileName[0] = 0;
@@ -75,7 +75,7 @@ public:
 
     Image(ImageType type, short width, short height, int imagesize, int format, short levels) :
             HybridObject(), mType(type), mState(UNINITIALIZED), mUpdateLock(),
-            mWidth(width), mHeight(height), mDepth(1), mImageSize(imagesize),
+            mXOffset(0), mYOffset(0), mWidth(width), mHeight(height), mDepth(1), mImageSize(imagesize),
             mFormat(format), mLevels(levels)
     {
         mFileName[0] = 0;


### PR DESCRIPTION
eimplement #1407 on Vulkan branch

Implemens plumbing for xoffset/yoffset parameters from setBuffer to glTexSubImage2D
Vulkan API buffer loads are still a TODO

_This PR shall be 'merged'._
- - -
GearVRf-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com