### PR TITLE
[handleOnUndock] handleOnUndock is called by onDestroy

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -33,6 +33,7 @@ import org.gearvrf.utility.VrAppSettings;
 
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
+import android.provider.Settings;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.media.AudioManager;
@@ -61,7 +62,7 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         System.loadLibrary("gvrf");
     }
     protected static final String TAG = "GVRActivity";
-
+    public static final String SETTINGS_GLOBAL_VR_DEVELOPER_MODE = "vrmode_developer_mode";
     private GVRViewManager mViewManager;
     private volatile GVRConfigurationManager mConfigurationManager;
     private GVRMain mGVRMain;
@@ -662,10 +663,13 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
                 }, new Runnable() {
                     @Override
                     public void run() {
-                        Log.i(TAG, "receiver calls finish instead of handleOnUndock");
-                        mViewManager.getActivity().finish();
-                        //Log.i(TAG, "receiver called handleOnUndock");
-                        //handleOnUndock();
+                        if(Settings.Global.getInt(mViewManager.getActivity().getContentResolver(), SETTINGS_GLOBAL_VR_DEVELOPER_MODE, 0) == 1) {
+                            Log.i(TAG, "receiver called handleOnUndock");
+                            handleOnUndock();
+                        } else {
+                            Log.i(TAG, "receiver calls finish instead of handleOnUndock");
+                            mViewManager.getActivity().finish();
+                        }
                     }
                 });
         if (null != mDockEventReceiver) {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -220,9 +220,9 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
             mDockEventReceiver.stop();
         }
 
-        if (null != mConfigurationManager && !mConfigurationManager.isDockListenerRequired()) {
+//        if (null != mConfigurationManager && !mConfigurationManager.isDockListenerRequired()) {
             handleOnUndock();
-        }
+//        }
 
         if (null != mActivityNative) {
             mActivityNative.onDestroy();
@@ -662,7 +662,10 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
                 }, new Runnable() {
                     @Override
                     public void run() {
-                        handleOnUndock();
+                        Log.i(TAG, "receiver calls finish instead of handleOnUndock");
+                        mViewManager.getActivity().finish();
+                        //Log.i(TAG, "receiver called handleOnUndock");
+                        //handleOnUndock();
                     }
                 });
         if (null != mDockEventReceiver) {


### PR DESCRIPTION
   - undock event didn't make Activity finish properly.
     :activity didn't get called onDestroy,
     :unregister dock event receiver was not called,
     :since activity was not finished, some services were connected for some time until garbages got collected.

   - Changes are
     :undock handler calls Activity finish,
     :onDestroy calls handleOnUndock so that activity finishes after doing things to be done before.

Signed-off-by: Sean Yoon <sukhwan.y@samsung.com>