### PR TITLE
HybridObject virtual destructor cleanup.

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.h
@@ -32,6 +32,8 @@ namespace gvr {
                 BitmapImage(format), GLImage(GL_TEXTURE_2D)
         { }
 
+        virtual ~GLBitmapImage() {}
+
         static int updateFromBitmap(JNIEnv *env, int target, jobject bitmap, bool);
 
         virtual int getId() { return mId; }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_cubemap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_cubemap_image.h
@@ -33,6 +33,7 @@ public:
             : GLImage(GL_TEXTURE_CUBE_MAP),
               CubemapImage(format)
     { }
+    virtual ~GLCubemapImage() {}
     virtual int getId() { return mId; }
     virtual bool isReady()
     {

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_external_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_external_image.h
@@ -27,6 +27,7 @@ class GLExternalImage: public GLImage, public ExternalImage
 public:
     GLExternalImage() : GLImage(GL_TEXTURE_EXTERNAL_OES)
     { }
+    virtual ~GLExternalImage() {}
     virtual int getId() { return mId; }
     virtual bool isReady()
     {

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
@@ -29,6 +29,7 @@ namespace gvr {
     public:
         GLFloatImage() : FloatImage(), GLImage(GL_TEXTURE_2D)
         { }
+        virtual ~GLFloatImage() {}
         virtual int getId() { return mId; }
         virtual bool isReady()
         {

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_imagetex.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_imagetex.h
@@ -41,6 +41,9 @@ namespace gvr {
             mTexParams.setMinFilter(GL_LINEAR); // if created with external texture
             mState = HAS_DATA;
         }
+
+        virtual ~GLImageTex() {}
+
         void updateTexParams() {
             int min_filter = mTexParams.getMinFilter();
             if(mIsCompressed && mLevels <= 1 && min_filter >= TextureParameters::NEAREST_MIPMAP_NEAREST)

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_material.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_material.h
@@ -39,6 +39,8 @@ namespace gvr
             uniforms_.useGPUBuffer(false);
         }
 
+        virtual ~GLMaterial() {}
+
         virtual UniformBlock& uniforms()
         {
             return uniforms_;

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_data.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_data.h
@@ -40,6 +40,9 @@ namespace gvr
         {
             copy(rdata);
         }
+
+        virtual ~GLRenderData() {}
+
         virtual void render(Shader*, Renderer*);
 
     private:

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.h
@@ -36,6 +36,7 @@ public:
     explicit GLRenderImage(int width, int height, int layers, GLuint texId, bool marktexParamsDirty);
     explicit GLRenderImage(int width, int height, int color_format, const TextureParameters* texture_parameters);
     explicit GLRenderImage(int width, int height, int color_format, int layers, const TextureParameters* texture_parameters);
+    virtual ~GLRenderImage() {}
     virtual int getId() { return mId; }
 
     virtual bool isReady()

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_target.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_target.h
@@ -23,7 +23,7 @@ public:
     }
     explicit GLRenderTarget(RenderTexture* renderTexture, const RenderTarget* source): RenderTarget(renderTexture, source){}
     explicit  GLRenderTarget(){}
-    ~GLRenderTarget(){}
+    virtual ~GLRenderTarget(){}
     virtual void beginRendering(Renderer *renderer);
 };
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/box_collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/box_collider.h
@@ -31,7 +31,7 @@ public:
         Collider(),
         half_extents_(0, 0, 0) { }
 
-    ~BoxCollider() { }
+    virtual ~BoxCollider() { }
 
     long shape_type() {
         return COLLIDER_SHAPE_BOX;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider_group.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider_group.h
@@ -34,7 +34,7 @@ namespace gvr {
 class ColliderGroup: public Collider {
 public:
     ColliderGroup();
-    ~ColliderGroup();
+    virtual ~ColliderGroup();
 
     void addCollider(Collider* collider);
     void removeCollider(Collider* collider);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/custom_camera.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/custom_camera.h
@@ -31,6 +31,8 @@ public:
             Camera(), projection_matrix_() {
     }
 
+    virtual ~CustomCamera() {}
+
     glm::mat4 projection_matrix() {
         return projection_matrix_;
     }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
@@ -34,7 +34,7 @@ public:
     MeshCollider(Mesh* mesh = NULL);
     MeshCollider(Mesh* mesh, bool pickCoordinates);
     MeshCollider(bool useMeshBounds);
-    ~MeshCollider();
+    virtual ~MeshCollider();
 
     long shape_type() {
         return COLLIDER_SHAPE_MESH;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/orthogonal_camera.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/orthogonal_camera.h
@@ -34,7 +34,7 @@ public:
                     1.0f) {
     }
 
-    ~OrthogonalCamera() {
+    virtual ~OrthogonalCamera() {
     }
 
     float left_clipping_distance() const {

--- a/GVRf/Framework/framework/src/main/jni/objects/components/perspective_camera.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/perspective_camera.h
@@ -33,7 +33,7 @@ public:
                     default_aspect_ratio_) {
     }
 
-    ~PerspectiveCamera() {
+    virtual ~PerspectiveCamera() {
     }
 
     static float default_aspect_ratio() {

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
@@ -130,7 +130,7 @@ public:
         copy(rdata);
     }
 
-    ~RenderData();
+    virtual ~RenderData();
 
     static long long getComponentType() {
         return COMPONENT_TYPE_RENDER_DATA;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_target.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_target.h
@@ -45,7 +45,7 @@ public:
     RenderTarget(Scene*);
     RenderTarget(RenderTexture*, const RenderTarget* source);
     RenderTarget();
-    ~RenderTarget();
+    virtual ~RenderTarget();
     void attachNextRenderTarget(RenderTarget* renderTarget){
         mNextRenderTarget = renderTarget;
     }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/shadow_map.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/shadow_map.h
@@ -29,7 +29,7 @@ class GLFrameBuffer;
     {
     public:
         ShadowMap(ShaderData* mtl);
-        ~ShadowMap();
+        virtual ~ShadowMap();
         virtual void  beginRendering(Renderer* renderer);
         void setLayerIndex(int layerIndex);
         void bindTexture(int loc, int texture_index);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/sphere_collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/sphere_collider.h
@@ -34,7 +34,7 @@ public:
         center_(0, 0, 0),
         radius_(0) { }
 
-    ~SphereCollider() { }
+    virtual ~SphereCollider() { }
 
     long shape_type() {
         return COLLIDER_SHAPE_SPHERE;

--- a/GVRf/Framework/framework/src/main/jni/objects/light.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/light.h
@@ -57,6 +57,8 @@ public:
     {
     }
 
+    virtual ~Light() {}
+
     static long long getComponentType() {
         return COMPONENT_TYPE_LIGHT;
     }

--- a/GVRf/Framework/framework/src/main/jni/objects/mesh.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/mesh.h
@@ -44,6 +44,7 @@ class Mesh: public HybridObject {
 public:
     Mesh(const char* descriptor);
     Mesh(VertexBuffer& vbuf);
+    virtual ~Mesh() {}
 
     VertexBuffer* getVertexBuffer() const { return mVertices; }
     IndexBuffer* getIndexBuffer() const { return mIndices; }

--- a/GVRf/Framework/framework/src/main/jni/objects/render_pass.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/render_pass.h
@@ -38,6 +38,7 @@ public:
     };
 
     RenderPass();
+    virtual ~RenderPass() {}
 
     ShaderData* material() const {
         return material_;

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
@@ -40,7 +40,7 @@ class CameraRig;
 class SceneObject: public HybridObject {
 public:
     SceneObject();
-    ~SceneObject();
+    virtual ~SceneObject();
 
     std::string name() const {
         return name_;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/external_image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/external_image.h
@@ -15,6 +15,7 @@ class ExternalImage : public Image
 public:
     ExternalImage() : Image(Image::ImageType::NONE, 0), mData(0)
     { }
+    virtual ~ExternalImage() {}
 
     virtual void setData(long data)
     {

--- a/GVRf/Framework/framework/src/main/jni/shaders/shader_manager.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/shader_manager.h
@@ -44,7 +44,7 @@ public:
             latest_shader_id_(0)
     { }
 
-    ~ShaderManager();
+    virtual ~ShaderManager();
 
 /*
  * Add a native shader to this shader manager.

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_bitmap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_bitmap_image.h
@@ -24,6 +24,7 @@ namespace gvr {
     {
     public:
         VkBitmapImage(int format);
+        virtual ~VkBitmapImage() {}
         virtual int getId() { return 1; }
         int updateFromBitmap(JNIEnv *env, VkImageViewType target, jobject bitmap);
         virtual void texParamsChanged(const TextureParameters&) { }

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_cubemap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_cubemap_image.h
@@ -25,6 +25,7 @@ namespace gvr {
     {
     public:
         VkCubemapImage(int format);
+        virtual ~VkCubemapImage() {}
         virtual int getId() { return 1; }
         virtual void texParamsChanged(const TextureParameters&) { }
 

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_float_image.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_float_image.h
@@ -30,6 +30,8 @@ namespace gvr {
         VkFloatImage() : FloatImage(), vkImageBase(VK_IMAGE_VIEW_TYPE_2D)
         { }
 
+        virtual ~VkFloatImage() {}
+
         virtual int getId() { return 0; }
         virtual void texParamsChanged(const TextureParameters&) { }
         virtual bool isReady()

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_render_target.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_render_target.h
@@ -32,7 +32,7 @@ public:
     explicit VkRenderTarget(Scene* scene);
     explicit VkRenderTarget(RenderTexture* renderTexture, const RenderTarget* source);
     explicit  VkRenderTarget(){}
-    ~VkRenderTarget(){}
+    virtual ~VkRenderTarget(){}
     virtual void    beginRendering(Renderer* renderer);
     virtual void    endRendering(Renderer*);
     VkCommandBuffer& getCommandBuffer(){

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_image.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_image.h
@@ -29,6 +29,8 @@ namespace gvr
 
         VulkanImage(ImageType type, int format, short width, short height);
 
+        virtual ~VulkanImage() {}
+
         virtual bool isReady()
         {
             return checkForUpdate(true);

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_material.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_material.h
@@ -30,6 +30,7 @@ namespace gvr {
     {
     public:
         VulkanMaterial(const char* uniform_desc, const char* texture_desc);
+        virtual ~VulkanMaterial() {}
         void useGPUBuffer(bool flag){
             uniforms_.useGPUBuffer(flag);
         }

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_render_data.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_render_data.h
@@ -32,6 +32,7 @@ namespace gvr
 {
 struct VulkanRenderPass : public RenderPass
 {
+    virtual ~VulkanRenderPass() {}
     bool descriptorSetNull = true;
     VkDescriptorPool m_descriptorPool;
     VkPipeline m_pipeline;
@@ -55,6 +56,9 @@ struct VulkanRenderPass : public RenderPass
         "mat4 u_view; mat4 u_mvp; mat4 u_mv; mat4 u_mv_it; mat4 u_model; mat4 u_view_i; float u_right;", TRANSFORM_UBO_INDEX, "Transform_ubo")
         {
         }
+
+        virtual ~VulkanRenderData() {}
+
         void createPipeline(Shader* shader, VulkanRenderer* renderer, int pass, VkRenderPass);
 
         VulkanUniformBlock& getTransformUbo(){


### PR DESCRIPTION
Every class derived from the Native HybridObject shall have a virtual destructor.

Yes, even VulkanRenderPass.

-----
GearVRf-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com