### PR TITLE
framework: prevent double-delete of a renderdata not owned by the camera

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/components/camera.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/camera.cpp
@@ -39,12 +39,6 @@ Camera::Camera() :
 }
 
 Camera::~Camera() {
-    if (post_effect_data_)
-    {
-        delete post_effect_data_;
-        post_effect_data_ = NULL;
-    }
-
 }
 
 void Camera::setPostEffect(RenderData* post_effects)

--- a/GVRf/Framework/framework/src/main/jni/objects/components/camera.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/camera.h
@@ -99,6 +99,7 @@ private:
     float background_color_b_;
     float background_color_a_;
     int render_mask_;
+    //post_effect_data is owned by someone else
     RenderData* post_effect_data_;
     glm::mat4 view_matrix_;
 };


### PR DESCRIPTION
Before adding the undertaker thread problems like this one have to be fixed.

The post effect renderData is its own hybridObject that is taken care of by Java as any other hybridObject.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>