### PR TITLE
Fixing GVRPhongShader for multiview

### DIFF
--- a/GVRf/Framework/framework/src/main/res/raw/fragment_template_multitex.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/fragment_template_multitex.fsh
@@ -3,7 +3,6 @@
 #extension GL_ARB_shading_language_420pack : enable
 #ifdef HAS_MULTIVIEW
 #extension GL_OVR_multiview2 : enable
-layout(num_views = 2) in;
 #endif
 precision highp float;
 


### PR DESCRIPTION
Fragment shader requires only the extension to be enabled.