### PR TITLE
arm64: fix jni error; now 64bit build runs

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/scene_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_jni.cpp
@@ -27,7 +27,7 @@ extern "C" {
     Java_org_gearvrf_NativeScene_ctor(JNIEnv * env, jobject obj);
 
     JNIEXPORT void JNICALL
-    Java_org_gearvrf_NativeScene_setJava(JNIEnv* env, jlong nativeScene, jobject javaScene);
+    Java_org_gearvrf_NativeScene_setJava(JNIEnv *env, jclass, jlong nativeScene, jobject javaScene);
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_NativeScene_addSceneObject(JNIEnv * env,
@@ -102,7 +102,7 @@ Java_org_gearvrf_NativeScene_ctor(JNIEnv* env, jobject obj) {
 }
 
 JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeScene_setJava(JNIEnv* env, jlong nativeScene, jobject javaScene) {
+Java_org_gearvrf_NativeScene_setJava(JNIEnv *env, jclass, jlong nativeScene, jobject javaScene) {
     JavaVM* jvm;
     env->GetJavaVM(&jvm);
     Scene* scene = reinterpret_cast<Scene*>(nativeScene);


### PR DESCRIPTION
1. fix jni error crashing the 64bit build; armeabi-v7a apparently is not so strict but was still incorrect
2. remove bad call to cameraRig_->setRotation(glm::quat()) and fix onDrawFrame formatting

---

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>