### PR TITLE
framework: fix the getBoxBound and getSphereBound apis

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRVertexBuffer.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRVertexBuffer.java
@@ -501,9 +501,8 @@ public class GVRVertexBuffer extends GVRHybridObject implements PrettyPrint
      */
     public float getSphereBound(float[] sphere)
     {
-        int rc;
         if ((sphere == null) || (sphere.length != 4) ||
-            ((rc = NativeVertexBuffer.getBoundingVolume(getNative(), FloatBuffer.wrap(sphere))) < 0))
+            ((NativeVertexBuffer.getBoundingVolume(getNative(), sphere)) < 0))
         {
             throw new IllegalArgumentException("Cannot copy sphere bound into array provided");
         }
@@ -521,7 +520,7 @@ public class GVRVertexBuffer extends GVRHybridObject implements PrettyPrint
     {
         int rc;
         if ((corners == null) || (corners.length != 6) ||
-            ((rc = NativeVertexBuffer.getBoundingVolume(getNative(), FloatBuffer.wrap(corners))) < 0))
+            ((rc = NativeVertexBuffer.getBoundingVolume(getNative(), corners)) < 0))
         {
             throw new IllegalArgumentException("Cannot copy box bound into array provided");
         }
@@ -565,7 +564,7 @@ class NativeVertexBuffer {
 
     static native int  getAttributeSize(long vbuf, String name);
 
-    static native int getBoundingVolume(long vbuf, FloatBuffer bv);
+    static native int getBoundingVolume(long vbuf, float[] bv);
 
     static native void dump(long vbuf, String attrName);
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/vertex_buffer_jni.cpp
@@ -78,7 +78,7 @@ namespace gvr {
 
     JNIEXPORT int JNICALL
     Java_org_gearvrf_NativeVertexBuffer_getBoundingVolume(JNIEnv* env, jobject obj,
-                                                         jlong jvbuf, jobject floatbuf);
+                                                         jlong jvbuf, jfloatArray outputArray);
     JNIEXPORT void JNICALL
     Java_org_gearvrf_NativeVertexBuffer_dump(JNIEnv* env, jobject obj,
                                                           jlong jvbuf, jstring attrName);
@@ -263,21 +263,20 @@ Java_org_gearvrf_NativeVertexBuffer_getAttributeSize(JNIEnv* env, jobject obj,
 }
 
 JNIEXPORT int JNICALL
-Java_org_gearvrf_NativeVertexBuffer_getBoundingVolume(JNIEnv* env, jobject obj,
-                                                      jlong jvbuf, jobject jfloatbuf)
+Java_org_gearvrf_NativeVertexBuffer_getBoundingVolume(JNIEnv* env, jobject,
+                                                      jlong jvbuf, jfloatArray outputArray)
 {
     VertexBuffer* vbuf = reinterpret_cast<VertexBuffer*>(jvbuf);
-    void* bufptr = env->GetDirectBufferAddress(jfloatbuf);
-    if (bufptr)
+
     {
-        int capacity = env->GetDirectBufferCapacity(jfloatbuf);
+        int capacity = env->GetArrayLength(outputArray);
         if (capacity < 4)
         {
             LOGE("VertexBuffer::getBoundingVolume destination buffer must hold at least 4 floats");
             return -1;
         }
         BoundingVolume bv;
-        float* f = (float*) bufptr;
+        jfloat* f = env->GetFloatArrayElements(outputArray, 0);
         vbuf->getBoundingVolume(bv);
         if (capacity == 4)
         {
@@ -308,6 +307,8 @@ Java_org_gearvrf_NativeVertexBuffer_getBoundingVolume(JNIEnv* env, jobject obj,
             f[8] = bv.max_corner().z;
             f[9] = bv.radius();
         }
+
+        env->ReleaseFloatArrayElements(outputArray, f, 0);
         return (bv.radius() > 0) ? 1 : 0;
     }
     return -1;


### PR DESCRIPTION
Problem: not passing a direct array from Java to C++; changed to use Java arrays from C++.

Fixes issue #1602 
Test@https://github.com/gearvrf/GearVRf-Tests/pull/214

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>