### PR TITLE
backend_oculus: leave vrapi initialized after onPause

### DIFF
--- a/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DaydreamActivityDelegate.java
+++ b/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DaydreamActivityDelegate.java
@@ -16,15 +16,13 @@
 package org.gearvrf;
 
 import android.content.res.AssetManager;
-import android.content.res.Configuration;
-import android.view.KeyEvent;
 
 import org.gearvrf.utility.VrAppSettings;
 
 /**
  * {@inheritDoc}
  */
-final class DaydreamActivityDelegate implements GVRActivity.GVRActivityDelegate, IActivityNative {
+final class DaydreamActivityDelegate extends GVRActivity.ActivityDelegateStubs implements IActivityNative {
     private GVRActivity mActivity;
     private DaydreamViewManager daydreamViewManager;
 
@@ -80,23 +78,6 @@ final class DaydreamActivityDelegate implements GVRActivity.GVRActivityDelegate,
     }
 
     @Override
-    public boolean onBackPress() {
-        return false;
-    }
-
-    @Override
-    public void onPause() {
-    }
-
-    @Override
-    public void onResume() {
-    }
-
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-    }
-
-    @Override
     public boolean setMain(GVRMain gvrMain, String dataFileName) {
         return true;
     }
@@ -113,26 +94,6 @@ final class DaydreamActivityDelegate implements GVRActivity.GVRActivityDelegate,
         params.setResolutionHeight(VrAppSettings.DEFAULT_FBO_RESOLUTION);
         params.setResolutionWidth(VrAppSettings.DEFAULT_FBO_RESOLUTION);
         return settings;
-    }
-
-    @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        return false;
-    }
-
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        return false;
-    }
-
-    @Override
-    public boolean onKeyLongPress(int keyCode, KeyEvent event) {
-        return false;
-    }
-
-    @Override
-    public void onDestroy() {
-
     }
 
     @Override

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityDelegate.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityDelegate.java
@@ -16,15 +16,13 @@
 package org.gearvrf;
 
 import android.content.res.AssetManager;
-import android.content.res.Configuration;
-import android.view.KeyEvent;
 
 import org.gearvrf.utility.VrAppSettings;
 
 /**
  * {@inheritDoc}
  */
-final class OvrActivityDelegate implements GVRActivity.GVRActivityDelegate {
+final class OvrActivityDelegate extends GVRActivity.ActivityDelegateStubs {
     private GVRActivity mActivity;
     private OvrViewManager mActiveViewManager;
     private OvrActivityNative mActivityNative;
@@ -90,7 +88,10 @@ final class OvrActivityDelegate implements GVRActivity.GVRActivityDelegate {
     }
 
     @Override
-    public void onConfigurationChanged(Configuration newConfig) {
+    public void onDestroy() {
+        if (null != mActivityHandler) {
+            mActivityHandler.onDestroy();
+        }
     }
 
     @Override
@@ -108,27 +109,8 @@ final class OvrActivityDelegate implements GVRActivity.GVRActivityDelegate {
     }
 
     @Override
-    public void onInitAppSettings(VrAppSettings appSettings) {
-    }
-
-    @Override
     public VrAppSettings makeVrAppSettings() {
         return new OvrVrAppSettings();
-    }
-
-    @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        return false;
-    }
-
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        return false;
-    }
-
-    @Override
-    public boolean onKeyLongPress(int keyCode, KeyEvent event) {
-        return false;
     }
 
     private OvrXMLParser mXmlParser;

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityHandler.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityHandler.java
@@ -1,15 +1,15 @@
 package org.gearvrf;
 
 interface OvrActivityHandler {
-    public void onPause();
+    void onPause();
 
-    public void onResume();
+    void onResume();
 
-    public void onSetScript();
+    void onDestroy();
 
-    public boolean onBack();
+    void onSetScript();
 
-    public boolean onBackLongPress();
+    boolean onBack();
 
     void setViewManager(GVRViewManager viewManager);
 }

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -59,28 +59,25 @@ namespace gvr {
         initializeOculusJava(*envMainThread_, oculusJavaMainThread_);
 
         const ovrInitParms initParms = vrapi_DefaultInitParms(&oculusJavaMainThread_);
-        mVrapiInitResult = vrapi_Initialize(&initParms);
-        if (VRAPI_INITIALIZE_UNKNOWN_ERROR == mVrapiInitResult) {
+        ovrInitializeStatus vrapiInitResult = vrapi_Initialize(&initParms);
+        if (VRAPI_INITIALIZE_UNKNOWN_ERROR == vrapiInitResult) {
             LOGE("Oculus is probably not present on this device");
-            return mVrapiInitResult;
+            return vrapiInitResult;
         }
 
-        if (VRAPI_INITIALIZE_PERMISSIONS_ERROR == mVrapiInitResult) {
-            char const * msg =
-                    mVrapiInitResult == VRAPI_INITIALIZE_PERMISSIONS_ERROR ?
-                    "Thread priority security exception. Make sure the APK is signed." :
-                    "VrApi initialization error.";
+        if (VRAPI_INITIALIZE_PERMISSIONS_ERROR == vrapiInitResult) {
+            char const * msg = "Thread priority security exception. Make sure the APK is signed.";
             vrapi_ShowFatalError(&oculusJavaMainThread_, nullptr, msg, __FILE__, __LINE__);
         }
 
-        return mVrapiInitResult;
+        return vrapiInitResult;
     }
 
+    /**
+     * Do not call unless vrapi has been successfully initialized prior to that.
+     */
     void GVRActivity::uninitializeVrApi() {
-        if (VRAPI_INITIALIZE_UNKNOWN_ERROR != mVrapiInitResult) {
-            vrapi_Shutdown();
-        }
-        mVrapiInitResult = VRAPI_INITIALIZE_UNKNOWN_ERROR;
+        vrapi_Shutdown();
     }
 
     void GVRActivity::showConfirmQuit() {

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.h
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.h
@@ -66,8 +66,6 @@ namespace gvr {
         ovrTextureFormat mColorTextureFormatConfiguration = VRAPI_TEXTURE_FORMAT_NONE;
         ovrTextureFormat mDepthTextureFormatConfiguration = VRAPI_TEXTURE_FORMAT_NONE;
 
-        int32_t mVrapiInitResult = VRAPI_INITIALIZE_UNKNOWN_ERROR;
-
         int x, y, width, height;                // viewport
 
         void initializeOculusJava(JNIEnv& env, ovrJava& oculusJava);
@@ -83,9 +81,9 @@ namespace gvr {
         void onSurfaceCreated(JNIEnv& env);
         void copyVulkanTexture(int texSwapChainIndex, int eye);
         void onSurfaceChanged(JNIEnv& env);
-    void onDrawFrame(jobject jViewManager);
+        void onDrawFrame(jobject jViewManager);
         int initializeVrApi();
-        void uninitializeVrApi();
+        static void uninitializeVrApi();
         void leaveVrMode();
 
         void showConfirmQuit();

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity_jni.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity_jni.cpp
@@ -94,9 +94,8 @@ namespace gvr {
         return activity->initializeVrApi();
     }
     
-    JNIEXPORT void JNICALL Java_org_gearvrf_OvrVrapiActivityHandler_nativeUninitializeVrApi(JNIEnv * jni, jclass clazz, jlong appPtr) {
-        GVRActivity *activity = reinterpret_cast<GVRActivity*>(appPtr);
-        activity->uninitializeVrApi();
+    JNIEXPORT void JNICALL Java_org_gearvrf_OvrVrapiActivityHandler_nativeUninitializeVrApi(JNIEnv *, jclass) {
+        GVRActivity::uninitializeVrApi();
     }
     
     JNIEXPORT jboolean JNICALL Java_org_gearvrf_OvrConfigurationManager_nativeIsHmtConnected(JNIEnv* jni, jclass clazz, jlong appPtr) {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -682,6 +682,7 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         void onCreate(GVRActivity activity);
         void onPause();
         void onResume();
+        void onDestroy();
         void onConfigurationChanged(final Configuration newConfig);
 
         boolean onKeyDown(int keyCode, KeyEvent event);
@@ -701,5 +702,103 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
         void parseXmlSettings(AssetManager assetManager, String dataFilename);
 
         boolean onBackPress();
+    }
+
+    static class ActivityDelegateStubs implements GVRActivityDelegate {
+
+        @Override
+        public void onCreate(GVRActivity activity) {
+
+        }
+
+        @Override
+        public void onPause() {
+
+        }
+
+        @Override
+        public void onResume() {
+
+        }
+
+        @Override
+        public void onDestroy() {
+
+        }
+
+        @Override
+        public void onConfigurationChanged(Configuration newConfig) {
+
+        }
+
+        @Override
+        public boolean onKeyDown(int keyCode, KeyEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean onKeyUp(int keyCode, KeyEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean onKeyLongPress(int keyCode, KeyEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean setMain(GVRMain gvrMain, String dataFileName) {
+            return false;
+        }
+
+        @Override
+        public void setViewManager(GVRViewManager viewManager) {
+
+        }
+
+        @Override
+        public void onInitAppSettings(VrAppSettings appSettings) {
+
+        }
+
+        @Override
+        public VrAppSettings makeVrAppSettings() {
+            return null;
+        }
+
+        @Override
+        public IActivityNative getActivityNative() {
+            return null;
+        }
+
+        @Override
+        public GVRViewManager makeViewManager() {
+            return null;
+        }
+
+        @Override
+        public GVRViewManager makeMonoscopicViewManager() {
+            return null;
+        }
+
+        @Override
+        public GVRCameraRig makeCameraRig(GVRContext context) {
+            return null;
+        }
+
+        @Override
+        public GVRConfigurationManager makeConfigurationManager(GVRActivity activity) {
+            return null;
+        }
+
+        @Override
+        public void parseXmlSettings(AssetManager assetManager, String dataFilename) {
+
+        }
+
+        @Override
+        public boolean onBackPress() {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Enables taking screenshots and recording videos from the Oculus global menu
Addresses https://github.com/Samsung/GearVRf/issues/1235

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>