### PR TITLE
framework: workaround for render data dirty flag not beeing cleared

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -195,7 +195,7 @@ void Renderer::cullFromCamera(Scene *scene, Camera* camera,
 
 void Renderer::addRenderData(RenderData *render_data, RenderState& rstate, std::vector<RenderData*>& renderList)
 {
-    if (render_data && (render_data->isValid(this, rstate) >= 0))
+    if (render_data && (render_data->isRenderable(this, rstate) > 0))
     {
         renderList.push_back(render_data);
     }
@@ -387,7 +387,7 @@ bool Renderer::renderPostEffectData(RenderState& rstate, RenderTexture* input_te
     int nativeShader = rpass->get_shader(rstate.is_multiview);
     Shader* shader = rstate.shader_manager->getShader(nativeShader);
 
-    if(post_effect->isValid(this, rstate) < 0)
+    if(post_effect->isRenderable(this, rstate) < 0)
     {
         LOGE("Renderer::renderPostEffectData is dirty");
         return false;             // no shader available

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data.cpp
@@ -237,7 +237,7 @@ const std::string& RenderData::getHashCode()
  * @param scene     Scene this RenderData is rendered to
  * @return true if renderable, else false
  */
-int RenderData::isValid(Renderer* renderer, const RenderState& rstate)
+int RenderData::isRenderable(Renderer* renderer, const RenderState& rstate)
 {
     Mesh* m = mesh();
     bool dirty = isDirty();
@@ -284,12 +284,14 @@ int RenderData::isValid(Renderer* renderer, const RenderState& rstate)
             RenderPass *rpass = pass(p);
             if (rpass->get_shader(rstate.is_multiview) <= 0)
             {
-                LOGE("RenderData::isValid shader could not be created");
+                LOGE("RenderData::isRenderable shader could not be created");
                 return -1;
             }
         }
+
+        clearDirty();
     }
-    return dirty ? 0 : 1;
+    return 1;
 }
 
 bool RenderData::updateGPU(Renderer* renderer, Shader* shader)

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data.h
@@ -375,7 +375,7 @@ public:
         render_pass_list_[pass]->set_shader(shaderid, isMultiview);
     }
 
-    int isValid(Renderer* renderer, const RenderState& scene);
+    int isRenderable(Renderer *renderer, const RenderState &scene);
 
     int             get_shader(bool useMultiview =false, int pass =0) const { return render_pass_list_[pass]->get_shader(useMultiview); }
     const std::string&     getHashCode();

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_target_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_target_jni.cpp
@@ -5,8 +5,7 @@
 #include "objects/components/render_target.h"
 
 #include "util/gvr_jni.h"
-#include "util/gvr_log.h"
-#include "glm/gtc/type_ptr.hpp"
+#include "objects/scene.h"
 
 namespace gvr {
     extern "C" {
@@ -52,6 +51,7 @@ Java_org_gearvrf_NativeRenderTarget_render(JNIEnv *env, jobject obj, jlong rende
     Scene* scene = reinterpret_cast<Scene*>(jscene);
     // Do not remote this: need it for screenshot capturer, center camera rendering
     target->setCamera(reinterpret_cast<Camera*>(camera));
+    scene->bindShaders();
     gRenderer->getInstance()->renderRenderTarget(scene, target, reinterpret_cast<ShaderManager*>(shader_manager),
                                                  reinterpret_cast<RenderTexture*>(posteffectrenderTextureA), reinterpret_cast<RenderTexture*>(posteffectRenderTextureB));
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/texture_capturer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/texture_capturer.cpp
@@ -160,7 +160,7 @@ void TextureCapturer::render(RenderState* rstate, RenderData* render_data) {
 
     material->getFloat("opacity", opacity);
     mMaterial->setFloat("opacity", opacity);
-    if (render_data->isValid(renderer, *rstate))
+    if (render_data->isRenderable(renderer, *rstate))
     {
         int id = render_data->get_shader(rstate->is_multiview);
         if (id > 0)

--- a/GVRf/Framework/framework/src/main/jni/objects/scene.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene.h
@@ -21,6 +21,7 @@
 #ifndef SCENE_H_
 #define SCENE_H_
 
+#include <atomic>
 #include <memory>
 #include <vector>
 #include <mutex>
@@ -200,7 +201,8 @@ private:
     jobject javaObj_;
     SceneObject scene_root_;
     CameraRig* main_camera_rig_;
-    int dirtyFlag_;
+    std::atomic<bool> needsBindShaders_;
+
     bool frustum_flag_;
     bool occlusion_flag_;
     bool pick_visible_;


### PR DESCRIPTION
+ ensures shaders are regenerated if a light is added

Since rarely if ever the render data dirty flag is cleared after being set, bindShader can and will be called continuously. Clear the flag now. "Workaround" in the title since the dirty flag probably needs more TLC.

With the flag cleared suddenly the shadows no longer appear. Fix that by ensuring the scene's bindShaders is run at an appropriate time after a light has been added.

Tested all the demos, gl renderer, s8.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>