### PR TITLE
backend_oculus: ensure the camera rig transform is updated prior to everything else

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrViewManager.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrViewManager.java
@@ -292,7 +292,6 @@ class OvrViewManager extends GVRViewManager implements OvrRotationSensorListener
 
     /** Called once per frame */
     protected void onDrawFrame() {
-        beforeDrawEyes();
 
         // update the gear controller
         if (mGearController != null)

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -41,6 +41,7 @@ namespace gvr {
         activityClass_ = GetGlobalClassReference(env, activityClassName);
 
         onDrawEyeMethodId = GetMethodId(env, env.FindClass(viewManagerClassName), "onDrawEye", "(IIZ)V");
+        onBeforeDrawEyesMethodId = GetMethodId(env, env.FindClass(viewManagerClassName), "beforeDrawEyes", "()V");
         updateSensoredSceneMethodId = GetMethodId(env, activityClass_, "updateSensoredScene", "()Z");
 
         mainThreadId_ = gettid();
@@ -270,6 +271,7 @@ void GVRActivity::onDrawFrame(jobject jViewManager) {
     if (!sensoredSceneUpdated_ && docked_) {
         sensoredSceneUpdated_ = updateSensoredScene();
     }
+    oculusJavaGlThread_.Env->CallVoidMethod(jViewManager, onBeforeDrawEyesMethodId);
 
     // Render the eye images.
     for (int eye = 0; eye < (use_multiview ? 1 : VRAPI_FRAME_LAYER_EYE_MAX); eye++) {

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.h
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.h
@@ -44,6 +44,7 @@ namespace gvr {
         jclass activityClass_ = nullptr;            // must be looked up from main thread or FindClass() will fail
 
         jmethodID onDrawEyeMethodId = nullptr;
+        jmethodID onBeforeDrawEyesMethodId = nullptr;
         jmethodID updateSensoredSceneMethodId = nullptr;
 
         jobject activity_;


### PR DESCRIPTION
The camera rig transform was previously updated after beforeDrawEyes (which also runs the drawFrameListeners). It can cause visual glitches if somebody modifies the camera rig transform from one of those listeners. And in any case, it is more correct to update the camera rig transform prior to doing anything else.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>