### PR TITLE
framework: fix crashes in gvr-shadows and gvr-simplephysics

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_target.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_target.cpp
@@ -38,7 +38,9 @@ RenderTarget::RenderTarget(RenderTexture* tex, bool is_multiview)
     mRenderState.shadow_map = false;
     mRenderState.material_override = NULL;
     mRenderState.is_multiview = is_multiview;
-    mRenderState.sampleCount = mRenderTexture->getSampleCount();
+    if (nullptr != mRenderTexture) {
+        mRenderState.sampleCount = mRenderTexture->getSampleCount();
+    }
 }
 void RenderTarget::beginRendering(Renderer *renderer) {
     mRenderTexture->useStencil(renderer->useStencilBuffer());


### PR DESCRIPTION
there is a case where a rendertarget passes null as a rendertexture;
added a check for it