### PR TITLE
backend_oculus: fix for vrapi usage so tests run again without crashes

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -49,8 +49,6 @@ namespace gvr {
 
     GVRActivity::~GVRActivity() {
         LOGV("GVRActivity::~GVRActivity");
-        uninitializeVrApi();
-
         envMainThread_->DeleteGlobalRef(activityClass_);
         envMainThread_->DeleteGlobalRef(activity_);
     }


### PR DESCRIPTION
Broke the automated tests in https://github.com/Samsung/GearVRf/pull/1662. Fixing it up here. VrApi is not really friendly to multiple activities per process but this is exactly the case with our tests.

Pending further verification. But tests do run now.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>