### PR TITLE
framework: make access to Texture::mImage more thread-safe

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/gl/gl_render_texture.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_render_texture.h
@@ -42,10 +42,6 @@ public:
 
     virtual ~GLRenderTexture();
 
-    virtual int getId() { return mImage->getId(); }
-    virtual int width() const { return mImage->getWidth(); }
-    virtual int height() const { return mImage->getHeight(); }
-
     virtual unsigned int getFrameBufferId() const {
         return renderTexture_gl_frame_buffer_->id();
     }
@@ -66,7 +62,7 @@ public:
     // it returns, the pixels have been copied to PBO and then to the client memory.
     virtual bool readRenderResult(uint8_t* readback_buffer, long capacity);
     virtual bool readRenderResult(uint8_t* readback_buffer);
-    bool bindTexture(int gl_location, int texIndex);
+    void bindTexture(int gl_location, int texIndex);
     void setLayerIndex(int layerIndex);
 
 private:

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/render_texture.h
@@ -57,8 +57,8 @@ public:
     }
 
     virtual ~RenderTexture() { }
-    virtual int width() const { mImage->getWidth(); }
-    virtual int height() const { return mImage->getHeight(); }
+    virtual int width() const { return getImage()->getWidth(); }
+    virtual int height() const { return getImage()->getHeight(); }
     virtual unsigned int getFrameBufferId() const = 0;
     virtual void bind() = 0;
     virtual void beginRendering(Renderer*) = 0;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/texture.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/texture.cpp
@@ -46,9 +46,12 @@ Texture::~Texture()
 
 bool Texture::isReady()
 {
-    if (mImage)
+    Image* image = mImage;
+    if (image)
     {
-        return mImage->isReady() && (mImage->getId() != 0);
+        bool isReady = image->isReady();
+        int id = image->getId();
+        return isReady && (id != 0);
     }
     return false;
 }
@@ -82,9 +85,9 @@ void Texture::setImage(JNIEnv* env, jobject javaImage, Image* image)
     clearData(env);
     mJavaImage = env->NewWeakGlobalRef(javaImage);
     mImage = image;
-    if (mImage)
+    if (image)
     {
-        mImage->texParamsChanged(getTexParams());
+        image->texParamsChanged(getTexParams());
     }
     LOGV("Texture::setImage");
 }
@@ -94,9 +97,10 @@ void Texture::updateTextureParameters(const int* texture_parameters, int n)
     if (texture_parameters)
     {
         mTexParams = texture_parameters;
-        if (mImage)
+        Image* image = mImage;
+        if (image)
         {
-            mImage->texParamsChanged(getTexParams());
+            image->texParamsChanged(getTexParams());
         }
         mTexParamsDirty = true;
     }

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/texture.h
@@ -20,6 +20,7 @@
 #ifndef TEXTURE_H_
 #define TEXTURE_H_
 
+#include <atomic>
 #include "image.h"
 #include "util/gvr_jni.h"
 
@@ -130,14 +131,16 @@ public:
 
     explicit Texture(int type = TEXTURE_2D);
     virtual ~Texture();
-    void clearData(JNIEnv* env);
     void setImage(Image* image);
     void setImage(JNIEnv* env, jobject javaImage, Image* image);
     void updateTextureParameters(const int* texture_parameters, int n);
 
     int getType() const { return mType; }
-    Image*  getImage()  { return mImage; }
-    virtual int getId() { return mImage ? mImage->getId() : 0; }
+    Image* getImage() const { return mImage; }
+    int getId() {
+        Image* image = mImage;
+        return image ? image->getId() : 0;
+    }
     virtual bool isReady();
 
     const TextureParameters& getTexParams() const
@@ -153,12 +156,15 @@ public:
 protected:
     JavaVM* mJava;
     jobject mJavaImage;
-    Image*  mImage;
     int     mType;
     bool    mTexParamsDirty;
     TextureParameters   mTexParams;
 
 private:
+    //since it can be read/written from the gl and other threads concurrently
+    std::atomic<Image*> mImage;
+    void clearData(JNIEnv* env);
+
     Texture(const Texture& texture) = delete;
     Texture(Texture&& texture) = delete;
     Texture& operator=(const Texture& texture) = delete;

--- a/GVRf/Framework/framework/src/main/jni/vulkan/vk_texture.cpp
+++ b/GVRf/Framework/framework/src/main/jni/vulkan/vk_texture.cpp
@@ -51,15 +51,16 @@ bool VkTexture::isReady()
 void VkTexture::updateSampler()
 {
     int numlod = 1;
-    if (mImage)
+    Image* image = getImage();
+    if (image)
     {
-        numlod = mImage->getLevels();
+        numlod = image->getLevels();
     }
     createSampler(mTexParams, numlod);
 }
 VkSampler VkTexture::getVkSampler(){
     uint64_t index = mTexParams.getHashCode();
-    index = (index << 32) | mImage->getLevels();
+    index = (index << 32) | getImage()->getLevels();
     return getSampler(index);
 }
 void VkTexture::createSampler(TextureParameters& textureParameters, int maxLod) {
@@ -107,19 +108,20 @@ void VkTexture::createSampler(TextureParameters& textureParameters, int maxLod) 
 }
 const VkImageView& VkTexture::getVkImageView()
 {
-    if (mImage == NULL)
+    Image* image = getImage();
+    if (image == NULL)
         LOGE("GetImageView : image is NULL");
 
     VkCubemapImage* cubemapImage;
     VkBitmapImage* bitmapImage;
-    switch(mImage->getType()){
+    switch(image->getType()){
 
         case Image::ImageType::CUBEMAP:
-            cubemapImage = static_cast<VkCubemapImage*>(mImage);
+            cubemapImage = static_cast<VkCubemapImage*>(image);
             return cubemapImage->getVkImageView();
 
         case Image::ImageType::BITMAP:
-            bitmapImage = static_cast<VkBitmapImage*>(mImage);
+            bitmapImage = static_cast<VkBitmapImage*>(image);
             return bitmapImage->getVkImageView();
     }
 }


### PR DESCRIPTION
fixes the texture switching test that otherwise crashes; the change to Texture::isReady does that.
Let's https://github.com/gearvrf/GearVRf-Tests/pull/221 succeed.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>