### PR TITLE
fix texparameters for mipmapping

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRTextureParameters.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRTextureParameters.java
@@ -42,7 +42,7 @@ public class GVRTextureParameters {
      */
     public GVRTextureParameters(GVRContext gvrContext) {
         mGVRContext = gvrContext;
-        minFilterType = TextureFilterType.GL_LINEAR;
+        minFilterType = TextureFilterType.GL_LINEAR_MIPMAP_NEAREST;
         magFilterType = TextureFilterType.GL_LINEAR;
         wrapSType = TextureWrapType.GL_CLAMP_TO_EDGE;
         wrapTType = TextureWrapType.GL_CLAMP_TO_EDGE;

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRTextureParameters.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRTextureParameters.java
@@ -203,7 +203,7 @@ public class GVRTextureParameters {
     public int[] getDefalutValuesArray() {
         int[] defaultValues = new int[5];
 
-        defaultValues[0] = GLES20.GL_LINEAR; // MIN FILTER
+        defaultValues[0] = GLES20.GL_LINEAR_MIPMAP_NEAREST; // MIN FILTER
         defaultValues[1] = GLES20.GL_LINEAR; // MAG FILTER
         defaultValues[2] = 1; // ANISO FILTER
         defaultValues[3] = GLES20.GL_CLAMP_TO_EDGE; // WRAP S

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.h
@@ -32,7 +32,7 @@ namespace gvr {
                 BitmapImage(format), GLImage(GL_TEXTURE_2D)
         { }
 
-        static int updateFromBitmap(JNIEnv *env, int target, jobject bitmap);
+        static int updateFromBitmap(JNIEnv *env, int target, jobject bitmap, bool);
 
         virtual int getId() { return mId; }
 
@@ -46,7 +46,14 @@ namespace gvr {
             mTexParams = texparams;
             mTexParamsDirty = true;
         }
+        void updateTexParams() {
+            int min_filter = mTexParams.getMinFilter();
 
+            if(mIsCompressed && mLevels <= 1 && min_filter >= TextureParameters::NEAREST_MIPMAP_NEAREST)
+                mTexParams.setMinFilter(GL_LINEAR);
+
+            GLImage::updateTexParams(mTexParams);
+        }
     protected:
         virtual void update(int texid);
         void updateFromMemory(int texid);

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_cubemap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_cubemap_image.cpp
@@ -20,9 +20,8 @@
 #include <gvr_gl.h>
 #include "gl/gl_cubemap_image.h"
 #include "gl_bitmap_image.h"
-
 namespace gvr {
-
+class TextureParameters;
 void GLCubemapImage::update(int texid)
 {
     if (mJava == NULL)
@@ -56,13 +55,16 @@ void GLCubemapImage::updateFromBitmap(int texid)
     // to avoid duplicated code in the throw case and normal
     // case.
     SCOPE_EXIT( clearData(env); );
+
     for (int i = 0; i < 6; i++)
     {
         jobject bitmap = env->GetObjectArrayElement(bmapArray, i);
         jobject bmapref = env->NewLocalRef(bitmap);
-        mFormat = GLBitmapImage::updateFromBitmap(env, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, bitmap);
+        mFormat = GLBitmapImage::updateFromBitmap(env, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, bitmap, false);
         env->DeleteLocalRef(bmapref);
     }
+    if(!mIsCompressed && mTexParams.getMinFilter() >=  TextureParameters::NEAREST_MIPMAP_NEAREST)
+        glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
 }
 
 void GLCubemapImage::updateFromMemory(int texid)

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_cubemap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_cubemap_image.h
@@ -43,6 +43,14 @@ public:
         mTexParams = texparams;
         mTexParamsDirty = true;
     }
+    void updateTexParams() {
+        int min_filter = mTexParams.getMinFilter();
+
+        if(mIsCompressed && mLevels <=1 && min_filter >= TextureParameters::NEAREST_MIPMAP_NEAREST)
+            mTexParams.setMinFilter(GL_LINEAR);
+
+        GLImage::updateTexParams(mTexParams);
+    }
 protected:
     virtual void update(int texid);
 

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_external_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_external_image.h
@@ -37,6 +37,10 @@ public:
         mTexParams = texparams;
         mTexParamsDirty = true;
     }
+    void updateTexParams() {
+        mTexParams.setMinFilter(GL_LINEAR);
+        GLImage::updateTexParams(mTexParams);
+    }
 private:
     GLExternalImage(const GLExternalImage&e);
     GLExternalImage(GLExternalImage&&);

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
@@ -39,6 +39,14 @@ namespace gvr {
             mTexParams = texparams;
             mTexParamsDirty = true;
         }
+        void updateTexParams() {
+            int min_filter = mTexParams.getMinFilter();
+
+            if(mIsCompressed && mLevels <= 1 && min_filter >= TextureParameters::NEAREST_MIPMAP_NEAREST)
+                mTexParams.setMinFilter(GL_LINEAR);
+
+            GLImage::updateTexParams(mTexParams);
+        }
     protected:
         virtual void update(int texid)
         {

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_image.cpp
@@ -55,7 +55,7 @@ bool GLImage::updateGPU()
     if (mId && mTexParamsDirty)
     {
         mTexParamsDirty = false;
-        updateTexParams(mTexParams);
+        updateTexParams();
     }
     return (mId != 0);
 }
@@ -90,6 +90,7 @@ void GLImage::updateTexParams(const TextureParameters& texparams)
     {
         glTexParameterf(mGLTarget, GL_TEXTURE_MAX_ANISOTROPY_EXT, texparams.getMaxAnisotropy());
     }
+
     glTexParameteri(mGLTarget, GL_TEXTURE_WRAP_S, wrap_s_type_);
     glTexParameteri(mGLTarget, GL_TEXTURE_WRAP_T, wrap_t_type_);
     glTexParameteri(mGLTarget, GL_TEXTURE_MIN_FILTER, min_filter_type_);

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_image.h
@@ -58,6 +58,7 @@ public:
     virtual int     getId() { return mId; }
     virtual bool    updateGPU();
     void            updateTexParams(const TextureParameters&);
+    virtual void    updateTexParams() = 0;
     GLenum          getTarget() const { return mGLTarget; }
     void            setTexId(GLuint id) { mId = id; }
     void            setTexParamsDirty(bool flag) {mTexParamsDirty = flag; }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_imagetex.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_imagetex.h
@@ -40,7 +40,14 @@ namespace gvr {
         {
             mState = HAS_DATA;
         }
+        void updateTexParams() {
+            int min_filter = mTexParams.getMinFilter();
 
+            if(mIsCompressed && mLevels <= 1 && min_filter >= TextureParameters::NEAREST_MIPMAP_NEAREST)
+                mTexParams.setMinFilter(GL_LINEAR);
+
+            GLImage::updateTexParams(mTexParams);
+        }
         explicit GLImageTex(ImageType type, int format, short width, short height) :
                 Image(type, format),
                 GLImage(GL_TEXTURE_2D)

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_imagetex.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_imagetex.h
@@ -38,11 +38,11 @@ namespace gvr {
                 GLImage(target,id)
 
         {
+            mTexParams.setMinFilter(GL_LINEAR); // if created with external texture
             mState = HAS_DATA;
         }
         void updateTexParams() {
             int min_filter = mTexParams.getMinFilter();
-
             if(mIsCompressed && mLevels <= 1 && min_filter >= TextureParameters::NEAREST_MIPMAP_NEAREST)
                 mTexParams.setMinFilter(GL_LINEAR);
 

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.cpp
@@ -46,7 +46,10 @@ GLRenderImage::GLRenderImage(int width, int height, int layers)
     mType = (layers > 1) ? Image::ImageType::ARRAY : Image::ImageType::BITMAP;
     mState = HAS_DATA;
 }
-
+void GLRenderImage::updateTexParams() {
+    mTexParams.setMinFilter(GL_LINEAR);
+    GLImage::updateTexParams(mTexParams);
+}
 void texImage3D(int color_format, int width, int height, int depth , GLenum target) {
     switch (color_format) {
         case ColorFormat::COLOR_565:
@@ -118,7 +121,7 @@ GLRenderImage::GLRenderImage(int width, int height, int layers, int color_format
 
     if (texparams)
     {
-        updateTexParams(mTexParams);
+        updateTexParams();
     }
     updateGPU();
     switch (target){
@@ -145,7 +148,7 @@ GLRenderImage::GLRenderImage(int width, int height, int color_format, const Text
 
     if (texparams)
     {
-        updateTexParams(mTexParams);
+        updateTexParams();
     }
     updateGPU();
     texImage2D(color_format,width,height,GL_TEXTURE_2D);

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.h
@@ -48,7 +48,7 @@ public:
         mTexParams = texparams;
         mTexParamsDirty = true;
     }
-
+    virtual void updateTexParams();
     void setupReadback(GLuint buffer, int);
 
 protected:

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.cpp
@@ -18,8 +18,8 @@
 
 namespace gvr {
 BitmapImage::BitmapImage(int format) :
-            Image(Image::BITMAP, format), mIsCompressed(false),
-            mData(NULL), mBitmap(NULL), mJava(NULL), mHasTransparency(false)
+            Image(Image::BITMAP, format),mData(NULL),
+            mBitmap(NULL), mJava(NULL), mHasTransparency(false)
 {
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.h
@@ -65,7 +65,6 @@ namespace gvr {
         jbyteArray mData;
         jobject mBitmap;
         bool mIsBuffer;
-        bool mIsCompressed;
         bool mHasTransparency;
     };
 

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/cubemap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/cubemap_image.cpp
@@ -45,6 +45,7 @@ namespace gvr {
         mWidth = width;
         mHeight = height;
         mImageSize = imageSize;
+        mIsCompressed = true;
         setDataOffsets(textureOffset, 6);
         clearData(env);
         mTextures = env->NewGlobalRef(textureArray);

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
@@ -58,7 +58,7 @@ public:
     virtual ~Image() { }
 
     Image() :
-            HybridObject(), mState(UNINITIALIZED), mType(NONE), mFormat(0),
+            HybridObject(), mState(UNINITIALIZED), mType(NONE), mFormat(0), mIsCompressed(false),
             mXOffset(0), mYOffset(0), mWidth(0), mHeight(0), mDepth(1), mImageSize(0), mUpdateLock(),
             mLevels(0)
     {
@@ -66,7 +66,7 @@ public:
     }
 
     Image(ImageType type, int format) :
-            HybridObject(), mState(UNINITIALIZED), mType(type), mFormat(format),
+            HybridObject(), mState(UNINITIALIZED), mType(type), mFormat(format),mIsCompressed(false),
             mXOffset(0), mYOffset(0), mWidth(0), mHeight(0), mDepth(1), mImageSize(0), mUpdateLock(),
             mLevels(0)
     {
@@ -74,7 +74,7 @@ public:
     }
 
     Image(ImageType type, short width, short height, int imagesize, int format, short levels) :
-            HybridObject(), mType(type), mState(UNINITIALIZED), mUpdateLock(),
+            HybridObject(), mType(type), mState(UNINITIALIZED), mUpdateLock(), mIsCompressed(false),
             mXOffset(0), mYOffset(0), mWidth(width), mHeight(height), mDepth(1), mImageSize(imagesize),
             mFormat(format), mLevels(levels)
     {
@@ -160,6 +160,7 @@ protected:
     short   mDepth;
     short   mState;
     int     mImageSize;
+    bool    mIsCompressed;
     int     mFormat;
     char    mFileName[64];
     std::vector<int>    mDataOffsets;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
@@ -57,7 +57,7 @@ public:
     TextureParameters() : MaxAnisotropy(1.0f)
     {
         Params.HashCode = 0;
-        Params.BitFields.MinFilter = LINEAR;
+        Params.BitFields.MinFilter = LINEAR_MIPMAP_NEAREST;
         Params.BitFields.MagFilter = LINEAR;
         Params.BitFields.WrapU = CLAMP;
         Params.BitFields.WrapV = CLAMP;
@@ -98,8 +98,8 @@ protected:
     {
         struct
         {
-            unsigned int MinFilter : 2;
-            unsigned int MagFilter : 2;
+            unsigned int MinFilter : 3;
+            unsigned int MagFilter : 1;
             unsigned int WrapU : 2;
             unsigned int WrapV : 2;
         } BitFields;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
@@ -86,7 +86,7 @@ public:
     int getWrapU() const { return Params.BitFields.WrapU; }
     int getWrapV() const { return Params.BitFields.WrapV; }
     float getMaxAnisotropy() const { return MaxAnisotropy; }
-    unsigned char getHashCode() const { return Params.HashCode; }
+    unsigned short getHashCode() const { return Params.HashCode; }
     void setMinFilter(int f) { Params.BitFields.MinFilter = f; }
     void setMagFilter(int f) { Params.BitFields.MagFilter = f; }
     void setWrapU(int wrap) { Params.BitFields.WrapU = wrap; }
@@ -99,11 +99,11 @@ protected:
         struct
         {
             unsigned int MinFilter : 3;
-            unsigned int MagFilter : 1;
+            unsigned int MagFilter : 3;
             unsigned int WrapU : 2;
             unsigned int WrapV : 2;
         } BitFields;
-        unsigned char HashCode;
+        unsigned short HashCode;
     } Params;
     float MaxAnisotropy;
 };

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_texture.cpp
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_texture.cpp
@@ -69,11 +69,10 @@ void VkTexture::createSampler(int maxLod) {
     VkSampler sampler = getSampler(index);
     if(sampler != 0)
         return;
-
-
+    
     // Sets the new MIN FILTER
-    VkFilter min_filter_type_ = MapFilter[mTexParams.getMinFilter()];
-
+    int min_filter = mTexParams.getMinFilter();
+    VkFilter min_filter_type_ = min_filter <= 1 ? MapFilter[min_filter] : VK_FILTER_LINEAR;
     // Sets the MAG FILTER
     VkFilter mag_filter_type_ = MapFilter[mTexParams.getMagFilter()];
 


### PR DESCRIPTION
defaulting min filter to GL_LINEAR_MIPMAP_NEAREST. and disable it internally if not applicable.
tested with 3dcursor, cubemap, shadows, render-to-texture, solarsystem, multilight, performance.