### PR TITLE
enable mipmapping in texture parameters

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
@@ -65,6 +65,7 @@ int GLBitmapImage::updateFromBitmap(JNIEnv *env, int target, jobject bitmap)
         }
         glTexImage2D(target, 0, internalFormat, info.width, info.height, 0, pixelFormat,
                      dataFormat, pixels);
+        glGenerateMipmap(target);
         AndroidBitmap_unlockPixels(env, bitmap);
         return internalFormat;
     }

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
@@ -98,8 +98,8 @@ protected:
     {
         struct
         {
-            unsigned int MinFilter : 2;
-            unsigned int MagFilter : 2;
+            unsigned int MinFilter : 3;
+            unsigned int MagFilter : 1;
             unsigned int WrapU : 2;
             unsigned int WrapV : 2;
         } BitFields;

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_texture.cpp
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_texture.cpp
@@ -70,9 +70,9 @@ void VkTexture::createSampler(int maxLod) {
     if(sampler != 0)
         return;
 
-
     // Sets the new MIN FILTER
-    VkFilter min_filter_type_ = MapFilter[mTexParams.getMinFilter()];
+    int min_filter = mTexParams.getMinFilter();
+    VkFilter min_filter_type_ = min_filter <= 1 ? MapFilter[min_filter] : VK_FILTER_LINEAR;
 
     // Sets the MAG FILTER
     VkFilter mag_filter_type_ = MapFilter[mTexParams.getMagFilter()];


### PR DESCRIPTION
it sets mipmap filtering mode to GL_LINEAR_MIPMAP_NEAREST in default texparams. It checks whether texture is compressed or not. 