### PR TITLE
Fixing gvr-cubemap reflection issue

### DIFF
--- a/GVRf/Framework/framework/src/main/res/raw/cubemap_reflection_frag.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/cubemap_reflection_frag.fsh
@@ -4,7 +4,7 @@
 #extension GL_OVR_multiview2 : enable
 #endif
 precision highp float;
-layout( set = 0, binding = 4 ) uniform samplerCube u_texture;
+layout( set = 0, binding = 4 ) uniform mediump samplerCube u_texture;
 
 @MATERIAL_UNIFORMS
 

--- a/GVRf/Framework/framework/src/main/res/raw/cubemap_reflection_frag.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/cubemap_reflection_frag.fsh
@@ -4,7 +4,7 @@
 #extension GL_OVR_multiview2 : enable
 #endif
 precision highp float;
-layout( set = 0, binding = 2 ) uniform samplerCube u_texture;
+layout( set = 0, binding = 4 ) uniform samplerCube u_texture;
 
 @MATERIAL_UNIFORMS
 

--- a/GVRf/Framework/framework/src/main/res/raw/cubemap_reflection_vert.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/cubemap_reflection_vert.vsh
@@ -7,7 +7,7 @@ layout(num_views = 2) in;
 
 precision highp float;
 layout(location = 0) in vec3 a_position;
-layout(location = 5) in vec3 a_normal;
+layout(location = 1) in vec3 a_normal;
 
 @MATRIX_UNIFORMS
 


### PR DESCRIPTION
Fixes reflection cube for vulkan.
Binding location for texture and location for normal was wrong.

Additionally fixing it on Note4. Adding mediump to samplerCube fixes the reflection.

GearVRf-DCO-1.0-Signed-off-by: Abhijit Jagdale a.jagdale@samsung.com