### PR TITLE
framework, backend_oculus: ensure there is a renderer instance always

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCamera.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCamera.java
@@ -213,7 +213,6 @@ public abstract class GVRCamera extends GVRComponent implements PrettyPrint {
      */
     public void addPostEffect(GVRMaterial postEffectData) {
         GVRContext ctx = getGVRContext();
-        GVRShaderId shader = postEffectData.getShaderType();
 
         if (mPostEffects == null)
         {

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
@@ -678,7 +678,6 @@ void GLRenderer::updatePostEffectMesh(Mesh* copy_mesh)
     float positions[] = { -1.0f, -1.0f, 0.0f, -1.0f, 1.0f, 0.0f, 1.0f, -1.0f, 0.0f, 1.0f, 1.0f, 0.0f };
     float uvs[] = { 0.0f, 0.0, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f, 1.0f };
     unsigned short faces[] = { 0, 2, 1, 1, 2, 3 };
-    Mesh* mesh = new Mesh("float3 a_position float2 a_texcoord");
 
     const int position_size = sizeof(positions)/ sizeof(positions[0]);
     const int uv_size = sizeof(uvs)/ sizeof(uvs[0]);
@@ -688,7 +687,6 @@ void GLRenderer::updatePostEffectMesh(Mesh* copy_mesh)
     copy_mesh->setFloatVec("a_texcoord", uvs, uv_size);
     copy_mesh->setTriangles(faces, faces_size);
 }
+
 }
-
-
 

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -37,8 +37,7 @@ void Renderer::initializeStats() {
 Renderer::Renderer() : numberDrawCalls(0),
                        numberTriangles(0),
                        numLights(0),
-                       batch_manager(nullptr),
-                       post_effect_mesh_(nullptr){
+                       batch_manager(nullptr) {
     if(do_batching && !gRenderer->isVulkanInstance()) {
         batch_manager = new BatchManager(BATCH_SIZE, MAX_INDICES);
     }

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
@@ -193,7 +193,6 @@ protected:
     int numberDrawCalls;
     int numberTriangles;
     bool useStencilBuffer_ = false;
-    Mesh* post_effect_mesh_;
 public:
     virtual void state_sort(std::vector<RenderData*>* render_data_vector) ;
     int numLights;


### PR DESCRIPTION
- fixes the gvr-blurfilter crash after pause/resume

+ fix formatting
+ some cleanup

The fix is adding gRenderer = Renderer::getInstance() to GVRActivity::onSurfaceChanged

---

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>