### PR TITLE
Don't use virtual functions in destructors I

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/components/component.inl
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/component.inl
@@ -38,7 +38,7 @@ inline Component::Component(long long type, SceneObject* owner_object) :
 }
 
 inline Component::~Component() {
-    set_owner_object(NULL);
+    owner_object_ = nullptr;
 }
 
 inline SceneObject *Component::owner_object() const {

--- a/GVRf/Framework/framework/src/main/jni/objects/components/transform.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/transform.cpp
@@ -34,7 +34,9 @@ Transform::Transform() :
 }
 
 Transform::~Transform() {
-    owner_object_->onTransformChanged();
+    if(owner_object_) {
+        owner_object_->onTransformChanged();
+    }
 }
 
 void Transform::invalidate()

--- a/GVRf/Framework/framework/src/main/jni/objects/components/transform.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/transform.cpp
@@ -34,6 +34,7 @@ Transform::Transform() :
 }
 
 Transform::~Transform() {
+    owner_object_->onTransformChanged();
 }
 
 void Transform::invalidate()


### PR DESCRIPTION
set_owner_object() is a virtual function. Don't call it from destructor please.

Part of the #1567 series

-----
GearVRf-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com