### PR TITLE
don't require a_texcoord for Phong shader

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRDirectLight.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRDirectLight.java
@@ -67,23 +67,23 @@ public class GVRDirectLight extends GVRLightBase
                 + " vec4 specular_intensity"
                 + " float shadow_map_index"
                 + " vec4 sm0 vec4 sm1 vec4 sm2 vec4 sm3";
-         if (useShadowShader)
-         {
-             if (fragmentShader == null)
-                 fragmentShader = TextFile.readTextFile(gvrContext.getContext(), R.raw.directshadowlight);
-             if (vertexShader == null)
-                 vertexShader = TextFile.readTextFile(gvrContext.getContext(), R.raw.vertex_shadow);
-             mVertexDescriptor = "vec4 shadow_position";
-             mVertexShaderSource = vertexShader;
-         }
-         else if (fragmentShader == null)
-         {
-             fragmentShader = TextFile.readTextFile(gvrContext.getContext(), R.raw.directlight);
-         }
-         mFragmentShaderSource = fragmentShader;
-         setAmbientIntensity(0.0f, 0.0f, 0.0f, 1.0f);
-         setDiffuseIntensity(1.0f, 1.0f, 1.0f, 1.0f);
-         setSpecularIntensity(1.0f, 1.0f, 1.0f, 1.0f);
+        if (useShadowShader)
+        {
+            if (fragmentShader == null)
+                fragmentShader = TextFile.readTextFile(gvrContext.getContext(), R.raw.directshadowlight);
+            if (vertexShader == null)
+                vertexShader = TextFile.readTextFile(gvrContext.getContext(), R.raw.vertex_shadow);
+            mVertexDescriptor = "vec4 shadow_position";
+            mVertexShaderSource = vertexShader;
+        }
+        else if (fragmentShader == null)
+        {
+            fragmentShader = TextFile.readTextFile(gvrContext.getContext(), R.raw.directlight);
+        }
+        mFragmentShaderSource = fragmentShader;
+        setAmbientIntensity(0.0f, 0.0f, 0.0f, 1.0f);
+        setDiffuseIntensity(1.0f, 1.0f, 1.0f, 1.0f);
+        setSpecularIntensity(1.0f, 1.0f, 1.0f, 1.0f);
     }
     
     /**

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
@@ -405,6 +405,7 @@ namespace gvr
      */
     void GLRenderer::makeShadowMaps(Scene* scene, ShaderManager* shader_manager)
     {
+        checkGLError("makeShadowMaps");
         const std::vector<Light*> lights = scene->getLightList();
         GLint drawFB, readFB;
         int texIndex = 0;

--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
@@ -11,7 +11,10 @@ precision highp float;
 @MATRIX_UNIFORMS
 
 layout(location = 0) in vec3 a_position;
+
+#ifdef HAS_a_texcoord
 layout(location = 1) in vec2 a_texcoord;
+#endif
 
 #if defined(HAS_a_normal) && defined(HAS_LIGHTSOURCES)
 layout(location = 2) in vec3 a_normal;

--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
@@ -11,7 +11,10 @@ precision highp float;
 
 
 layout(location = 0) in vec3 a_position;
+
+#ifdef HAS_a_texcoord
 layout(location = 1) in vec2 a_texcoord;
+#endif
 
 #if defined(HAS_a_normal) && defined(HAS_LIGHTSOURCES)
 layout(location = 5) in vec3 a_normal;
@@ -43,16 +46,12 @@ layout(location = 5) out vec2 ambient_coord;
 layout(location = 6) out vec2 specular_coord;
 layout(location = 7) out vec2 emissive_coord;
 layout(location = 8) out vec2 lightmap_coord;
-
-
-
 layout(location = 9) out vec2 opacity_coord;
 layout(location = 10) out vec2 normal_coord;
 layout(location = 11) out vec2 diffuse_coord1;
 layout(location = 12) out vec2 ambient_coord1;
 layout(location = 13) out vec2 specular_coord1;
 layout(location = 14) out vec2 emissive_coord1;
-layout(location = 15) out vec2 normal_coord1;
 
 //
 // The Phong vertex shader supports up to 4 sets of texture coordinates.


### PR DESCRIPTION
Jassimp generates models which have a_texcoord1 but not a_texcoord. This
fix suppresses a log warning about the shader not having a_texcoord by
generating a shader that doesn't require it

Removed normal_coord1 from shader - we currently don't support layering
normal maps

fixed spacing in GVRDirectLight
This is a minor fix not required for 4.0.

GearVRF DCO signed off by: Nola Donato nola.donato@samsung.com