### PR TITLE
monoscopic, android.mk: remove reference to oculus mobile sdk

### DIFF
--- a/GVRf/Framework/backend_monoscopic/src/main/jni/Application.mk
+++ b/GVRf/Framework/backend_monoscopic/src/main/jni/Application.mk
@@ -22,8 +22,3 @@
  APP_PLATFORM := android-19
  APP_STL := gnustl_static
  NDK_TOOLCHAIN_VERSION := 4.9
- ifndef OVR_MOBILE_SDK
-    	OVR_MOBILE_SDK=../../../../../ovr_sdk_mobile
- endif
-
- NDK_MODULE_PATH := $(OVR_MOBILE_SDK)


### PR DESCRIPTION
Gets rid of an annoying build warning

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>