### PR TITLE
Restore tiled rendering enhancer

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/eglextension/tiledrendering/tiled_rendering_enhancer.h
+++ b/GVRf/Framework/framework/src/main/jni/eglextension/tiledrendering/tiled_rendering_enhancer.h
@@ -25,12 +25,8 @@
 
 namespace gvr {
 
-class TiledRenderingEnhancer {
-private:
-    TiledRenderingEnhancer() = delete;
-
-public:
-    static void start(GLuint x, GLuint y, GLuint width, GLuint height,
+namespace TiledRenderingEnhancer {
+    void start(GLuint x, GLuint y, GLuint width, GLuint height,
             GLbitfield preserveMask) {
         PFNGLSTARTTILINGQCOMPROC start =
                 reinterpret_cast<PFNGLSTARTTILINGQCOMPROC>(eglGetProcAddress(
@@ -38,14 +34,14 @@ public:
         start(x, y, width, height, preserveMask);
     }
 
-    static void end(GLbitfield preserveMask) {
+    void end(GLbitfield preserveMask) {
         PFNGLENDTILINGQCOMPROC end =
                 reinterpret_cast<PFNGLENDTILINGQCOMPROC>(eglGetProcAddress(
                         "glEndTilingQCOM"));
         end(preserveMask);
     }
 
-    static bool available() {
+    bool available() {
         PFNGLSTARTTILINGQCOMPROC start =
                 reinterpret_cast<PFNGLSTARTTILINGQCOMPROC>(eglGetProcAddress(
                         "glStartTilingQCOM"));

--- a/GVRf/Framework/framework/src/main/jni/eglextension/tiledrendering/tiled_rendering_enhancer.h
+++ b/GVRf/Framework/framework/src/main/jni/eglextension/tiledrendering/tiled_rendering_enhancer.h
@@ -1,0 +1,61 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/***************************************************************************
+ * Enables more efficient tiled rendering when rendering on the front buffer.
+ ***************************************************************************/
+
+#ifndef TILED_RENDERING_H_
+#define TILED_RENDERING_H_
+
+#include "gl/gl_headers.h"
+
+namespace gvr {
+
+class TiledRenderingEnhancer {
+private:
+    TiledRenderingEnhancer() = delete;
+
+public:
+    static void start(GLuint x, GLuint y, GLuint width, GLuint height,
+            GLbitfield preserveMask) {
+        PFNGLSTARTTILINGQCOMPROC start =
+                reinterpret_cast<PFNGLSTARTTILINGQCOMPROC>(eglGetProcAddress(
+                        "glStartTilingQCOM"));
+        start(x, y, width, height, preserveMask);
+    }
+
+    static void end(GLbitfield preserveMask) {
+        PFNGLENDTILINGQCOMPROC end =
+                reinterpret_cast<PFNGLENDTILINGQCOMPROC>(eglGetProcAddress(
+                        "glEndTilingQCOM"));
+        end(preserveMask);
+    }
+
+    static bool available() {
+        PFNGLSTARTTILINGQCOMPROC start =
+                reinterpret_cast<PFNGLSTARTTILINGQCOMPROC>(eglGetProcAddress(
+                        "glStartTilingQCOM"));
+        PFNGLENDTILINGQCOMPROC end =
+                reinterpret_cast<PFNGLENDTILINGQCOMPROC>(eglGetProcAddress(
+                        "glEndTilingQCOM"));
+        return start && end;
+    }
+};
+
+}
+
+#endif


### PR DESCRIPTION
Turns out other repo uses TiledRenderingEnhancer.

Restore from ea2b3ec77b38aaf408a9afe22a86194079974f43
Convert to a C++ namespace