### PR TITLE
framework: silence the verbose "DataDescriptor: %s" trace by default

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/data_descriptor.cpp
@@ -12,13 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#define VERBOSE_LOGGING 0
+
 #include <cstring>
 #include <sstream>
 #include <istream>
 #include "objects/data_descriptor.h"
 #include "util/gvr_log.h"
-
-#define VERBOSE_LOGGING 0
 
 namespace gvr
 {


### PR DESCRIPTION
Stuff like ``12-29 11:52:01.229 30675 30751 V gvrf : DataDescriptor: mat4 u_bone_matrix[60]`` will disappear from the logs.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>  