### PR TITLE
framework: fix shader data crash exposed by the new tests

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderData.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderData.java
@@ -220,10 +220,7 @@ public class GVRShaderData extends GVRHybridObject
         synchronized (textures)
         {
             textures.put(key, texture);
-            if (texture != null)
-            {
-                NativeShaderData.setTexture(getNative(), key, texture.getNative());
-            }
+            NativeShaderData.setTexture(getNative(), key, texture != null ? texture.getNative() : 0);
         }
     }
 


### PR DESCRIPTION
Includes https://github.com/Samsung/GearVRf/pull/1737 for now

Tests pull request leading to the crash: https://github.com/gearvrf/GearVRf-Tests/pull/232

Actual change is the last commit. If you null out a texture in shader data it must propagate to the c++ layer. Otherwise come gc-time it can and will become an invalid pointer. Since the Java object holds no reference there is nothing to keep it around.

---

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>