### PR TITLE
framework: fix jni crash due to a local ref being deleted too early

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -666,7 +666,7 @@ class NativeScene {
 
     static native long ctor();
 
-    static native void setJava(long scene, Object javaScene);
+    static native void setJava(long scene, GVRScene javaScene);
 
     static native void addSceneObject(long scene, long sceneObject);
    

--- a/GVRf/Framework/framework/src/main/jni/view_manager_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/view_manager_jni.cpp
@@ -61,18 +61,23 @@ extern "C" {
 
         javaSceneObject = jni->NewLocalRef(javaSceneObject);
         renderTarget->cullFromCamera(scene, javaSceneObject, renderTarget->getCamera(),gRenderer,shader_manager);
-        jni->DeleteLocalRef(javaSceneObject);
 
         if(!gRenderer->isVulkanInstance())
             renderTarget->beginRendering(gRenderer);
         gRenderer->renderRenderTarget(scene, javaSceneObject, renderTarget,shader_manager,post_effect_render_texture_a,post_effect_render_texture_b);
         if(!gRenderer->isVulkanInstance())
             renderTarget->endRendering(gRenderer);
+
+        jni->DeleteLocalRef(javaSceneObject);
     }
-     void Java_org_gearvrf_GVRRenderBundle_addRenderTarget(JNIEnv* jni, jclass clazz, jlong jrenderTarget , jint eye, jint index){
-        RenderTarget* renderTarget = reinterpret_cast<RenderTarget*>(jrenderTarget);
-         Renderer::getInstance()->addRenderTarget(renderTarget, EYE(eye), index);
+
+    void
+    Java_org_gearvrf_GVRRenderBundle_addRenderTarget(JNIEnv *jni, jclass clazz, jlong jrenderTarget,
+                                                     jint eye, jint index) {
+        RenderTarget *renderTarget = reinterpret_cast<RenderTarget *>(jrenderTarget);
+        Renderer::getInstance()->addRenderTarget(renderTarget, EYE(eye), index);
     }
+
     long Java_org_gearvrf_GVRRenderBundle_getRenderTextureNative(JNIEnv *jni, jclass clazz, jlong jrenderTextureInfo)
     {
         RenderTextureInfo* renderTextureInfo = reinterpret_cast<RenderTextureInfo*>(jrenderTextureInfo);


### PR DESCRIPTION
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>