### PR TITLE
Fixing crash issue of vulkan on pause or resume of apps

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -49,7 +49,7 @@ namespace gvr {
     GVRActivity::~GVRActivity() {
         LOGV("GVRActivity::~GVRActivity");
         uninitializeVrApi();
-
+        Renderer::resetInstance();
         envMainThread_->DeleteGlobalRef(activityClass_);
         envMainThread_->DeleteGlobalRef(activity_);
     }
@@ -351,7 +351,7 @@ void GVRActivity::onDrawFrame(jobject jViewManager) {
 
     void GVRActivity::leaveVrMode() {
         LOGV("GVRActivity::leaveVrMode");
-        Renderer::resetInstance();
+
         if (nullptr != oculusMobile_) {
             for (int eye = 0; eye < (use_multiview ? 1 : VRAPI_FRAME_LAYER_EYE_MAX); eye++) {
                 frameBuffer_[eye].destroy();


### PR DESCRIPTION
App crashed since Vulkan Instance was freed on pause/resume of app, the RenderTarget which had 
Command Buffer made from the Command Pool associated with Vulkan Instance was no more valid.
Hence freeing vulkan instance only when the app is closed.