### PR TITLE
framework: workaround for RenderShaderTests crash

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrViewManager.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrViewManager.java
@@ -177,6 +177,7 @@ class OvrViewManager extends GVRViewManager implements OvrRotationSensorListener
      */
     void onDestroy() {
         Log.v(TAG, "onDestroy");
+        mGearController.onDestroy();
         mRotationSensor.onDestroy();
         super.onDestroy();
     }

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
@@ -139,6 +139,7 @@ final class OvrVrapiActivityHandler implements OvrActivityHandler {
     public void onDestroy() {
         if (this == sVrapiOwner.get()) {
             nativeUninitializeVrApi();
+            sVrapiOwner.clear();
         }
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRActivity.java
@@ -207,6 +207,8 @@ public class GVRActivity extends Activity implements IEventReceiver, IScriptable
     @Override
     protected void onDestroy() {
         android.util.Log.i(TAG, "onDestroy " + Integer.toHexString(hashCode()));
+        mDelegate.onDestroy();
+
         if (mViewManager != null) {
             mViewManager.onDestroy();
             mViewManager.getEventManager().sendEventWithMask(

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRGearCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRGearCursorController.java
@@ -416,16 +416,11 @@ public final class GVRGearCursorController extends GVRCursorController
                 .RIGHT;
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            if (initialized) {
-                thread.uninitialize();
-                thread.quitSafely();
-                initialized = false;
-            }
-        } finally {
-            super.finalize();
+    public void onDestroy() {
+        if (initialized) {
+            thread.uninitialize();
+            thread.quitSafely();
+            initialized = false;
         }
     }
 


### PR DESCRIPTION
Fixes the crash caused by RenderShaderTests. The tearDown for the tests clears the scene, which detaches all components. It all happens on the test thread. Since there is no way for c++ code to claim ownership of a component, transforms (for example) end up getting deleted concurrently to the tearDown execution.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>