### PR TITLE
Code cleanup: constructors

### DIFF
--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_conetwistconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_conetwistconstraint.h
@@ -32,11 +32,11 @@ namespace gvr {
 
     class BulletConeTwistConstraint : public PhysicsConeTwistConstraint, BulletObject {
     public:
-        BulletConeTwistConstraint(PhysicsRigidBody *rigidBodyB, PhysicsVec3 pivot,
-                                  PhysicsMat3x3 const &bodyRotation,
-                                  PhysicsMat3x3 const &coneRotation);
+        explicit BulletConeTwistConstraint(PhysicsRigidBody *rigidBodyB, PhysicsVec3 pivot,
+                                           PhysicsMat3x3 const &bodyRotation,
+                                           PhysicsMat3x3 const &coneRotation);
 
-        ~BulletConeTwistConstraint();
+        virtual ~BulletConeTwistConstraint();
 
         void setSwingLimit(float limit);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fixedconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fixedconstraint.h
@@ -31,9 +31,9 @@ namespace gvr {
                                          BulletObject  {
 
     public:
-        BulletFixedConstraint(PhysicsRigidBody* rigidBodyB);
+        explicit BulletFixedConstraint(PhysicsRigidBody* rigidBodyB);
 
-        ~BulletFixedConstraint();
+        virtual ~BulletFixedConstraint();
 
         void* getUnderlying() {
             return this->mFixedConstraint;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_generic6dofconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_generic6dofconstraint.h
@@ -32,10 +32,10 @@ namespace gvr {
 
     class BulletGeneric6dofConstraint : public PhysicsGenericConstraint, BulletObject {
     public:
-        BulletGeneric6dofConstraint(PhysicsRigidBody *rigidBodyB, float const joint[],
-                                    float const rotationA[], float const rotationB[]);
+        explicit BulletGeneric6dofConstraint(PhysicsRigidBody *rigidBodyB, float const joint[],
+                                             float const rotationA[], float const rotationB[]);
 
-        ~BulletGeneric6dofConstraint();
+        virtual ~BulletGeneric6dofConstraint();
 
         void setLinearLowerLimits(float limitX, float limitY, float limitZ);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_hingeconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_hingeconstraint.h
@@ -33,11 +33,11 @@ namespace gvr {
                                   BulletObject {
 
     public:
-        BulletHingeConstraint(PhysicsRigidBody *rigidBodyB, float const pivotInA[],
-                              float const pivotInB[], float const axisInA[],
-                              float const axisInB[]);
+        explicit BulletHingeConstraint(PhysicsRigidBody *rigidBodyB, float const pivotInA[],
+                                       float const pivotInB[], float const axisInA[],
+                                       float const axisInB[]);
 
-        ~BulletHingeConstraint();
+        virtual ~BulletHingeConstraint();
 
         void setLimits(float lower, float upper);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.h
@@ -31,10 +31,10 @@ namespace gvr {
                                                BulletObject {
 
     public:
-        BulletPoint2PointConstraint(PhysicsRigidBody* rigidBodyB, float pivotInA[],
-                                    float pivotInB[]);
+        explicit BulletPoint2PointConstraint(PhysicsRigidBody* rigidBodyB, float pivotInA[],
+                                             float pivotInB[]);
 
-        ~BulletPoint2PointConstraint();
+        virtual ~BulletPoint2PointConstraint();
 
         virtual void* getUnderlying() {
             return this->mPoint2PointConstraint;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.h
@@ -31,7 +31,7 @@ class BulletRigidBody : public PhysicsRigidBody,
  public:
     BulletRigidBody();
 
-    ~BulletRigidBody();
+    virtual ~BulletRigidBody();
 
     btRigidBody *getRigidBody() const {
         return mRigidBody;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.h
@@ -33,9 +33,9 @@ namespace gvr {
     class BulletSliderConstraint : public PhysicsSliderConstraint,
                                           BulletObject {
     public:
-        BulletSliderConstraint(PhysicsRigidBody *rigidBodyB);
+        explicit BulletSliderConstraint(PhysicsRigidBody *rigidBodyB);
 
-        ~BulletSliderConstraint();
+        virtual ~BulletSliderConstraint();
 
         void setAngularLowerLimit(float limit);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_world.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_world.h
@@ -41,7 +41,7 @@ class BulletWorld : public PhysicsWorld {
  public:
     BulletWorld();
 
-    ~BulletWorld();
+    virtual ~BulletWorld();
 
     void addConstraint(PhysicsConstraint *constraint);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_conetwistconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_conetwistconstraint.h
@@ -26,6 +26,8 @@ namespace gvr {
 
     class PhysicsConeTwistConstraint : public PhysicsConstraint {
     public:
+        virtual ~PhysicsConeTwistConstraint() {}
+
         virtual void setSwingLimit(float limit) = 0;
 
         virtual float getSwingLimit() const = 0;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_constraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_constraint.h
@@ -32,6 +32,8 @@ namespace gvr {
     public:
         PhysicsConstraint() : Component(PhysicsConstraint::getComponentType()){}
 
+        virtual ~PhysicsConstraint() {}
+
         static long long getComponentType() {
             return COMPONENT_TYPE_PHYSICS_CONSTRAINT;
         }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_fixedconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_fixedconstraint.h
@@ -24,7 +24,8 @@ class PhysicsRigidBody;
 
 class PhysicsFixedConstraint : public PhysicsConstraint {
  public:
-    PhysicsFixedConstraint(PhysicsRigidBody *rigidBodyB) : PhysicsConstraint() {}
+    virtual ~PhysicsFixedConstraint() {}
+    explicit PhysicsFixedConstraint(PhysicsRigidBody *rigidBodyB) : PhysicsConstraint() {}
 };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_genericconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_genericconstraint.h
@@ -12,6 +12,8 @@ namespace gvr {
 
     class PhysicsGenericConstraint : public PhysicsConstraint {
     public:
+        virtual ~PhysicsGenericConstraint() {}
+
         virtual void setLinearLowerLimits(float limitX, float limitY, float limitZ) = 0;
 
         virtual PhysicsVec3 getLinearLowerLimits() const = 0;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_hingeconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_hingeconstraint.h
@@ -27,6 +27,7 @@ namespace gvr {
 
     class PhysicsHingeConstraint : public PhysicsConstraint {
     public:
+        virtual ~PhysicsHingeConstraint() {}
 
         virtual void setLimits(float lower, float upper) = 0;
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_point2pointconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_point2pointconstraint.h
@@ -26,6 +26,8 @@ class PhysicsRigidBody;
 class PhysicsPoint2pointConstraint : public PhysicsConstraint {
 public:
 
+    virtual ~PhysicsPoint2pointConstraint() {}
+
     virtual void setPivotInA(PhysicsVec3 pivot) = 0;
 
     virtual PhysicsVec3 getPivotInA() const = 0;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_rigidbody.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_rigidbody.h
@@ -37,6 +37,8 @@ class PhysicsRigidBody : public Component {
 
 	PhysicsRigidBody() : Component(PhysicsRigidBody::getComponentType()) {}
 
+	virtual ~PhysicsRigidBody() {}
+
 	static long long getComponentType() {
 	    return COMPONENT_TYPE_PHYSICS_RIGID_BODY;
 	}

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_sliderconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_sliderconstraint.h
@@ -26,6 +26,8 @@ namespace gvr {
 
     class PhysicsSliderConstraint : public PhysicsConstraint {
     public:
+        virtual ~PhysicsSliderConstraint() {}
+
         virtual void setAngularLowerLimit(float limit) = 0;
 
         virtual float getAngularLowerLimit() const = 0;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_world.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_world.h
@@ -40,6 +40,8 @@ class PhysicsWorld : public Component {
  public:
 	PhysicsWorld() : Component(PhysicsWorld::getComponentType()){}
 
+	virtual ~PhysicsWorld() {}
+
 	static long long getComponentType() {
 	        return COMPONENT_TYPE_PHYSICS_WORLD;
 	}

--- a/GVRf/Framework/framework/src/main/jni/configuration_manager.h
+++ b/GVRf/Framework/framework/src/main/jni/configuration_manager.h
@@ -29,13 +29,13 @@ namespace gvr {
         int getMaxLights();
 
     private:
-        ConfigurationManager(const ConfigurationManager &configuration_manager);
+        ConfigurationManager(const ConfigurationManager &configuration_manager) = delete;
 
-        ConfigurationManager(ConfigurationManager &&configuration_manager);
+        ConfigurationManager(ConfigurationManager &&configuration_manager) = delete;
 
-        ConfigurationManager &operator=(const ConfigurationManager &configuration_manager);
+        ConfigurationManager &operator=(const ConfigurationManager &configuration_manager) = delete;
 
-        ConfigurationManager &operator=(ConfigurationManager &&configuration_manager);
+        ConfigurationManager &operator=(ConfigurationManager &&configuration_manager) = delete;
 
         void calculateMaxLights();
 

--- a/GVRf/Framework/framework/src/main/jni/eglextension/msaa/msaa.h
+++ b/GVRf/Framework/framework/src/main/jni/eglextension/msaa/msaa.h
@@ -32,7 +32,7 @@ typedef void (GL_APIENTRYP PFNGLRENDERBUFFERSTORAGEMULTISAMPLE)(GLenum target,
 
 class MSAA {
 private:
-    MSAA();
+    MSAA() = delete;
 
 public:
     static int getMaxSampleCount() {

--- a/GVRf/Framework/framework/src/main/jni/eglextension/tiledrendering/tiled_rendering_enhancer.h
+++ b/GVRf/Framework/framework/src/main/jni/eglextension/tiledrendering/tiled_rendering_enhancer.h
@@ -27,7 +27,7 @@ namespace gvr {
 
 class TiledRenderingEnhancer {
 private:
-    TiledRenderingEnhancer();
+    TiledRenderingEnhancer() = delete;
 
 public:
     static void start(GLuint x, GLuint y, GLuint width, GLuint height,

--- a/GVRf/Framework/framework/src/main/jni/engine/exporter/exporter.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/exporter/exporter.h
@@ -25,7 +25,7 @@
 namespace gvr {
 class Exporter {
 private:
-    Exporter();
+    Exporter() = delete;
 
 public:
     static int writeToFile(Scene *scene, const std::string filename);

--- a/GVRf/Framework/framework/src/main/jni/engine/picker/picker.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/picker/picker.h
@@ -33,7 +33,7 @@ class SceneObject;
 class CameraRig;
 class Transform;
 
-class Picker {
+class Picker final {
 private:
     Picker();
     ~Picker();

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/batch.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/batch.h
@@ -32,10 +32,10 @@ namespace gvr{
 class RenderData;
 class ShaderData;
 class Mesh;
-class Batch {
+class Batch final {
 public:
     Batch();
-    Batch(int,int);
+    explicit Batch(int,int);
     ~Batch();
     bool add(RenderData *render_data);
     bool setupMesh(bool);

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/batch_manager.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/batch_manager.h
@@ -34,9 +34,9 @@ class Mesh;
 class Batch;
 struct RenderState;
 extern bool isRenderPassEqual(RenderData* rdata1, RenderData* rdata2);
-class BatchManager{
+class BatchManager final {
 public:
-    BatchManager(int batch_size, int max_indices);
+    explicit BatchManager(int batch_size, int max_indices);
     ~BatchManager();
     Batch* getNewBatch();
     void freeBatch(Batch* batch){

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.h
@@ -111,47 +111,47 @@ public:
         return numberDrawCalls;
     }
 
-     int getNumberTriangles() {
+    int getNumberTriangles() {
         return numberTriangles;
-     }
-     int incrementTriangles(int number=1){
+    }
+    int incrementTriangles(int number=1){
         return numberTriangles += number;
-     }
-     int incrementDrawCalls(){
+    }
+    int incrementDrawCalls(){
         return ++numberDrawCalls;
-     }
-     static Renderer* getInstance(std::string type =  " ");
-     static void resetInstance(){
-         //@todo fix for vulkan
-         if (!isVulkan_) {
-             delete instance;
-             instance = NULL;
-         }
-     }
-     virtual ShaderData* createMaterial(const char* uniform_desc, const char* texture_desc) = 0;
-     virtual RenderData* createRenderData() = 0;
-     virtual UniformBlock* createUniformBlock(const char* desc, int, const char* name, int) = 0;
-     virtual Image* createImage(int type, int format) = 0;
-        virtual RenderPass* createRenderPass() = 0;
-     virtual Texture* createTexture(int target = GL_TEXTURE_2D) = 0;
-     virtual RenderTexture* createRenderTexture(int width, int height, int sample_count,
-                                                int jcolor_format, int jdepth_format, bool resolve_depth,
-                                                const TextureParameters* texture_parameters, int number_views) = 0;
+    }
+    static Renderer* getInstance(std::string type =  " ");
+    static void resetInstance(){
+        //@todo fix for vulkan
+        if (!isVulkan_) {
+            delete instance;
+            instance = NULL;
+        }
+    }
+    virtual ShaderData* createMaterial(const char* uniform_desc, const char* texture_desc) = 0;
+    virtual RenderData* createRenderData() = 0;
+    virtual UniformBlock* createUniformBlock(const char* desc, int, const char* name, int) = 0;
+    virtual Image* createImage(int type, int format) = 0;
+    virtual RenderPass* createRenderPass() = 0;
+    virtual Texture* createTexture(int target = GL_TEXTURE_2D) = 0;
+    virtual RenderTexture* createRenderTexture(int width, int height, int sample_count,
+                                               int jcolor_format, int jdepth_format, bool resolve_depth,
+                                               const TextureParameters* texture_parameters, int number_views) = 0;
     virtual RenderTexture* createRenderTexture(int width, int height, int sample_count, int layers) = 0;
     virtual RenderTexture* createRenderTexture(const RenderTextureInfo&)=0;
     virtual Shader* createShader(int id, const char* signature,
                                  const char* uniformDescriptor, const char* textureDescriptor,
                                  const char* vertexDescriptor, const char* vertexShader,
                                  const char* fragmentShader) = 0;
-     virtual VertexBuffer* createVertexBuffer(const char* descriptor, int vcount) = 0;
-     virtual IndexBuffer* createIndexBuffer(int bytesPerIndex, int icount) = 0;
-     void updateTransforms(RenderState& rstate, UniformBlock* block, RenderData*);
-     virtual void initializeStats();
-     virtual void cullFromCamera(Scene *scene, Camera* camera,
-                ShaderManager* shader_manager, std::vector<RenderData*>* render_data_vector,bool);
-     virtual void set_face_culling(int cull_face) = 0;
+    virtual VertexBuffer* createVertexBuffer(const char* descriptor, int vcount) = 0;
+    virtual IndexBuffer* createIndexBuffer(int bytesPerIndex, int icount) = 0;
+    void updateTransforms(RenderState& rstate, UniformBlock* block, RenderData*);
+    virtual void initializeStats();
+    virtual void cullFromCamera(Scene *scene, Camera* camera,
+                                ShaderManager* shader_manager, std::vector<RenderData*>* render_data_vector,bool);
+    virtual void set_face_culling(int cull_face) = 0;
 
-     virtual void renderRenderData(RenderState& rstate, RenderData* render_data);
+    virtual void renderRenderData(RenderState& rstate, RenderData* render_data);
     virtual RenderTarget* createRenderTarget(Scene*) = 0;
     virtual RenderTarget* createRenderTarget(RenderTexture*, bool) = 0;
     virtual RenderTarget* createRenderTarget(RenderTexture*, const RenderTarget*) = 0;
@@ -204,10 +204,10 @@ private:
             float frustum[6][4], std::vector<SceneObject*>& scene_objects,
             bool continue_cull, int planeMask);
 
-    Renderer(const Renderer& render_engine);
-    Renderer(Renderer&& render_engine);
-    Renderer& operator=(const Renderer& render_engine);
-    Renderer& operator=(Renderer&& render_engine);
+    Renderer(const Renderer& render_engine) = delete;
+    Renderer(Renderer&& render_engine) = delete;
+    Renderer& operator=(const Renderer& render_engine) = delete;
+    Renderer& operator=(Renderer&& render_engine) = delete;
     BatchManager* batch_manager;
     static Renderer* instance;
 

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_cubemap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_cubemap_image.h
@@ -56,10 +56,10 @@ protected:
     virtual void update(int texid);
 
 private:
-    GLCubemapImage(const GLCubemapImage&);
-    GLCubemapImage(GLCubemapImage&&);
-    GLCubemapImage& operator=(const GLCubemapImage&);
-    GLCubemapImage& operator=(GLCubemapImage&&);
+    GLCubemapImage(const GLCubemapImage&) = delete;
+    GLCubemapImage(GLCubemapImage&&) = delete;
+    GLCubemapImage& operator=(const GLCubemapImage&) = delete;
+    GLCubemapImage& operator=(GLCubemapImage&&) = delete;
 
     void updateFromBitmap(int texid);
     void updateFromMemory(int texid);

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_external_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_external_image.h
@@ -43,10 +43,10 @@ public:
         GLImage::updateTexParams(mTexParams);
     }
 private:
-    GLExternalImage(const GLExternalImage&e);
-    GLExternalImage(GLExternalImage&&);
-    GLExternalImage& operator=(const GLExternalImage&);
-    GLExternalImage& operator=(GLExternalImage&&);
+    GLExternalImage(const GLExternalImage&e) = delete;
+    GLExternalImage(GLExternalImage&&) = delete;
+    GLExternalImage& operator=(const GLExternalImage&) = delete;
+    GLExternalImage& operator=(GLExternalImage&&) = delete;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_external_texture.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_external_texture.h
@@ -30,10 +30,10 @@ public:
     }
 
 private:
-    GLExternalRendererTexture(const GLExternalRendererTexture&e);
-    GLExternalRendererTexture(GLExternalRendererTexture&&);
-    GLExternalRendererTexture& operator=(const GLExternalRendererTexture&);
-    GLExternalRendererTexture& operator=(GLExternalRendererTexture&&);
+    GLExternalRendererTexture(const GLExternalRendererTexture&e) = delete;
+    GLExternalRendererTexture(GLExternalRendererTexture&&) = delete;
+    GLExternalRendererTexture& operator=(const GLExternalRendererTexture&) = delete;
+    GLExternalRendererTexture& operator=(GLExternalRendererTexture&&) = delete;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
@@ -63,10 +63,10 @@ namespace gvr {
         }
 
     private:
-        GLFloatImage(const GLFloatImage&);
-        GLFloatImage(GLFloatImage&&);
-        GLFloatImage& operator=(const GLFloatImage&);
-        GLFloatImage& operator=(GLFloatImage&&);
+        GLFloatImage(const GLFloatImage&) = delete;
+        GLFloatImage(GLFloatImage&&) = delete;
+        GLFloatImage& operator=(const GLFloatImage&) = delete;
+        GLFloatImage& operator=(GLFloatImage&&) = delete;
     };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_frame_buffer.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_frame_buffer.h
@@ -39,10 +39,10 @@ public:
         return id_;
     }
 private:
-    GLFrameBuffer(const GLFrameBuffer& gl_frame_buffer);
-    GLFrameBuffer(GLFrameBuffer&& gl_frame_buffer);
-    GLFrameBuffer& operator=(const GLFrameBuffer& gl_frame_buffer);
-    GLFrameBuffer& operator=(GLFrameBuffer&& gl_frame_buffer);
+    GLFrameBuffer(const GLFrameBuffer& gl_frame_buffer) = delete;
+    GLFrameBuffer(GLFrameBuffer&& gl_frame_buffer) = delete;
+    GLFrameBuffer& operator=(const GLFrameBuffer& gl_frame_buffer) = delete;
+    GLFrameBuffer& operator=(GLFrameBuffer&& gl_frame_buffer) = delete;
 
 private:
     GLuint id_;

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_image.h
@@ -63,10 +63,10 @@ public:
     void            setTexId(GLuint id) { mId = id; }
     void            setTexParamsDirty(bool flag) {mTexParamsDirty = flag; }
 private:
-    GLImage(const GLImage& gl_texture);
-    GLImage(GLImage&& gl_texture);
-    GLImage& operator=(const GLImage& gl_texture);
-    GLImage& operator=(GLImage&& gl_texture);
+    GLImage(const GLImage& gl_texture) = delete;
+    GLImage(GLImage&& gl_texture) = delete;
+    GLImage& operator=(const GLImage& gl_texture) = delete;
+    GLImage& operator=(GLImage&& gl_texture) = delete;
 
 protected:
 

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_index_buffer.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_index_buffer.h
@@ -24,7 +24,7 @@ namespace gvr {
     class GLIndexBuffer : public IndexBuffer
     {
     public:
-        GLIndexBuffer(int bytesPerIndex, int vertexCount);
+        explicit GLIndexBuffer(int bytesPerIndex, int vertexCount);
         virtual ~GLIndexBuffer();
 
         virtual bool    bindBuffer(Shader*);

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_material.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_material.h
@@ -32,7 +32,7 @@ namespace gvr
     class GLMaterial : public ShaderData
     {
     public:
-        GLMaterial(const char* uniform_desc, const char* texture_desc)
+        explicit GLMaterial(const char* uniform_desc, const char* texture_desc)
         : ShaderData(texture_desc),
           uniforms_(uniform_desc, MATERIAL_UBO_INDEX, "Material_ubo")
         {

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_program.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_program.h
@@ -27,9 +27,9 @@
 #include "util/gvr_gl.h"
 
 namespace gvr {
-class GLProgram {
+class GLProgram final {
 public:
-    GLProgram(const char* pVertexSourceStrings,
+    explicit GLProgram(const char* pVertexSourceStrings,
             const char* pFragmentSourceStrings) {
         GLint vertex_shader_string_lengths[1] = { (GLint) strlen(
                 pVertexSourceStrings) };
@@ -41,7 +41,7 @@ public:
                 fragment_shader_string_lengths);
     }
 
-    GLProgram(const char** pVertexSourceStrings,
+    explicit GLProgram(const char** pVertexSourceStrings,
             const GLint* pVertexSourceStringLengths,
             const char** pFragmentSourceStrings,
             const GLint* pFragmentSourceStringLengths, int count) :

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_buffer.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_buffer.h
@@ -26,7 +26,7 @@
 
 namespace gvr {
 
-class GLRenderBuffer {
+class GLRenderBuffer final {
 public:
     GLRenderBuffer() {
         glGenRenderbuffers(1, &id_);
@@ -41,10 +41,10 @@ public:
     }
 
 private:
-    GLRenderBuffer(const GLRenderBuffer& gl_render_buffer);
-    GLRenderBuffer(GLRenderBuffer&& gl_render_buffer);
-    GLRenderBuffer& operator=(const GLRenderBuffer& gl_render_buffer);
-    GLRenderBuffer& operator=(GLRenderBuffer&& gl_render_buffer);
+    GLRenderBuffer(const GLRenderBuffer& gl_render_buffer) = delete;
+    GLRenderBuffer(GLRenderBuffer&& gl_render_buffer) = delete;
+    GLRenderBuffer& operator=(const GLRenderBuffer& gl_render_buffer) = delete;
+    GLRenderBuffer& operator=(GLRenderBuffer&& gl_render_buffer) = delete;
 
 private:
     GLuint id_;

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_data.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_data.h
@@ -46,10 +46,9 @@ namespace gvr
         virtual void render(Shader*, Renderer*);
 
     private:
-        //  GLRenderData(const GLRenderData& render_data);
-        GLRenderData(GLRenderData &&render_data);
-        GLRenderData &operator=(const GLRenderData &render_data);
-        GLRenderData &operator=(GLRenderData &&render_data);
+        GLRenderData(GLRenderData &&render_data) = delete;
+        GLRenderData &operator=(const GLRenderData &render_data) = delete;
+        GLRenderData &operator=(GLRenderData &&render_data) = delete;
     };
 }
 #endif

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.h
@@ -56,10 +56,10 @@ protected:
     virtual GLuint createTexture();
 
 private:
-    GLRenderImage(const GLRenderImage&);
-    GLRenderImage(GLRenderImage&&);
-    GLRenderImage& operator=(const GLRenderImage&);
-    GLRenderImage& operator=(GLRenderImage&&);
+    GLRenderImage(const GLRenderImage&) = delete;
+    GLRenderImage(GLRenderImage&&) = delete;
+    GLRenderImage& operator=(const GLRenderImage&) = delete;
+    GLRenderImage& operator=(GLRenderImage&&) = delete;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_target.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_target.h
@@ -22,7 +22,7 @@ public:
     explicit GLRenderTarget(Scene* scene): RenderTarget(scene){
     }
     explicit GLRenderTarget(RenderTexture* renderTexture, const RenderTarget* source): RenderTarget(renderTexture, source){}
-    explicit  GLRenderTarget(){}
+    GLRenderTarget(){}
     virtual ~GLRenderTarget(){}
     virtual void beginRendering(Renderer *renderer);
 };

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_texture.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_texture.h
@@ -50,7 +50,7 @@ public:
         return renderTexture_gl_frame_buffer_->id();
     }
 
-        virtual void bind() {
+    virtual void bind() {
         glBindFramebuffer(GL_FRAMEBUFFER, renderTexture_gl_frame_buffer_->id());
     }
 
@@ -70,10 +70,10 @@ public:
     void setLayerIndex(int layerIndex);
 
 private:
-    GLRenderTexture(const GLRenderTexture&);
-    GLRenderTexture(GLRenderTexture&&);
-    GLRenderTexture& operator=(const GLRenderTexture&);
-    GLRenderTexture& operator=(GLRenderTexture&&);
+    GLRenderTexture(const GLRenderTexture&) = delete;
+    GLRenderTexture(GLRenderTexture&&) = delete;
+    GLRenderTexture& operator=(const GLRenderTexture&) = delete;
+    GLRenderTexture& operator=(GLRenderTexture&&) = delete;
 
 
     void invalidateFrameBuffer(GLenum target, bool is_fbo, const bool color_buffer, const bool depth_buffer);
@@ -94,6 +94,8 @@ protected:
                                      // when resolveDepth is on.
     GLuint renderTexture_gl_pbo_ = 0;
 };
+
+
 class GLMultiviewRenderTexture: public GLRenderTexture
 {
 public:

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_shader.h
@@ -83,10 +83,10 @@ protected:
     void initialize(bool);
 
 private:
-    GLShader(const GLShader& shader);
-    GLShader(GLShader&& shader);
-    GLShader& operator=(const GLShader& shader);
-    GLShader& operator=(GLShader&& shader);
+    GLShader(const GLShader& shader) = delete;
+    GLShader(GLShader&& shader) = delete;
+    GLShader& operator=(const GLShader& shader) = delete;
+    GLShader& operator=(GLShader&& shader) = delete;
 
     GLProgram* mProgram;
     bool mIsReady;

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_uniform_block.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_uniform_block.h
@@ -33,8 +33,8 @@ namespace gvr
     class GLUniformBlock : public UniformBlock
     {
     public:
-        GLUniformBlock(const char *descriptor, int bindingPoint, const char *blockName);
-        GLUniformBlock(const char *descriptor, int bindingPoint, const char *blockName, int maxelems);
+        explicit GLUniformBlock(const char *descriptor, int bindingPoint, const char *blockName);
+        explicit GLUniformBlock(const char *descriptor, int bindingPoint, const char *blockName, int maxelems);
 
         virtual ~GLUniformBlock();
 

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_vertex_buffer.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_vertex_buffer.h
@@ -26,7 +26,7 @@ namespace gvr {
     class GLVertexBuffer : public VertexBuffer
     {
     public:
-        GLVertexBuffer(const char* layout_desc, int vertexCount);
+        explicit GLVertexBuffer(const char* layout_desc, int vertexCount);
         virtual ~GLVertexBuffer();
 
         virtual bool    updateGPU(Renderer*, IndexBuffer*f, Shader*);

--- a/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.h
@@ -31,7 +31,7 @@
 #include "glm/geometric.hpp"
 
 namespace gvr {
-class BoundingVolume {
+class BoundingVolume final {
 public:
     BoundingVolume();
 

--- a/GVRf/Framework/framework/src/main/jni/objects/components/bone.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/bone.h
@@ -52,10 +52,10 @@ public:
     }
 
 private:
-    Bone(const Bone& bone);
-    Bone(Bone&& bone);
-    Bone& operator=(const Bone& bone);
-    Bone& operator=(Bone&& bone);
+    Bone(const Bone& bone) = delete;
+    Bone(Bone&& bone) = delete;
+    Bone& operator=(const Bone& bone) = delete;
+    Bone& operator=(Bone&& bone) = delete;
 
 private:
     static glm::mat4 identityMatrix_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/camera.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/camera.h
@@ -88,10 +88,10 @@ public:
         return COMPONENT_TYPE_CAMERA;
     }
 private:
-    Camera(const Camera& camera);
-    Camera(Camera&& camera);
-    Camera& operator=(const Camera& camera);
-    Camera& operator=(Camera&& camera);
+    Camera(const Camera& camera) = delete;
+    Camera(Camera&& camera) = delete;
+    Camera& operator=(const Camera& camera) = delete;
+    Camera& operator=(Camera&& camera) = delete;
 
 private:
     float background_color_r_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/camera_rig.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/camera_rig.h
@@ -160,10 +160,10 @@ public:
     void setRotation(const glm::quat& transform_rotation);
 
 private:
-    CameraRig(const CameraRig& camera_rig);
-    CameraRig(CameraRig&& camera_rig);
-    CameraRig& operator=(const CameraRig& camera_rig);
-    CameraRig& operator=(CameraRig&& camera_rig);
+    CameraRig(const CameraRig& camera_rig) = delete;
+    CameraRig(CameraRig&& camera_rig) = delete;
+    CameraRig& operator=(const CameraRig& camera_rig) = delete;
+    CameraRig& operator=(CameraRig&& camera_rig) = delete;
 
 private:
     static const CameraRigType DEFAULT_CAMERA_RIG_TYPE = FREE;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
@@ -59,7 +59,7 @@ public:
 class Collider: public Component {
 public:
     Collider() : Component(Collider::getComponentType()), pick_distance_(0) {}
-    Collider(long long type) : Component(type), pick_distance_(0) {}
+    explicit Collider(long long type) : Component(type), pick_distance_(0) {}
 
     virtual ~Collider() {}
 
@@ -98,10 +98,10 @@ public:
 protected:
     float pick_distance_;
 
-    Collider(const Collider& collider);
-    Collider(Collider&& collider);
-    Collider& operator=(const Collider& collider);
-    Collider& operator=(Collider&& collider);
+    Collider(const Collider& collider) = delete;
+    Collider(Collider&& collider) = delete;
+    Collider& operator=(const Collider& collider) = delete;
+    Collider& operator=(Collider&& collider) = delete;
 };
 
 inline ColliderData::ColliderData(Collider* collider) :

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider_group.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider_group.h
@@ -45,10 +45,10 @@ public:
     }
 
 private:
-    ColliderGroup(const ColliderGroup& colliderGroup);
-    ColliderGroup(ColliderGroup&& colliderGroup);
-    ColliderGroup& operator=(const ColliderGroup& colliderGroup);
-    ColliderGroup& operator=(ColliderGroup&& colliderGroup);
+    ColliderGroup(const ColliderGroup& colliderGroup) = delete;
+    ColliderGroup(ColliderGroup&& colliderGroup) = delete;
+    ColliderGroup& operator=(const ColliderGroup& colliderGroup) = delete;
+    ColliderGroup& operator=(ColliderGroup&& colliderGroup) = delete;
 
 private:
     glm::vec3 hit_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/component.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/component.h
@@ -31,9 +31,9 @@ class Scene;
 class Component: public HybridObject {
 public:
     Component();
-    Component(long long type);
-    Component(SceneObject* owner_object);
-    Component(long long type, SceneObject* owner_object);
+    explicit Component(long long type);
+    explicit Component(SceneObject* owner_object);
+    explicit Component(long long type, SceneObject* owner_object);
     virtual ~Component();
 
     SceneObject* owner_object() const;
@@ -49,10 +49,10 @@ public:
     virtual void set_enable(bool enable);
 
 private:
-    Component(const Component& component);
-    Component(Component&& component);
-    Component& operator=(const Component& component);
-    Component& operator=(Component&& component);
+    Component(const Component& component) = delete;
+    Component(Component&& component) = delete;
+    Component& operator=(const Component& component) = delete;
+    Component& operator=(Component&& component) = delete;
 
 protected:
     SceneObject* owner_object_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/custom_camera.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/custom_camera.h
@@ -46,10 +46,10 @@ public:
     }
 
 private:
-    CustomCamera(const CustomCamera& camera);
-    CustomCamera(CustomCamera&& camera);
-    CustomCamera& operator=(const CustomCamera& camera);
-    CustomCamera& operator=(CustomCamera&& camera);
+    CustomCamera(const CustomCamera& camera) = delete;
+    CustomCamera(CustomCamera&& camera) = delete;
+    CustomCamera& operator=(const CustomCamera& camera) = delete;
+    CustomCamera& operator=(CustomCamera&& camera) = delete;
 
 protected:
     glm::mat4 projection_matrix_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/java_component.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/java_component.h
@@ -31,7 +31,7 @@ namespace gvr {
 
     class JavaComponent : public Component {
     public:
-        JavaComponent(long long type) : Component(type), javaObj_(0L), javaVM_(NULL) { }
+        explicit JavaComponent(long long type) : Component(type), javaObj_(0L), javaVM_(NULL) { }
         JavaComponent() : Component(), javaObj_(0L), javaVM_(NULL) { }
 
         virtual ~JavaComponent();
@@ -40,10 +40,10 @@ namespace gvr {
         void free_java();
 
     private:
-        JavaComponent(const JavaComponent &component);
-        JavaComponent(JavaComponent &&component);
-        JavaComponent &operator=(const JavaComponent &component);
-        JavaComponent &operator=(JavaComponent &&component);
+        JavaComponent(const JavaComponent &component) = delete;
+        JavaComponent(JavaComponent &&component) = delete;
+        JavaComponent &operator=(const JavaComponent &component) = delete;
+        JavaComponent &operator=(JavaComponent &&component) = delete;
 
     protected:
         jobject javaObj_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/mesh_collider.h
@@ -31,9 +31,9 @@ class BoundingVolume;
 
 class MeshCollider: public Collider {
 public:
-    MeshCollider(Mesh* mesh = NULL);
-    MeshCollider(Mesh* mesh, bool pickCoordinates);
-    MeshCollider(bool useMeshBounds);
+    explicit MeshCollider(Mesh* mesh = NULL);
+    explicit MeshCollider(Mesh* mesh, bool pickCoordinates);
+    explicit MeshCollider(bool useMeshBounds);
     virtual ~MeshCollider();
 
     long shape_type() {
@@ -56,10 +56,10 @@ public:
     static ColliderData isHit(const BoundingVolume& bounds, const glm::vec3& rayStart, const glm::vec3& rayDir);
 
 private:
-    MeshCollider(const MeshCollider& mesh_collider);
-    MeshCollider(MeshCollider&& mesh_collider);
-    MeshCollider& operator=(const MeshCollider& mesh_collider);
-    MeshCollider& operator=(MeshCollider&& mesh_collider);
+    MeshCollider(const MeshCollider& mesh_collider) = delete;
+    MeshCollider(MeshCollider&& mesh_collider) = delete;
+    MeshCollider& operator=(const MeshCollider& mesh_collider) = delete;
+    MeshCollider& operator=(MeshCollider&& mesh_collider) = delete;
     static ColliderData isHit(const Mesh& mesh, const glm::vec3& rayStart, const glm::vec3& rayDir, bool pickCoordinates);
     static float rayTriangleIntersect(glm::vec3& hitPos, const glm::vec3& rayStart, const glm::vec3& rayDir,
                                const glm::vec3& V1, const glm::vec3& V2, const glm::vec3& V3);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/orthogonal_camera.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/orthogonal_camera.h
@@ -88,10 +88,10 @@ public:
     glm::mat4 getProjectionMatrix() const;
 
 private:
-    OrthogonalCamera(const OrthogonalCamera& camera);
-    OrthogonalCamera(OrthogonalCamera&& camera);
-    OrthogonalCamera& operator=(const OrthogonalCamera& camera);
-    OrthogonalCamera& operator=(OrthogonalCamera&& camera);
+    OrthogonalCamera(const OrthogonalCamera& camera) = delete;
+    OrthogonalCamera(OrthogonalCamera&& camera) = delete;
+    OrthogonalCamera& operator=(const OrthogonalCamera& camera) = delete;
+    OrthogonalCamera& operator=(OrthogonalCamera&& camera) = delete;
 
 private:
     float left_clipping_distance_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/perspective_camera.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/perspective_camera.h
@@ -91,10 +91,10 @@ public:
     glm::mat4 getProjectionMatrix() const;
 
 private:
-    PerspectiveCamera(const PerspectiveCamera& camera);
-    PerspectiveCamera(PerspectiveCamera&& camera);
-    PerspectiveCamera& operator=(const PerspectiveCamera& camera);
-    PerspectiveCamera& operator=(PerspectiveCamera&& camera);
+    PerspectiveCamera(const PerspectiveCamera& camera) = delete;
+    PerspectiveCamera(PerspectiveCamera&& camera) = delete;
+    PerspectiveCamera& operator=(const PerspectiveCamera& camera) = delete;
+    PerspectiveCamera& operator=(PerspectiveCamera&& camera) = delete;
 
 private:
     static float default_fov_y_; // in radians

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
@@ -393,10 +393,9 @@ public:
     void adjustRenderingOrderForTransparency(bool hasAlpha);
 
 private:
-    //  RenderData(const RenderData& render_data);
-    RenderData(RenderData&& render_data);
-    RenderData& operator=(const RenderData& render_data);
-    RenderData& operator=(RenderData&& render_data);
+    RenderData(RenderData&& render_data) = delete;
+    RenderData& operator=(const RenderData& render_data) = delete;
+    RenderData& operator=(RenderData&& render_data) = delete;
 
 protected:
     static const int DEFAULT_RENDER_MASK = Left | Right;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_target.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_target.h
@@ -41,9 +41,9 @@ class Renderer;
 class RenderTarget : public Component
 {
 public:
-    RenderTarget(RenderTexture*, bool is_multiview);
-    RenderTarget(Scene*);
-    RenderTarget(RenderTexture*, const RenderTarget* source);
+    explicit RenderTarget(RenderTexture*, bool is_multiview);
+    explicit RenderTarget(Scene*);
+    explicit RenderTarget(RenderTexture*, const RenderTarget* source);
     RenderTarget();
     virtual ~RenderTarget();
     void attachNextRenderTarget(RenderTarget* renderTarget){
@@ -67,10 +67,10 @@ public:
     }
     virtual void cullFromCamera(Scene*, Camera* camera, Renderer* renderer, ShaderManager* shader_manager);
 private:
-    RenderTarget(const RenderTarget& render_texture);
-    RenderTarget(RenderTarget&& render_texture);
-    RenderTarget& operator=(const RenderTarget& render_texture);
-    RenderTarget& operator=(RenderTarget&& render_texture);
+    RenderTarget(const RenderTarget& render_texture) = delete;
+    RenderTarget(RenderTarget&& render_texture) = delete;
+    RenderTarget& operator=(const RenderTarget& render_texture) = delete;
+    RenderTarget& operator=(RenderTarget&& render_texture) = delete;
 
 protected:
     RenderTarget* mNextRenderTarget;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/shadow_map.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/shadow_map.h
@@ -28,7 +28,7 @@ class GLFrameBuffer;
     class ShadowMap : public GLRenderTarget
     {
     public:
-        ShadowMap(ShaderData* mtl);
+        explicit ShadowMap(ShaderData* mtl);
         virtual ~ShadowMap();
         virtual void  beginRendering(Renderer* renderer);
         void setLayerIndex(int layerIndex);

--- a/GVRf/Framework/framework/src/main/jni/objects/components/sphere_collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/sphere_collider.h
@@ -55,10 +55,10 @@ public:
     static ColliderData isHit(const glm::mat4& model_matrix, const glm::vec3& center, float radius, const glm::vec3& rayStart, const glm::vec3& rayDir);
 
 private:
-    SphereCollider(const SphereCollider& mesh_collider);
-    SphereCollider(SphereCollider&& mesh_collider);
-    SphereCollider& operator=(const SphereCollider& mesh_collider);
-    SphereCollider& operator=(SphereCollider&& mesh_collider);
+    SphereCollider(const SphereCollider& mesh_collider) = delete;
+    SphereCollider(SphereCollider&& mesh_collider) = delete;
+    SphereCollider& operator=(const SphereCollider& mesh_collider) = delete;
+    SphereCollider& operator=(SphereCollider&& mesh_collider) = delete;
 
 private:
     glm::vec3   center_;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/texture_capturer.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/texture_capturer.h
@@ -25,7 +25,7 @@ struct RenderState;
 
 class TextureCapturer : public Component {
 public:
-    TextureCapturer(ShaderManager *shaderManager);
+    explicit TextureCapturer(ShaderManager *shaderManager);
     virtual ~TextureCapturer();
 
     void setCapturerObject(JNIEnv *env, jobject capturer);
@@ -51,10 +51,10 @@ public:
     }
 
 private:
-    TextureCapturer(const TextureCapturer& capturer);
-    TextureCapturer(TextureCapturer&& capturer);
-    TextureCapturer& operator=(const TextureCapturer& capturer);
-    TextureCapturer& operator=(TextureCapturer&& capturer);
+    TextureCapturer(const TextureCapturer& capturer) = delete;
+    TextureCapturer(TextureCapturer&& capturer) = delete;
+    TextureCapturer& operator=(const TextureCapturer& capturer) = delete;
+    TextureCapturer& operator=(TextureCapturer&& capturer) = delete;
 
 private:
     ShaderManager *mShaderManager;

--- a/GVRf/Framework/framework/src/main/jni/objects/components/transform.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/transform.h
@@ -248,10 +248,10 @@ public:
     void setModelMatrix(glm::mat4 mat);
 
 private:
-    Transform(const Transform& transform);
-    Transform(Transform&& transform);
-    Transform& operator=(const Transform& transform);
-    Transform& operator=(Transform&& transform);
+    Transform(const Transform& transform) = delete;
+    Transform(Transform&& transform) = delete;
+    Transform& operator=(const Transform& transform) = delete;
+    Transform& operator=(Transform&& transform) = delete;
 
 private:
     glm::vec3 position_;

--- a/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.h
@@ -52,7 +52,7 @@ namespace gvr {
         };
 
     public:
-        DataDescriptor(const char* descriptor);
+        explicit DataDescriptor(const char* descriptor);
         virtual ~DataDescriptor() { }
 
         /**

--- a/GVRf/Framework/framework/src/main/jni/objects/index_buffer.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/index_buffer.h
@@ -21,7 +21,7 @@ namespace gvr {
     class IndexBuffer : public HybridObject
     {
     public:
-        IndexBuffer(int bytesPerIndex, int indexCount);
+        explicit IndexBuffer(int bytesPerIndex, int indexCount);
         virtual ~IndexBuffer();
 
         /**

--- a/GVRf/Framework/framework/src/main/jni/objects/lazy.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/lazy.h
@@ -23,7 +23,7 @@
 
 namespace gvr {
 template<class T>
-class Lazy {
+class Lazy final {
 public:
     explicit Lazy(T element, bool valid = false) :
             element_(element), valid_(valid) {
@@ -58,8 +58,8 @@ public:
     }
 
 private:
-    Lazy& operator=(const Lazy& lazy);
-    Lazy& operator=(Lazy&& lazy);
+    Lazy& operator=(const Lazy& lazy) = delete;
+    Lazy& operator=(Lazy&& lazy) = delete;
 
 private:
     T element_;

--- a/GVRf/Framework/framework/src/main/jni/objects/light.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/light.h
@@ -194,10 +194,10 @@ public:
     virtual void onRemovedFromScene(Scene* scene);
 
 private:
-    Light(const Light& light);
-    Light(Light&& light);
-    Light& operator=(const Light& light);
-    Light& operator=(Light&& light);
+    Light(const Light& light) = delete;
+    Light(Light&& light) = delete;
+    Light& operator=(const Light& light) = delete;
+    Light& operator=(Light&& light) = delete;
 
 
     /*

--- a/GVRf/Framework/framework/src/main/jni/objects/mesh.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/mesh.h
@@ -42,8 +42,8 @@ namespace gvr {
 
 class Mesh: public HybridObject {
 public:
-    Mesh(const char* descriptor);
-    Mesh(VertexBuffer& vbuf);
+    explicit Mesh(const char* descriptor);
+    explicit Mesh(VertexBuffer& vbuf);
     virtual ~Mesh() {}
 
     VertexBuffer* getVertexBuffer() const { return mVertices; }
@@ -105,9 +105,9 @@ public:
     bool isDirty() const { return mVertices->isDirty(); }
 
 private:
-    Mesh(const Mesh& mesh);
-    Mesh(Mesh&& mesh);
-    Mesh& operator=(const Mesh& mesh);
+    Mesh(const Mesh& mesh) = delete;
+    Mesh(Mesh&& mesh) = delete;
+    Mesh& operator=(const Mesh& mesh) = delete;
 
 
 protected:

--- a/GVRf/Framework/framework/src/main/jni/objects/rotation_sensor_data.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/rotation_sensor_data.h
@@ -33,7 +33,7 @@ public:
             time_stamp_(0), quaterion_(), gyro_() {
     }
 
-    RotationSensorData(long long time_stamp, float w, float x, float y, float z,
+    explicit RotationSensorData(long long time_stamp, float w, float x, float y, float z,
             float gyro_x, float gyro_y, float gyro_z) :
             time_stamp_(time_stamp), quaterion_(w, x, y, z), gyro_(gyro_x,
                     gyro_y, gyro_z) {
@@ -82,10 +82,10 @@ public:
     }
 
 private:
-    RotationSensorData(const RotationSensorData& rotation_sensor_data);
-    RotationSensorData(RotationSensorData&& rotation_sensor_data);
+    RotationSensorData(const RotationSensorData& rotation_sensor_data) = delete;
+    RotationSensorData(RotationSensorData&& rotation_sensor_data) = delete;
     RotationSensorData& operator=(
-            const RotationSensorData& rotation_sensor_data);
+            const RotationSensorData& rotation_sensor_data) = delete;
 
 private:
     long long time_stamp_;

--- a/GVRf/Framework/framework/src/main/jni/objects/scene.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene.h
@@ -191,10 +191,10 @@ public:
     static void set_main_scene(Scene* scene);
 
 private:
-    Scene(const Scene& scene);
-    Scene(Scene&& scene);
-    Scene& operator=(const Scene& scene);
-    Scene& operator=(Scene&& scene);
+    Scene(const Scene& scene) = delete;
+    Scene(Scene&& scene) = delete;
+    Scene& operator=(const Scene& scene) = delete;
+    Scene& operator=(Scene&& scene) = delete;
     void gatherColliders();
     void clearAllColliders();
 

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
@@ -176,10 +176,10 @@ private:
     bool query_currently_issued_;
     GLuint *queries_ = nullptr;
 
-    SceneObject(const SceneObject& scene_object);
-    SceneObject(SceneObject&& scene_object);
-    SceneObject& operator=(const SceneObject& scene_object);
-    SceneObject& operator=(SceneObject&& scene_object);
+    SceneObject(const SceneObject& scene_object) = delete;
+    SceneObject(SceneObject&& scene_object) = delete;
+    SceneObject& operator=(const SceneObject& scene_object) = delete;
+    SceneObject& operator=(SceneObject&& scene_object) = delete;
 
     bool checkSphereVsFrustum(float frustum[6][4], BoundingVolume &sphere);
 

--- a/GVRf/Framework/framework/src/main/jni/objects/shader_data.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/shader_data.h
@@ -41,7 +41,7 @@ class RenderData;
 class ShaderData : public HybridObject
 {
 public:
-    ShaderData(const char* texture_desc);
+    explicit ShaderData(const char* texture_desc);
 
     virtual ~ShaderData() { }
 
@@ -74,10 +74,10 @@ public:
     virtual const UniformBlock& uniforms() const = 0;
     virtual void useGPUBuffer(bool flag) = 0;
 private:
-    ShaderData(const ShaderData&);
-    ShaderData(ShaderData&&);
-    ShaderData& operator=(const ShaderData&);
-    ShaderData& operator=(ShaderData&&);
+    ShaderData(const ShaderData&) = delete;
+    ShaderData(ShaderData&&) = delete;
+    ShaderData& operator=(const ShaderData&) = delete;
+    ShaderData& operator=(ShaderData&&) = delete;
 
 protected:
     int mNativeShader;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/cubemap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/cubemap_image.h
@@ -44,10 +44,10 @@ namespace gvr {
                     jobjectArray textureArray, const int* textureOffset);
 
     private:
-        CubemapImage(const CubemapImage& base_texture);
-        CubemapImage(CubemapImage&& base_texture);
-        CubemapImage& operator=(const CubemapImage& base_texture);
-        CubemapImage& operator=(CubemapImage&& base_texture);
+        CubemapImage(const CubemapImage& base_texture) = delete;
+        CubemapImage(CubemapImage&& base_texture) = delete;
+        CubemapImage& operator=(const CubemapImage& base_texture) = delete;
+        CubemapImage& operator=(CubemapImage&& base_texture) = delete;
 
     protected:
         void clearData(JNIEnv* env);

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/external_image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/external_image.h
@@ -28,10 +28,10 @@ public:
     }
 
 private:
-    ExternalImage(const ExternalImage& render_texture);
-    ExternalImage(ExternalImage&& render_texture);
-    ExternalImage& operator=(const ExternalImage& render_texture);
-    ExternalImage& operator=(ExternalImage&& render_texture);
+    ExternalImage(const ExternalImage& render_texture) = delete;
+    ExternalImage(ExternalImage&& render_texture) = delete;
+    ExternalImage& operator=(const ExternalImage& render_texture) = delete;
+    ExternalImage& operator=(ExternalImage&& render_texture) = delete;
 
 private:
     long mData;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
@@ -65,7 +65,7 @@ public:
         mFileName[0] = 0;
     }
 
-    Image(ImageType type, int format) :
+    explicit Image(ImageType type, int format) :
             HybridObject(), mState(UNINITIALIZED), mType(type), mFormat(format),mIsCompressed(false),
             mXOffset(0), mYOffset(0), mWidth(0), mHeight(0), mDepth(1), mImageSize(0), mUpdateLock(),
             mLevels(0)
@@ -73,7 +73,7 @@ public:
         mFileName[0] = 0;
     }
 
-    Image(ImageType type, short width, short height, int imagesize, int format, short levels) :
+    explicit Image(ImageType type, short width, short height, int imagesize, int format, short levels) :
             HybridObject(), mType(type), mState(UNINITIALIZED), mUpdateLock(), mIsCompressed(false),
             mXOffset(0), mYOffset(0), mWidth(width), mHeight(height), mDepth(1), mImageSize(imagesize),
             mFormat(format), mLevels(levels)
@@ -166,10 +166,10 @@ protected:
     std::vector<int>    mDataOffsets;
 
 private:
-    Image(const Image& image);
-    Image(Image&& image);
-    Image& operator=(const Image& image);
-    Image& operator=(Image&& image);
+    Image(const Image& image) = delete;
+    Image(Image&& image) = delete;
+    Image& operator=(const Image& image) = delete;
+    Image& operator=(Image&& image) = delete;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.h
@@ -46,7 +46,7 @@ public:
               readback_started_(false)
     { }
 
-    RenderTexture(Image* image)
+    explicit RenderTexture(Image* image)
     : Texture(image->getType()),
       mSampleCount(1),
       mUseStencil(false),
@@ -85,10 +85,10 @@ public:
 
     }
 private:
-    RenderTexture(const RenderTexture&);
-    RenderTexture(RenderTexture&&);
-    RenderTexture& operator=(const RenderTexture&);
-    RenderTexture& operator=(RenderTexture&&);
+    RenderTexture(const RenderTexture&) = delete;
+    RenderTexture(RenderTexture&&) = delete;
+    RenderTexture& operator=(const RenderTexture&) = delete;
+    RenderTexture& operator=(RenderTexture&&) = delete;
 
 protected:
     float   mBackColor[4];

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
@@ -124,7 +124,7 @@ public:
     };
 
 
-    Texture(int type = TEXTURE_2D);
+    explicit Texture(int type = TEXTURE_2D);
     virtual ~Texture();
     virtual void clearData(JNIEnv* env);
     virtual void setImage(Image* image);
@@ -155,10 +155,10 @@ protected:
     TextureParameters   mTexParams;
 
 private:
-    Texture(const Texture& texture);
-    Texture(Texture&& texture);
-    Texture& operator=(const Texture& texture);
-    Texture& operator=(Texture&& texture);
+    Texture(const Texture& texture) = delete;
+    Texture(Texture&& texture) = delete;
+    Texture& operator=(const Texture& texture) = delete;
+    Texture& operator=(Texture&& texture) = delete;
 };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/uniform_block.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/uniform_block.h
@@ -57,8 +57,8 @@ namespace gvr
     class UniformBlock : public DataDescriptor
     {
     public:
-        UniformBlock(const char *descriptor, int binding_point, const char *blockName);
-        UniformBlock(const char *descriptor, int binding_point, const char *blockName, int maxElems);
+        explicit UniformBlock(const char *descriptor, int binding_point, const char *blockName);
+        explicit UniformBlock(const char *descriptor, int binding_point, const char *blockName, int maxElems);
 
         /**
          * Gets the OpenGL binding point for this uniform block.

--- a/GVRf/Framework/framework/src/main/jni/objects/vertex_bone_data.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/vertex_bone_data.h
@@ -36,7 +36,7 @@
 
 namespace gvr {
 class Bone;
-class VertexBoneData {
+class VertexBoneData final {
 public:
     VertexBoneData();
     void setBones(std::vector<Bone*>&& bonesVec);

--- a/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer.h
@@ -32,7 +32,7 @@ namespace gvr {
     {
     public:
 
-        VertexBuffer(const char* layout_desc, int vertexCount);
+        explicit VertexBuffer(const char* layout_desc, int vertexCount);
         virtual ~VertexBuffer();
 
         /**

--- a/GVRf/Framework/framework/src/main/jni/shaders/material/external_renderer_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/material/external_renderer_shader.h
@@ -23,18 +23,19 @@ class ShaderData;
 class ExternalRendererShader
 {
 public:
-    ExternalRendererShader(long id) {}
+    explicit ExternalRendererShader(long id) {}
+    virtual ~ExternalRendererShader() {}
     virtual void render(RenderState* rstate, RenderData* render_data, ShaderData* material);
 
 private:
     ExternalRendererShader(
-            const ExternalRendererShader& shader);
+            const ExternalRendererShader& shader) = delete;
     ExternalRendererShader(
-            ExternalRendererShader&& shader);
+            ExternalRendererShader&& shader) = delete;
     ExternalRendererShader& operator=(
-            const ExternalRendererShader& shader);
+            const ExternalRendererShader& shader) = delete;
     ExternalRendererShader& operator=(
-            ExternalRendererShader&& shader);
+            ExternalRendererShader&& shader) = delete;
 
     float scratchBuffer[6];
 };

--- a/GVRf/Framework/framework/src/main/jni/shaders/shader.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/shader.h
@@ -60,12 +60,12 @@ public:
  * @param fragmentShader    String with GLSL source for fragment shader
  * @see ShaderManager::addShader
  */
-    Shader(int id, const char* signature,
-            const char* uniformDescriptor,
-            const char* textureDescriptor,
-            const char* vertexDescriptor,
-            const char* vertexShader,
-            const char* fragmentShader);
+    explicit Shader(int id, const char* signature,
+                    const char* uniformDescriptor,
+                    const char* textureDescriptor,
+                    const char* vertexDescriptor,
+                    const char* vertexShader,
+                    const char* fragmentShader);
 
     virtual ~Shader() { };
 
@@ -138,10 +138,10 @@ public:
     bool calcMatrix(float* inputMatrices, int inputSize, float* outputMatrices, int outputSize) const;
 
 private:
-    Shader(const Shader& shader);
-    Shader(Shader&& shader);
-    Shader& operator=(const Shader& shader);
-    Shader& operator=(Shader&& shader);
+    Shader(const Shader& shader) = delete;
+    Shader(Shader&& shader) = delete;
+    Shader& operator=(const Shader& shader) = delete;
+    Shader& operator=(Shader&& shader) = delete;
 
 protected:
     bool shaderDirty = true;

--- a/GVRf/Framework/framework/src/main/jni/shaders/shader_manager.h
+++ b/GVRf/Framework/framework/src/main/jni/shaders/shader_manager.h
@@ -90,10 +90,10 @@ public:
     void dump();
 
 private:
-    ShaderManager(const ShaderManager& shader_manager);
-    ShaderManager(ShaderManager&& shader_manager);
-    ShaderManager& operator=(const ShaderManager& shader_manager);
-    ShaderManager& operator=(ShaderManager&& shader_manager);
+    ShaderManager(const ShaderManager& shader_manager) = delete;
+    ShaderManager(ShaderManager&& shader_manager) = delete;
+    ShaderManager& operator=(const ShaderManager& shader_manager) = delete;
+    ShaderManager& operator=(ShaderManager&& shader_manager) = delete;
 
 private:
     int latest_shader_id_ = 0;

--- a/GVRf/Framework/framework/src/main/jni/util/gvr_image_capture.h
+++ b/GVRf/Framework/framework/src/main/jni/util/gvr_image_capture.h
@@ -31,9 +31,9 @@ int write_truecolor_tga( int width, int height, GLubyte* valRGBA, char* fileName
 // Reads back in RGBA format.
 // Images are saved to /sdcard/image-xx.tga
 
-class GVRImageCapture {
+class GVRImageCapture final {
 public:
-    GVRImageCapture(uint width = 0, uint height = 0); // Default width and height for PBOs.
+    explicit GVRImageCapture(uint width = 0, uint height = 0); // Default width and height for PBOs.
     ~GVRImageCapture();
     void captureImage(int startX, int startY, uint width, uint height, char* msg = NULL);
     void captureImage(int startX, int startY, char* msg = NULL);

--- a/GVRf/Framework/framework/src/main/jni/util/scope_exit.h
+++ b/GVRf/Framework/framework/src/main/jni/util/scope_exit.h
@@ -24,7 +24,7 @@
  * "finally" block but follows C++ RAII (resource allocation
  * is initialization) principle.
  */
-class ScopeExit {
+class ScopeExit final {
 public:
     ScopeExit (const std::function<void()> &func)
     : m_func(func)

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_bitmap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_bitmap_image.h
@@ -23,7 +23,7 @@ namespace gvr {
     class VkBitmapImage : public vkImageBase, public BitmapImage
     {
     public:
-        VkBitmapImage(int format);
+        explicit VkBitmapImage(int format);
         virtual ~VkBitmapImage() {}
         virtual int getId() { return 1; }
         int updateFromBitmap(JNIEnv *env, VkImageViewType target, jobject bitmap);

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_cubemap_image.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_cubemap_image.h
@@ -24,7 +24,7 @@ namespace gvr {
     class VkCubemapImage : public vkImageBase, public CubemapImage
     {
     public:
-        VkCubemapImage(int format);
+        explicit VkCubemapImage(int format);
         virtual ~VkCubemapImage() {}
         virtual int getId() { return 1; }
         virtual void texParamsChanged(const TextureParameters&) { }
@@ -38,10 +38,10 @@ namespace gvr {
         virtual void update(int texid);
 
     private:
-        VkCubemapImage(const VkCubemapImage&);
-        VkCubemapImage(VkCubemapImage&&);
-        VkCubemapImage& operator=(const VkCubemapImage&);
-        VkCubemapImage& operator=(VkCubemapImage&&);
+        VkCubemapImage(const VkCubemapImage&) = delete;
+        VkCubemapImage(VkCubemapImage&&) = delete;
+        VkCubemapImage& operator=(const VkCubemapImage&) = delete;
+        VkCubemapImage& operator=(VkCubemapImage&&) = delete;
 
         void updateFromBitmap(int texid);
         void updateFromMemory(int texid);

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_float_image.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_float_image.h
@@ -78,10 +78,10 @@ namespace gvr {
         }
 
     private:
-        VkFloatImage(const VkFloatImage&);
-        VkFloatImage(VkFloatImage&&);
-        VkFloatImage& operator=(const VkFloatImage&);
-        VkFloatImage& operator=(VkFloatImage&&);
+        VkFloatImage(const VkFloatImage&) = delete;
+        VkFloatImage(VkFloatImage&&) = delete;
+        VkFloatImage& operator=(const VkFloatImage&) = delete;
+        VkFloatImage& operator=(VkFloatImage&&) = delete;
     };
 
 }

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_framebuffer.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_framebuffer.h
@@ -20,7 +20,7 @@
 
 namespace gvr {
 
-class VKFramebuffer {
+class VKFramebuffer final{
     vkImageBase *mAttachments[3];
 
     VkRenderPass mRenderpass;

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_imagebase.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_imagebase.h
@@ -37,19 +37,19 @@ namespace gvr {
 class vkImageBase
 {
     public:
-    vkImageBase(VkImageViewType type) : outBuffer(new VkBuffer),imageType(type), size(0), format_(VK_FORMAT_R8G8B8A8_UNORM), usage_flags_(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT),mSampleCount(1)
-    { }
-    vkImageBase(VkImageViewType type, VkFormat format, int width, int height, int depth, VkImageUsageFlags flags, VkImageLayout imageLayout)
-    : mLayers(1),imageType(type), outBuffer(new VkBuffer), size(0), format_(format), usage_flags_(flags), width_(width), height_(height), depth_(depth), imageLayout(imageLayout), mSampleCount(1)
-    { }
+        explicit vkImageBase(VkImageViewType type) : outBuffer(new VkBuffer),imageType(type), size(0), format_(VK_FORMAT_R8G8B8A8_UNORM), usage_flags_(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT),mSampleCount(1)
+        { }
+        explicit vkImageBase(VkImageViewType type, VkFormat format, int width, int height, int depth, VkImageUsageFlags flags, VkImageLayout imageLayout)
+        : mLayers(1),imageType(type), outBuffer(new VkBuffer), size(0), format_(format), usage_flags_(flags), width_(width), height_(height), depth_(depth), imageLayout(imageLayout), mSampleCount(1)
+        { }
 
-    vkImageBase(VkImageViewType type, VkFormat format, int width, int height, int depth, VkImageUsageFlags flags, VkImageLayout imageLayout, int sample_count)
-    :mLayers(1), imageType(type), outBuffer(new VkBuffer), size(0), format_(format), usage_flags_(flags), width_(width), height_(height), depth_(depth), imageLayout(imageLayout), mSampleCount(sample_count)
-    { }
-    vkImageBase(VkImageViewType type, VkFormat format, int width, int height, int depth, VkImageUsageFlags flags, VkImageLayout imageLayout, int layers, int sample_count )
-    :imageType(type), outBuffer(new VkBuffer), mLayers(layers) ,size(0), format_(format), usage_flags_(flags), width_(width), height_(height), depth_(depth), imageLayout(imageLayout), mSampleCount(sample_count)
-    { }
-    ~vkImageBase();
+        explicit vkImageBase(VkImageViewType type, VkFormat format, int width, int height, int depth, VkImageUsageFlags flags, VkImageLayout imageLayout, int sample_count)
+        :mLayers(1), imageType(type), outBuffer(new VkBuffer), size(0), format_(format), usage_flags_(flags), width_(width), height_(height), depth_(depth), imageLayout(imageLayout), mSampleCount(sample_count)
+        { }
+        explicit vkImageBase(VkImageViewType type, VkFormat format, int width, int height, int depth, VkImageUsageFlags flags, VkImageLayout imageLayout, int layers, int sample_count )
+        :imageType(type), outBuffer(new VkBuffer), mLayers(layers) ,size(0), format_(format), usage_flags_(flags), width_(width), height_(height), depth_(depth), imageLayout(imageLayout), mSampleCount(sample_count)
+        { }
+        virtual ~vkImageBase();
         void createImageView(bool host_accessible);
         int updateMipVkImage(uint64_t texSize, std::vector<void*>& pixels,std::vector<ImageInfo>& bitmapInfos, std::vector<VkBufferImageCopy>& bufferCopyRegions, VkImageViewType target, VkFormat internalFormat, int mipLevels =1,VkImageCreateFlags flags=0);
 

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_render_to_texture.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_render_to_texture.h
@@ -51,13 +51,13 @@ public:
     virtual ~VkRenderTexture(){
         delete fbo;
     }
-    VkRenderTexture(int width, int height, int sample_count = 1):RenderTexture(sample_count), fbo(nullptr),mWidth(width), mHeight(height){}
+    explicit VkRenderTexture(int width, int height, int sample_count = 1):RenderTexture(sample_count), fbo(nullptr),mWidth(width), mHeight(height){}
     virtual unsigned int getFrameBufferId() const {
-
+        return 0;
     }
 
     virtual unsigned int getDepthBufferId() const {
-
+        return 0;
     }
     virtual void bind();
     virtual void beginRendering(Renderer* renderer);

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_texture.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_texture.h
@@ -26,7 +26,7 @@ namespace gvr {
 class VkTexture : public  Texture
 {
 public:
-    explicit VkTexture() : Texture() { }
+    VkTexture() : Texture() { }
 
     explicit VkTexture(int texture_type) :
             Texture(texture_type)
@@ -47,10 +47,10 @@ public:
         return  mImageInfo;
     }
 private:
-    VkTexture(const VkTexture& gl_texture);
-    VkTexture(VkTexture&& gl_texture);
-    VkTexture& operator=(const VkTexture& gl_texture);
-    VkTexture& operator=(VkTexture&& gl_texture);
+    VkTexture(const VkTexture& gl_texture) = delete;
+    VkTexture(VkTexture&& gl_texture) = delete;
+    VkTexture& operator=(const VkTexture& gl_texture) = delete;
+    VkTexture& operator=(VkTexture&& gl_texture) = delete;
     void createSampler(int maxLod);
     void updateSampler();
     bool updateImage();

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkanCore.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkanCore.h
@@ -79,7 +79,8 @@ class VkRenderTexture;
 class VulkanShader;
 class VkRenderTarget;
 class RenderTarget;
-class VulkanCore {
+
+class VulkanCore final {
 public:
     // Return NULL if Vulkan inititialisation failed. NULL denotes no Vulkan support for this device.
     static VulkanCore *getInstance(ANativeWindow *newNativeWindow = nullptr) {
@@ -173,7 +174,7 @@ private:
     std::unordered_map<std::string, VkPipeline> pipelineHashMap;
 
 
-    VulkanCore(ANativeWindow *newNativeWindow) : m_pPhysicalDevices(NULL), postEffectCmdBuffer(
+    explicit VulkanCore(ANativeWindow *newNativeWindow) : m_pPhysicalDevices(NULL), postEffectCmdBuffer(
             nullptr),mRenderPassMap{0,0} {
         m_Vulkan_Initialised = false;
         initVulkanDevice(newNativeWindow);

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_image.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_image.h
@@ -25,9 +25,9 @@ namespace gvr
     class VulkanImage : public vkImageBase, public Image
     {
     public:
-        VulkanImage(int target);
+        explicit VulkanImage(int target);
 
-        VulkanImage(ImageType type, int format, short width, short height);
+        explicit VulkanImage(ImageType type, int format, short width, short height);
 
         virtual ~VulkanImage() {}
 

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_index_buffer.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_index_buffer.h
@@ -30,7 +30,7 @@ namespace gvr {
     class VulkanIndexBuffer : public IndexBuffer
     {
     public:
-        VulkanIndexBuffer(int bytesPerIndex, int vertexCount);
+        explicit VulkanIndexBuffer(int bytesPerIndex, int vertexCount);
         virtual ~VulkanIndexBuffer();
 
         virtual bool    updateGPU(Renderer*);

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_material.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_material.h
@@ -29,7 +29,7 @@ namespace gvr {
     class VulkanMaterial : public ShaderData
     {
     public:
-        VulkanMaterial(const char* uniform_desc, const char* texture_desc);
+        explicit VulkanMaterial(const char* uniform_desc, const char* texture_desc);
         virtual ~VulkanMaterial() {}
         void useGPUBuffer(bool flag){
             uniforms_.useGPUBuffer(flag);

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_render_data.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_render_data.h
@@ -52,7 +52,7 @@ struct VulkanRenderPass : public RenderPass
         {
         }
 
-        VulkanRenderData(const RenderData &rdata) : RenderData(rdata), ubo(
+        explicit VulkanRenderData(const RenderData &rdata) : RenderData(rdata), ubo(
         "mat4 u_view; mat4 u_mvp; mat4 u_mv; mat4 u_mv_it; mat4 u_model; mat4 u_view_i; float u_right;", TRANSFORM_UBO_INDEX, "Transform_ubo")
         {
         }

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_shader.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_shader.h
@@ -55,7 +55,7 @@ public:
             const char* vertexShader,
             const char* fragmentShader);
 
-    ~VulkanShader();
+    virtual ~VulkanShader();
 
     virtual bool useShader(bool) { return true; }
 
@@ -95,10 +95,10 @@ private:
     VkPipelineLayout m_pipelineLayout;
     VkDescriptorSetLayout m_descriptorLayout;
 
-    VulkanShader(const VulkanShader& shader);
-    VulkanShader(VulkanShader&& shader);
-    VulkanShader& operator=(const VulkanShader& shader);
-    VulkanShader& operator=(VulkanShader&& shader);
+    VulkanShader(const VulkanShader& shader) = delete;
+    VulkanShader(VulkanShader&& shader) = delete;
+    VulkanShader& operator=(const VulkanShader& shader) = delete;
+    VulkanShader& operator=(VulkanShader&& shader) = delete;
     std::vector<uint32_t> compiledVS;
     std::vector<uint32_t> compiledFS;
 

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_uniform_block.h
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vulkan_uniform_block.h
@@ -22,7 +22,7 @@ namespace gvr {
     class VulkanUniformBlock;
     class VulkanCore;
 
-    class VulkanDescriptor
+    class VulkanDescriptor final
     {
     public:
         VulkanDescriptor();
@@ -55,8 +55,9 @@ namespace gvr {
         int getPaddingSize(short &totaSize, int padSize);
         void uboPadding();
     public:
-        VulkanUniformBlock(const char* descriptor, int bindingPoint,const char* blockName);
-        VulkanUniformBlock(const char* descriptor, int bindingPoint,const char* blockName, int maxelems);
+        explicit VulkanUniformBlock(const char* descriptor, int bindingPoint,const char* blockName);
+        explicit VulkanUniformBlock(const char* descriptor, int bindingPoint,const char* blockName, int maxelems);
+        virtual ~VulkanUniformBlock() {}
         bool bindBuffer(Shader*, Renderer*) {}
         virtual bool updateGPU(Renderer*);
         virtual std::string makeShaderLayout();


### PR DESCRIPTION
1. Make constructors explicit (except default constructors)
2. Explicitly delete hidden constructors and assignment operators
3. Make destructors virtual, _or_ make classes final and keep destructors non-virtual
4. Fix minor formatting glitches

-----
GearVRf-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com