### PR TITLE
fix for multiple texcoord sets in jassimp

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRJassimpAdapter.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRJassimpAdapter.java
@@ -732,13 +732,13 @@ class GVRJassimpAdapter {
             shaderKey += texIndex;
             gvrmtl.setInt(textureKey + "_blendop", blendop);
         }
-        gvrmtl.setTexCoord(textureKey, texCoordKey, shaderKey);
         GVRTextureParameters texParams = new GVRTextureParameters(mContext);
         texParams.setWrapSType(wrapModeMap.get(aimtl.getTextureMapModeU(texType, texIndex)));
         texParams.setWrapTType(wrapModeMap.get(aimtl.getTextureMapModeV(texType, texIndex)));
         GVRTexture gvrTex = new GVRTexture(mContext, texParams);
         GVRAssetLoader.TextureRequest texRequest;
 
+        gvrTex.setTexCoord(texCoordKey, shaderKey);
         gvrmtl.setTexture(textureKey, gvrTex);
         if (texFileName.startsWith("*"))
         {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderData.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderData.java
@@ -425,9 +425,14 @@ public class GVRShaderData extends GVRHybridObject
         synchronized (textures)
         {
             GVRTexture tex = textures.get(texName);
+
             if (tex != null)
             {
                 tex.setTexCoord(texCoordAttr, shaderVarName);
+            }
+            else
+            {
+                throw new UnsupportedOperationException("Texture must be set before updating texture coordinate information");
             }
         }
     }


### PR DESCRIPTION
GVRMaterial.setTexCoord would silently fail if you did not set a texture
beforehand. Really we should get rid of this API and just use
GVRTexture.setTexCoord directly - this does the real work. I changed it
to throw an exception if it doesn't have a texture so the user at least
knows about it. I also changed jassimp to call GVRTexture.setTexCoord.

This fix is highly localized to jassimp.

GearVRF DCO signed off by: Nola Donato nola.donato@samsung.com