### PR TITLE
Remove virtual calls from constructors

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
@@ -79,8 +79,8 @@ namespace gvr
         glClear(mask);
     }
 
-    UniformBlock *GLRenderer::createUniformBlock(const char* desc, int binding,
-                                                 const char* name, int maxelems)
+    GLUniformBlock *GLRenderer::createUniformBlock(const char* desc, int binding,
+                                                   const char* name, int maxelems)
     {
         if (maxelems <= 1)
         {
@@ -177,13 +177,11 @@ namespace gvr
 
         desc = " mat4 u_view_[2]; mat4 u_mvp_[2]; mat4 u_mv_[2]; mat4 u_mv_it_[2]; mat4 u_view_i_[2]; mat4 u_model; float u_right; uint u_render_mask; ";
 
-        transform_ubo_[1] = static_cast<GLUniformBlock*>
-        (createUniformBlock(desc, TRANSFORM_UBO_INDEX, "Transform_ubo", 0));
+        transform_ubo_[1] = GLRenderer::createUniformBlock(desc, TRANSFORM_UBO_INDEX, "Transform_ubo", 0);
         transform_ubo_[1]->useGPUBuffer(false);
 
         desc = " mat4 u_view; mat4 u_mvp; mat4 u_mv; mat4 u_mv_it; mat4 u_view_i; mat4 u_model; float u_right;";
-        transform_ubo_[0] = static_cast<GLUniformBlock*>
-                            (createUniformBlock(desc, TRANSFORM_UBO_INDEX, "Transform_ubo", 0));
+        transform_ubo_[0] = GLRenderer::createUniformBlock(desc, TRANSFORM_UBO_INDEX, "Transform_ubo", 0);
         transform_ubo_[0]->useGPUBuffer(false);
     }
 

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.h
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.h
@@ -83,7 +83,7 @@ public:
     virtual RenderPass* createRenderPass();
     virtual ShaderData* createMaterial(const char* uniform_desc, const char* texture_desc);
     virtual RenderData* createRenderData();
-    virtual UniformBlock* createUniformBlock(const char* desc, int binding, const char* name, int maxelems);
+    virtual GLUniformBlock* createUniformBlock(const char* desc, int binding, const char* name, int maxelems);
     virtual Image* createImage(int type, int format);
     virtual Texture* createTexture(int target = GL_TEXTURE_2D);
     virtual RenderTarget* createRenderTarget(Scene*) ;

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_image.cpp
@@ -25,16 +25,10 @@
 namespace gvr {
 
 GLRenderImage::GLRenderImage(int width, int height, int layers, GLuint texId, bool marktexParamsDirty)
-        : GLImage((layers > 1) ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D)
+        : GLRenderImage(width, height, layers)
 {
-    mWidth = width;
-    mHeight = height;
-    mDepth = layers;
-    mType = (layers > 1) ? Image::ImageType::ARRAY : Image::ImageType::BITMAP;
-    mState = HAS_DATA;
     setTexId(texId);
     setTexParamsDirty(marktexParamsDirty);
-
 }
 
 GLRenderImage::GLRenderImage(int width, int height, int layers)
@@ -46,10 +40,12 @@ GLRenderImage::GLRenderImage(int width, int height, int layers)
     mType = (layers > 1) ? Image::ImageType::ARRAY : Image::ImageType::BITMAP;
     mState = HAS_DATA;
 }
+
 void GLRenderImage::updateTexParams() {
     mTexParams.setMinFilter(GL_LINEAR);
     GLImage::updateTexParams(mTexParams);
 }
+
 void texImage3D(int color_format, int width, int height, int depth , GLenum target) {
     switch (color_format) {
         case ColorFormat::COLOR_565:
@@ -76,6 +72,7 @@ void texImage3D(int color_format, int width, int height, int depth , GLenum targ
             break;
     }
 }
+
 void texImage2D(int color_format, int width, int height, GLenum target){
     switch (color_format)
     {
@@ -110,20 +107,17 @@ void texImage2D(int color_format, int width, int height, GLenum target){
 
 }
 GLRenderImage::GLRenderImage(int width, int height, int layers, int color_format,  const TextureParameters* texparams)
-        : GLImage((layers > 1) ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D)
+        : GLRenderImage(width, height, layers)
 {
     GLenum target = GLImage::getTarget();
-    mWidth = width;
-    mHeight = height;
-    mDepth = layers;
-    mType = Image::ImageType::BITMAP;
-    mState = HAS_DATA;
 
     if (texparams)
     {
-        updateTexParams();
+        GLRenderImage::updateTexParams();
     }
-    updateGPU();
+
+    GLRenderImage::updateGPU();
+
     switch (target){
         case GL_TEXTURE_2D:
             texImage2D(color_format,width,height,GL_TEXTURE_2D);
@@ -136,22 +130,10 @@ GLRenderImage::GLRenderImage(int width, int height, int layers, int color_format
     }
 
 }
-GLRenderImage::GLRenderImage(int width, int height, int color_format, const TextureParameters* texparams)
-    : GLImage(GL_TEXTURE_2D)
-{
-    GLenum target = GLImage::getTarget();
-    mWidth = width;
-    mHeight = height;
-    mDepth = 1;
-    mType = Image::ImageType::BITMAP;
-    mState = HAS_DATA;
 
-    if (texparams)
-    {
-        updateTexParams();
-    }
-    updateGPU();
-    texImage2D(color_format,width,height,GL_TEXTURE_2D);
+GLRenderImage::GLRenderImage(int width, int height, int color_format, const TextureParameters* texparams)
+    : GLRenderImage(width, height, 1, color_format, texparams)
+{
 }
 
 GLuint GLRenderImage::createTexture()

--- a/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.h
@@ -153,7 +153,7 @@ namespace gvr {
          * Parse the descriptor string to create the map
          * which contains the name, offset and size of all uniforms.
          */
-        virtual void parseDescriptor();
+        void parseDescriptor();
 
         const char* addName(const char* name, int len, DataEntry& entry);
         int findName(const char* name) const;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
@@ -126,9 +126,9 @@ public:
 
     explicit Texture(int type = TEXTURE_2D);
     virtual ~Texture();
-    virtual void clearData(JNIEnv* env);
-    virtual void setImage(Image* image);
-    virtual void setImage(JNIEnv* env, jobject javaImage, Image* image);
+    void clearData(JNIEnv* env);
+    void setImage(Image* image);
+    void setImage(JNIEnv* env, jobject javaImage, Image* image);
     void updateTextureParameters(const int* texture_parameters, int n);
 
     int getType() const { return mType; }


### PR DESCRIPTION
Remove virtual calls from constructors of GLRenderer, GLRenderImage, DataDescriptor, Rendertexture; also from ~Texture destructor.
Use explicit qualification in constructors.
Eliminate downcast in constructor by using covariant return type for GLRenderer::createUniformBlock. Use delegate constructors in GLRenderImage.
Functions no longer virtual: Texture::setImage(), Texture::clearData(), DataDescriptor::parseDescriptor()
- - -
GearVRf-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com