### PR TITLE
X3D parser fixes of ROUTE, MeshCreator changes from maint_v3.x

### DIFF
--- a/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
+++ b/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
@@ -62,6 +62,8 @@ import java.util.Vector;
 
 import javax.script.Bindings;
 
+import lu.flier.script.V8Object;
+
 
 /**
  * @author m1.williams
@@ -936,6 +938,23 @@ public class AnimationInteractivityManager {
         }
     }
 
+    /* Allows string matching fields, handling mis-matched case, if value has 'set' so
+    'set_translation' and 'translation' or 'translation_changed' and 'translation' match.
+    Also gets rid of leading and trailing spaces.  All possible in JavaScript and X3D Routes.
+     */
+    private boolean StringFieldMatch (String original, String matching) {
+        boolean equal = false;
+        original = original.toLowerCase().trim();
+        matching = matching.toLowerCase();
+        if (original.endsWith(matching)) {
+            equal = true;
+        }
+        else if (original.startsWith(matching)) {
+            equal = true;
+        }
+        return equal;
+    }
+
     // funtion called each event and sets the arguments (parameters)
     // from INPUT_ONLY and INPUT_OUTPUT to the function that 'compiles' and run JavaScript
     private Object[] SetJavaScriptArguments(InteractiveObject interactiveObj, Object argument0, boolean stateChanged) {
@@ -985,17 +1004,17 @@ public class AnimationInteractivityManager {
                     if (fieldType.equalsIgnoreCase("SFColor")) {
                         float[] color = {0, 0, 0};
                         if (definedItem.getGVRMaterial() != null) {
-                            if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("diffuseColor")) {
+                            if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "diffuseColor") ) {
                                 float[] diffuseColor = definedItem.getGVRMaterial().getVec4("diffuse_color");
                                 for (int i = 0; i < 3; i++) {
                                     color[i] = diffuseColor[i]; // only get the first 3 values, not the alpha value
                                 }
-                            } else if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("emissiveColor")) {
+                            } else if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "emissiveColor") ) {
                                 float[] emissiveColor = definedItem.getGVRMaterial().getVec4("emissive_color");
                                 for (int i = 0; i < 3; i++) {
                                     color[i] = emissiveColor[i]; // only get the first 3 values, not the alpha value
                                 }
-                            } else if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("specularColor")) {
+                            } else if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "specularColor") ) {
                                 float[] specularColor = definedItem.getGVRMaterial().getVec4("specular_color");
                                 for (int i = 0; i < 3; i++) {
                                     color[i] = specularColor[i]; // only get the first 3 values, not the alpha value
@@ -1028,7 +1047,7 @@ public class AnimationInteractivityManager {
                     }  // end if SFColor
 
                     else if (fieldType.equalsIgnoreCase("SFRotation")) {
-                        if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("rotation")) {
+                        if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "rotation") ) {
                             if (definedItem.getGVRSceneObject() != null) {
                                 // Likely the rotation in a Transform / GVRTransform
                                 // GearVRf saves rotations as quaternions, but X3D scripting uses AxisAngle
@@ -1039,7 +1058,7 @@ public class AnimationInteractivityManager {
                                 scriptParameters.add(definedItem.getAxisAngle().angle);
                             }
                         }  // rotation parameter
-                        else if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("orientation")) {
+                        else if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "orientation") ) {
                             if ( definedItem.getViewpoint() != null ) {
                                 // have a Viewpoint which for the time-being means get the current direction of the camera
                                 float[] lookAt = gvrContext.getMainScene().getMainCameraRig().getLookAt();
@@ -1062,33 +1081,33 @@ public class AnimationInteractivityManager {
                                 float[] parameter = {0, 0, 0};
                                 if (gvrComponent instanceof GVRSpotLight) {
                                     GVRSpotLight gvrSpotLightBase = (GVRSpotLight) gvrComponent;
-                                    if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("attenuation")) {
+                                    if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "attenuation") ) {
                                         parameter[0] = gvrSpotLightBase.getAttenuationConstant();
                                         parameter[1] = gvrSpotLightBase.getAttenuationLinear();
                                         parameter[2] = gvrSpotLightBase.getAttenuationQuadratic();
-                                    } else if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("location")) {
+                                    } else if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "location") ) {
                                         parameter[0] = definedItem.getGVRSceneObject().getTransform().getPositionX();
                                         parameter[1] = definedItem.getGVRSceneObject().getTransform().getPositionY();
                                         parameter[2] = definedItem.getGVRSceneObject().getTransform().getPositionZ();
-                                    } else if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("direction")) {
+                                    } else if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "direction") ) {
                                         parameter[0] = definedItem.getDirection().x;
                                         parameter[1] = definedItem.getDirection().y;
                                         parameter[2] = definedItem.getDirection().z;
                                     }
                                 } else if (gvrComponent instanceof GVRPointLight) {
                                     GVRPointLight gvrPointLightBase = (GVRPointLight) gvrComponent;
-                                    if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("attenuation")) {
+                                    if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "attenuation") ) {
                                         parameter[0] = gvrPointLightBase.getAttenuationConstant();
                                         parameter[1] = gvrPointLightBase.getAttenuationLinear();
                                         parameter[2] = gvrPointLightBase.getAttenuationQuadratic();
-                                    } else if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("location")) {
+                                    } else if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "location") ) {
                                         parameter[0] = definedItem.getGVRSceneObject().getTransform().getPositionX();
                                         parameter[1] = definedItem.getGVRSceneObject().getTransform().getPositionY();
                                         parameter[2] = definedItem.getGVRSceneObject().getTransform().getPositionZ();
                                     }
                                 } else if (gvrComponent instanceof GVRDirectLight) {
                                     GVRDirectLight gvrDirectLightBase = (GVRDirectLight) gvrComponent;
-                                    if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("direction")) {
+                                    if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "direction") ) {
                                         parameter[0] = definedItem.getDirection().x;
                                         parameter[1] = definedItem.getDirection().y;
                                         parameter[2] = definedItem.getDirection().z;
@@ -1101,13 +1120,13 @@ public class AnimationInteractivityManager {
                             }  //  end gvrComponent != null. it's a light
                             else {
                                 if (definedItem.getGVRSceneObject() != null) {
-                                    if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("translation")) {
+                                    if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "translation") ) {
                                         GVRSceneObject gvrSceneObjectTranslation = root
                                                 .getSceneObjectByName((definedItem.getGVRSceneObject().getName() + x3dObject.TRANSFORM_TRANSLATION_));
                                         scriptParameters.add(gvrSceneObjectTranslation.getTransform().getPositionX());
                                         scriptParameters.add(gvrSceneObjectTranslation.getTransform().getPositionY());
                                         scriptParameters.add(gvrSceneObjectTranslation.getTransform().getPositionZ());
-                                    } else if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("scale")) {
+                                    } else if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "scale") ) {
                                         GVRSceneObject gvrSceneObjectScale = root
                                                 .getSceneObjectByName((definedItem.getGVRSceneObject().getName() + x3dObject.TRANSFORM_SCALE_));
                                         scriptParameters.add(gvrSceneObjectScale.getTransform().getScaleX());
@@ -1121,12 +1140,12 @@ public class AnimationInteractivityManager {
 
                     else if (fieldType.equalsIgnoreCase("SFFloat")) {
                         if (definedItem.getGVRMaterial() != null) {
-                            if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("shininess")) {
+                            if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "shininess") ) {
                                 scriptParameters.add(
                                         definedItem.getGVRMaterial().getFloat("specular_exponent")
                                 );
                             }
-                            else if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("transparency")) {
+                            else if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "transparency") ) {
                                 scriptParameters.add(definedItem.getGVRMaterial().getOpacity());
                             }
                         } else if (definedItem.getGVRSceneObject() != null) {
@@ -1136,9 +1155,9 @@ public class AnimationInteractivityManager {
                                 float parameter = 0;
                                 if (gvrComponent instanceof GVRSpotLight) {
                                     GVRSpotLight gvrSpotLightBase = (GVRSpotLight) gvrComponent;
-                                    if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("beamWidth")) {
+                                    if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "beamWidth") ) {
                                         parameter = gvrSpotLightBase.getInnerConeAngle() * (float) Math.PI / 180;
-                                    } else if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("cutOffAngle")) {
+                                    } else if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "cutOffAngle") ) {
                                         parameter = gvrSpotLightBase.getOuterConeAngle() * (float) Math.PI / 180;
                                     }
                                 } else if (gvrComponent instanceof GVRPointLight) {
@@ -1171,7 +1190,7 @@ public class AnimationInteractivityManager {
                         GVRTexture gvrTexture = definedItem.getGVRTexture();
                         if (gvrTexture != null) {
                             // have a url containting a texture map
-                            if (scriptObject.getFromDefinedItemField(field).equalsIgnoreCase("url") ) {
+                            if ( StringFieldMatch( scriptObject.getFromDefinedItemField(field), "url") ) {
                                 GVRImage gvrImage = gvrTexture.getImage();
                                 if ( gvrImage != null ) {
                                     if ( gvrImage.getFileName() != null) {
@@ -1465,7 +1484,6 @@ public class AnimationInteractivityManager {
                 //  Then call SetResultsFromScript() to set the GearVR values
                 Bindings localBindings = gvrJavascriptFile.getLocalBindings();
                 SetResultsFromScript(interactiveObject, localBindings);
-
             } else {
                 Log.e(TAG, "Error in SCRIPT node '" +  interactiveObject.getScriptObject().getName() +
                         "' running Rhino Engine JavaScript function '" + functionName + "'");
@@ -1493,7 +1511,7 @@ public class AnimationInteractivityManager {
                     // However, not all JavaScript functions set returned-values, and thus left null.  For
                     // example the initialize() method may not set some Script field values, so don't
                     // process those and thus check if returnedJavaScriptValue != null
-                    if (returnedJavaScriptValue != null) {
+                    if ((returnedJavaScriptValue != null) || ( !(returnedJavaScriptValue instanceof V8Object) )) {
                         if (fieldType.equalsIgnoreCase("SFBool")) {
                             SFBool sfBool = (SFBool) returnedJavaScriptValue;
                             if ( scriptObjectToDefinedItem != null) {
@@ -1509,10 +1527,10 @@ public class AnimationInteractivityManager {
                             }
                             else if ( scriptObject.getToTimeSensor(fieldNode) != null) {
                                 TimeSensor timeSensor = scriptObject.getToTimeSensor(fieldNode);
-                                if ( scriptObject.getFieldName(fieldNode).equalsIgnoreCase("loop")){
+                                if ( StringFieldMatch( scriptObject.getFieldName(fieldNode), "loop") ) {
                                     timeSensor.setLoop( sfBool.getValue(), gvrContext );
                                 }
-                                if ( scriptObject.getFieldName(fieldNode).equalsIgnoreCase("enabled")){
+                                if ( StringFieldMatch( scriptObject.getFieldName(fieldNode), "enabled") ) {
                                     timeSensor.setEnabled( sfBool.getValue(), gvrContext );
                                 }
                             }
@@ -1523,9 +1541,9 @@ public class AnimationInteractivityManager {
                         else if (fieldType.equalsIgnoreCase("SFFloat")) {
                             SFFloat sfFloat = (SFFloat) returnedJavaScriptValue;
                             if (scriptObjectToDefinedItem.getGVRMaterial() != null) {
-                                if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("shininess")) {
+                                if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "shininess") ) {
                                     scriptObjectToDefinedItem.getGVRMaterial().setSpecularExponent(sfFloat.getValue());
-                                } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("transparency")) {
+                                } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "transparency") ) {
                                     scriptObjectToDefinedItem.getGVRMaterial().setOpacity(sfFloat.getValue());
                                 }
                             } else if (scriptObjectToDefinedItem.getGVRSceneObject() != null) {
@@ -1533,25 +1551,25 @@ public class AnimationInteractivityManager {
                                 if (gvrComponent != null) {
                                     if (gvrComponent instanceof GVRSpotLight) {
                                         GVRSpotLight gvrSpotLightBase = (GVRSpotLight) gvrComponent;
-                                        if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("beamWidth")) {
+                                        if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "beamWidth") ) {
                                             gvrSpotLightBase.setInnerConeAngle(sfFloat.getValue() * 180 / (float) Math.PI);
-                                        } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("cutOffAngle")) {
+                                        } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "cutOffAngle") ) {
                                             gvrSpotLightBase.setOuterConeAngle(sfFloat.getValue() * 180 / (float) Math.PI);
-                                        } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("intensity")) {
+                                        } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "intensity") ) {
                                             //TODO: we aren't changing intensity since this would be multiplied by color
-                                        } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("radius")) {
-                                            //TODO: radius is not currently supported in GearVR for the spot light
+                                        } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "radius") ) {
+                                           //TODO: radius is not currently supported in GearVR for the spot light
                                         }
                                     } else if (gvrComponent instanceof GVRPointLight) {
                                         GVRPointLight gvrPointLightBase = (GVRPointLight) gvrComponent;
-                                        if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("intensity")) {
+                                        if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "intensity") ) {
                                             //TODO: we aren't changing intensity since this would be multiplied by color
-                                        } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("radius")) {
+                                        } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "radius") ) {
                                             //TODO: radius is not currently supported in GearVR for the point light
                                         }
                                     } else if (gvrComponent instanceof GVRDirectLight) {
                                         GVRDirectLight gvrDirectLightBase = (GVRDirectLight) gvrComponent;
-                                        if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("intensity")) {
+                                        if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "intensity") ) {
                                             //TODO: we aren't changing intensity since GVR multiplies this by color
                                         }
                                     }
@@ -1565,13 +1583,13 @@ public class AnimationInteractivityManager {
                             SFTime sfTime = (SFTime) returnedJavaScriptValue;
                             if ( scriptObject.getToTimeSensor(fieldNode) != null) {
                                 TimeSensor timeSensor = scriptObject.getToTimeSensor(fieldNode);
-                                if ( scriptObject.getFieldName(fieldNode).equalsIgnoreCase("startTime")){
+                                if ( StringFieldMatch( scriptObject.getFieldName(fieldNode), "startTime") ) {
                                     timeSensor.startTime = (float)sfTime.getValue();
                                 }
-                                else if ( scriptObject.getFieldName(fieldNode).equalsIgnoreCase("stopTime")){
+                                else if ( StringFieldMatch( scriptObject.getFieldName(fieldNode), "stopTime") ) {
                                     timeSensor.stopTime = (float)sfTime.getValue();
                                 }
-                                else if ( scriptObject.getFieldName(fieldNode).equalsIgnoreCase("cycleInterval")){
+                                else if ( StringFieldMatch( scriptObject.getFieldName(fieldNode), "cycleInterval") ) {
                                     timeSensor.setCycleInterval( (float)sfTime.getValue() );
                                 }
                                 else Log.e(TAG, "Error: Not setting SFTime '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "'." );
@@ -1581,11 +1599,11 @@ public class AnimationInteractivityManager {
                             SFColor sfColor = (SFColor) returnedJavaScriptValue;
                             if (scriptObjectToDefinedItem.getGVRMaterial() != null) {
                                 //  SFColor change to a GVRMaterial
-                                if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("diffuseColor")) {
+                                if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "diffuseColor") ) {
                                     scriptObjectToDefinedItem.getGVRMaterial().setVec4("diffuse_color", sfColor.getRed(), sfColor.getGreen(), sfColor.getBlue(), 1.0f);
-                                } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("specularColor")) {
+                                } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "specularColor") ) {
                                     scriptObjectToDefinedItem.getGVRMaterial().setVec4("specular_color", sfColor.getRed(), sfColor.getGreen(), sfColor.getBlue(), 1.0f);
-                                } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("emissiveColor")) {
+                                } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "emissiveColor") ) {
                                     scriptObjectToDefinedItem.getGVRMaterial().setVec4("emissive_color", sfColor.getRed(), sfColor.getGreen(), sfColor.getBlue(), 1.0f);
                                 }
                             }  //  end SFColor change to a GVRMaterial
@@ -1594,7 +1612,7 @@ public class AnimationInteractivityManager {
                                 GVRSceneObject gvrSceneObject = scriptObjectToDefinedItem.getGVRSceneObject();
                                 GVRComponent gvrComponent = gvrSceneObject.getComponent(GVRLightBase.getComponentType());
                                 if (gvrComponent != null) {
-                                    if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("color")) {
+                                    if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "color") ) {
                                         // SFColor change to a GVRSceneObject (likely a Light Component)
                                         if (gvrComponent instanceof GVRSpotLight) {
                                             GVRSpotLight gvrSpotLightBase = (GVRSpotLight) gvrComponent;
@@ -1618,8 +1636,8 @@ public class AnimationInteractivityManager {
                             if (scriptObjectToDefinedItem.getGVRSceneObject() != null) {
                                 //  SFVec3f change to a GVRSceneObject
                                 GVRSceneObject gvrSceneObject = scriptObjectToDefinedItem.getGVRSceneObject();
-                                if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("translation") ||
-                                        scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("location")) {
+                                if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "translation")  ||
+                                    StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "location") ) {
                                     // location applies to point light and spot light
                                     GVRSceneObject gvrSceneObjectTranslation = root
                                             .getSceneObjectByName((scriptObjectToDefinedItem.getGVRSceneObject().getName() + x3dObject.TRANSFORM_TRANSLATION_));
@@ -1627,7 +1645,7 @@ public class AnimationInteractivityManager {
                                         gvrSceneObjectTranslation.getTransform().setPosition(sfVec3f.x, sfVec3f.y, sfVec3f.z);
                                     else
                                         gvrSceneObject.getTransform().setPosition(sfVec3f.x, sfVec3f.y, sfVec3f.z);
-                                } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("scale")) {
+                                } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "scale") ) {
                                     GVRSceneObject gvrSceneObjectScale = root
                                             .getSceneObjectByName((scriptObjectToDefinedItem.getGVRSceneObject().getName() + x3dObject.TRANSFORM_SCALE_));
                                     if (gvrSceneObjectScale != null)
@@ -1640,26 +1658,26 @@ public class AnimationInteractivityManager {
                                     if (gvrComponent != null) {
                                         if (gvrComponent instanceof GVRSpotLight) {
                                             GVRSpotLight gvrSpotLightBase = (GVRSpotLight) gvrComponent;
-                                            if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("attenuation")) {
+                                            if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "attenuation") ) {
                                                 gvrSpotLightBase.setAttenuation(sfVec3f.getX(), sfVec3f.getY(), sfVec3f.getZ());
-                                            } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("direction")) {
+                                            } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "direction") ) {
                                                 scriptObjectToDefinedItem.setDirection(sfVec3f.x, sfVec3f.y, sfVec3f.z);
                                                 Vector3f v3 = new Vector3f(sfVec3f).normalize();
                                                 Quaternionf q = ConvertDirectionalVectorToQuaternion(v3);
                                                 gvrSpotLightBase.getTransform().setRotation(q.w, q.x, q.y, q.z);
-                                            } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("location")) {
+                                            } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "location") ) {
                                                 gvrSpotLightBase.getTransform().setPosition(sfVec3f.getX(), sfVec3f.getY(), sfVec3f.getZ());
                                             }
                                         } else if (gvrComponent instanceof GVRPointLight) {
                                             GVRPointLight gvrPointLightBase = (GVRPointLight) gvrComponent;
-                                            if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("attenuation")) {
+                                            if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "attenuation") ) {
                                                 gvrPointLightBase.setAttenuation(sfVec3f.getX(), sfVec3f.getY(), sfVec3f.getZ());
-                                            } else if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("location")) {
+                                            } else if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "location") ) {
                                                 gvrPointLightBase.getTransform().setPosition(sfVec3f.getX(), sfVec3f.getY(), sfVec3f.getZ());
                                             }
                                         } else if (gvrComponent instanceof GVRDirectLight) {
                                             GVRDirectLight gvrDirectLightBase = (GVRDirectLight) gvrComponent;
-                                            if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("direction")) {
+                                            if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "direction") ) {
                                                 scriptObjectToDefinedItem.setDirection(sfVec3f.x, sfVec3f.y, sfVec3f.z);
                                                 Vector3f v3 = new Vector3f(sfVec3f).normalize();
                                                 Quaternionf q = ConvertDirectionalVectorToQuaternion(v3);
@@ -1677,7 +1695,7 @@ public class AnimationInteractivityManager {
                             SFRotation sfRotation = (SFRotation) returnedJavaScriptValue;
                             if (scriptObjectToDefinedItem.getGVRSceneObject() != null) {
                                 //  SFRotation change to a GVRSceneObject
-                                if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("rotation")) {
+                                if ( StringFieldMatch( scriptObject.getToDefinedItemField(fieldNode), "rotation") ) {
                                     scriptObjectToDefinedItem.setAxisAngle(sfRotation.angle, sfRotation.x, sfRotation.y, sfRotation.z);
 
                                     GVRSceneObject gvrSceneObjectRotation = root
@@ -1699,7 +1717,7 @@ public class AnimationInteractivityManager {
                                 SFInt32 sfInt32 = new SFInt32(new Integer(returnedJavaScriptValue.toString()).intValue() );
                                 if (scriptObjectToDefinedItem.getGVRSceneObject() != null) {
                                     // Check if the field is 'whichChoice', meaning it's a Switch node
-                                    if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("whichChoice")) {
+                                     if ( StringFieldMatch(scriptObject.getToDefinedItemField(fieldNode), "whichChoice") ) {
                                         GVRSceneObject gvrSwitchSceneObject = scriptObject.getToDefinedItem(fieldNode).getGVRSceneObject();
                                         GVRComponent gvrComponent = gvrSwitchSceneObject.getComponent(GVRSwitch.getComponentType());
                                         if (gvrComponent instanceof GVRSwitch) {
@@ -1729,32 +1747,35 @@ public class AnimationInteractivityManager {
                             GVRTexture gvrTexture = scriptObjectToDefinedItem.getGVRTexture();
                             if (gvrTexture != null) {
                                 //  MFString change to a GVRTexture object
-                                if (scriptObject.getToDefinedItemField(fieldNode).equalsIgnoreCase("url")) {
+                                if (StringFieldMatch(scriptObject.getToDefinedItemField(fieldNode), "url")) {
                                     if (scriptObjectToDefinedItem.getGVRMaterial() != null) {
                                         // We have the GVRMaterial that contains a GVRTexture
-                                        if ( ! gvrTexture.getImage().getFileName().equals(mfString.get1Value(0))) {
+                                        if (!gvrTexture.getImage().getFileName().equals(mfString.get1Value(0))) {
                                             // Only loadTexture if it is different than the current
                                             GVRAssetLoader.TextureRequest request = new GVRAssetLoader.TextureRequest(assetRequest,
-                                                    gvrTexture, mfString.get1Value(0));
+                                                        gvrTexture, mfString.get1Value(0));
                                             assetRequest.loadTexture(request);
                                         }
                                     } // end having GVRMaterial containing GVRTexture
                                     else {
-                                        Log.e(TAG, "Error: No GVRMaterial associated with MFString Texture url '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "'." );
+                                        Log.e(TAG, "Error: No GVRMaterial associated with MFString Texture url '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "'.");
                                     }
                                 }  //  definedItem != null
                                 else {
-                                    Log.e(TAG, "Error: No url associated with MFString '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "'." );
+                                    Log.e(TAG, "Error: No url associated with MFString '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "'.");
                                 }
                             }  // end GVRTexture != null
                             else {
-                                Log.e(TAG, "Error: Not setting MFString '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "'." );
+                                Log.e(TAG, "Error: Not setting MFString '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "'.");
                             }
                         }  //  end MFString
                         else {
                             Log.e(TAG, "Error: " + fieldType + " in '" + scriptObject.getFieldName(fieldNode) + "' value from SCRIPT '" + scriptObject.getName() + "' not supported." );
                         }
                     }  //  end value != null
+                    else {
+                        Log.e(TAG, "Warning: " + fieldType + " '" + scriptObject.getFieldName(fieldNode) + "' from SCRIPT '" + scriptObject.getName() + "' may not be set.");
+                    }
                 }  //  end OUTPUT-ONLY or INPUT_OUTPUT
             }  // end for-loop list of fields for a single script
         } catch (Exception e) {

--- a/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/X3Dobject.java
+++ b/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/X3Dobject.java
@@ -606,7 +606,7 @@ public class X3Dobject {
     // Default is true to use Universal lights shader.
     public final static boolean UNIVERSAL_LIGHTS = true;
 
-    private final static String JAVASCRIPT_IMPORT_PACKAGE = "importPackage(org.gearvrf.x3d.data_types)\nimportPackage(org.joml)\nimportPackage(org.gearvrf)\nnimportPackage(org.gearvrf.x3ddemo)";
+    private final static String JAVASCRIPT_IMPORT_PACKAGE = "importPackage(org.gearvrf.x3d.data_types)\nimportPackage(org.joml)\nimportPackage(org.gearvrf)";
 
     // Strings appended to GVRScene names when there are multiple
     // animations on the same <Transform> or GVRSceneObject


### PR DESCRIPTION
Enabled &lt;ROUTE&gt; _field_ to accept different pre-fixes and post-fixes. Also, no longer case sensitive
For example:
&lt;Route fromNode="myObj" fromField ="translation_changed" ...
&lt;Route fromNode="myObj" toField ="set_translation" ...
&lt;Route fromNode="myObj" fromField ="TRANSLATION" ...
will all work like:
&lt;Route fromNode="myObj" fromField ="translation" ...

Implemented PR https://github.com/Samsung/GearVRf/pull/1323 from maint-v3.x, but not merged into v4. Also enabled a setting to turn off Textures and/or Lights from AssetRequest

Enabled scale to be negative instead of &gt;= 0

Fixed bug with &lt;Inline&gt; inside &lt;Transform&gt;

GearVRF DCO signed off by: Mitch Williams
M1.Williams@partner.samsung.com
