### PR TITLE
framework: delete local ref as soon as we are done

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer.cpp
@@ -405,7 +405,9 @@ bool Renderer::renderPostEffectData(RenderState& rstate, RenderTexture* input_te
         //@todo duped in render_data.cpp
         JNIEnv* env = nullptr;
         int rc = rstate.scene->get_java_env(&env);
-        post_effect->bindShader(env, rstate.scene->getJavaObj(*env), rstate.is_multiview);
+        jobject localSceneObject = rstate.scene->getJavaObj(*env);
+        post_effect->bindShader(env, localSceneObject, rstate.is_multiview);
+        env->DeleteLocalRef(localSceneObject);
         if (rc > 0)
         {
             rstate.scene->detach_java_env();

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_data.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_data.cpp
@@ -139,6 +139,9 @@ void RenderData::bindShader(JNIEnv* env, jobject localSceneObject, bool isMultiv
     if (nullptr != localJavaObject && nullptr != localSceneObject) {
         env->CallVoidMethod(localJavaObject, bindShaderMethod_, localSceneObject, isMultiview);
     }
+    if (localJavaObject) {
+        env->DeleteLocalRef(localJavaObject);
+    }
 }
 
 bool compareRenderDataByShader(RenderData *i, RenderData *j)
@@ -274,7 +277,9 @@ int RenderData::isValid(Renderer* renderer, const RenderState& rstate)
         //@todo implementation details leaked; unify common JNI reqs of Scene and RenderData
         JNIEnv* env = nullptr;
         int rc = rstate.scene->get_java_env(&env);
-        bindShader(env, rstate.scene->getJavaObj(*env), rstate.is_multiview);
+        jobject localSceneObject = rstate.scene->getJavaObj(*env);
+        bindShader(env, localSceneObject, rstate.is_multiview);
+        env->DeleteLocalRef(localSceneObject);
         if (rc > 0) {
             rstate.scene->detach_java_env();
         }


### PR DESCRIPTION
Roshan is seeing local ref table overflow in some cases. This change ensures we are deleting them as soon as possible.

---

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>