### PR TITLE
Revert "[handleOnUndock] handleOnUndock is called by onDestroy (#1592)"

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -33,7 +33,6 @@ import org.gearvrf.utility.VrAppSettings;
 
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
-import android.provider.Settings;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.media.AudioManager;
@@ -62,7 +61,7 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         System.loadLibrary("gvrf");
     }
     protected static final String TAG = "GVRActivity";
-    public static final String SETTINGS_GLOBAL_VR_DEVELOPER_MODE = "vrmode_developer_mode";
+
     private GVRViewManager mViewManager;
     private volatile GVRConfigurationManager mConfigurationManager;
     private GVRMain mGVRMain;
@@ -221,9 +220,9 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
             mDockEventReceiver.stop();
         }
 
-//        if (null != mConfigurationManager && !mConfigurationManager.isDockListenerRequired()) {
+        if (null != mConfigurationManager && !mConfigurationManager.isDockListenerRequired()) {
             handleOnUndock();
-//        }
+        }
 
         if (null != mActivityNative) {
             mActivityNative.onDestroy();
@@ -660,13 +659,7 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
                 }, new Runnable() {
                     @Override
                     public void run() {
-                        if(Settings.Global.getInt(mViewManager.getActivity().getContentResolver(), SETTINGS_GLOBAL_VR_DEVELOPER_MODE, 0) == 1) {
-                            Log.i(TAG, "receiver called handleOnUndock");
-                            handleOnUndock();
-                        } else {
-                            Log.i(TAG, "receiver calls finish instead of handleOnUndock");
-                            mViewManager.getActivity().finish();
-                        }
+                        handleOnUndock();
                     }
                 });
         if (null != mDockEventReceiver) {


### PR DESCRIPTION
The patch caused an issue of black screen on undocking HMT. SO revert it.
This reverts commit c0062e3b33193c50102df6aaf57574b0736294d7.