### PR TITLE
framework: controller: fix for UnsupportedOperationException

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRCursorControllerSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRCursorControllerSceneObject.java
@@ -62,6 +62,10 @@ public class GVRCursorControllerSceneObject extends GVRSceneObject
      */
     public void setCursor(GVRSceneObject obj)
     {
+        final GVRSceneObject parent = obj.getParent();
+        if (null != parent) {
+            parent.removeChildObject(obj);
+        }
         cursor = obj;
         cursor.getTransform().setPosition(0, 0, -rayDepth);
         addChildObject(cursor);


### PR DESCRIPTION
Have no clear reproduction steps. It just happens at some point while moving object around (gvr-controller).

The exception:
```
10-05 09:50:36.192 28925 29057 E AndroidRuntime: Process: org.gearvrf.sample.controller, PID: 28925
10-05 09:50:36.192 28925 29057 E AndroidRuntime: java.lang.UnsupportedOperationException: GVRSceneObject cannot have multiple parents
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at org.gearvrf.GVRSceneObject.addChildObject(GVRSceneObject.java:685)
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at org.gearvrf.scene_objects.GVRCursorControllerSceneObject.setCursor(GVRCursorControllerSceneObject.java:67)
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at org.gearvrf.sample.controller.SampleMain$1.selectGearController(SampleMain.java:270)
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at org.gearvrf.sample.controller.SampleMain$1.onCursorControllerAdded(SampleMain.java:215)
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at org.gearvrf.sample.controller.SampleMain$1.onCursorControllerActive(SampleMain.java:259)
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at org.gearvrf.GVRInputManagerImpl.activateCursorController(GVRInputManagerImpl.java:86)
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at org.gearvrf.io.GearCursorController.onDrawFrame(GearCursorController.java:207)
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at org.gearvrf.OvrViewManager.onDrawFrame(OvrViewManager.java:287)
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at org.gearvrf.OvrVrapiActivityHandler$8.onDrawFrame(OvrVrapiActivityHandler.java:450)
10-05 09:50:36.192 28925 29057 E AndroidRuntime: 	at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1562)
```

---

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>