### PR TITLE
gazecursor: fixes so events work when docked

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRCursorController.java
@@ -1099,14 +1099,14 @@ public abstract class GVRCursorController implements IEventReceiver
         }
     }
 
-    protected class ControllerPick implements Runnable
+    protected final class ControllerPick implements Runnable
     {
         public MotionEvent mEvent;
         public GVRPicker mPicker;
         public boolean mActive;
         public boolean mDoPick;
 
-        public void init(GVRPicker picker, MotionEvent event, boolean active)
+        public ControllerPick(GVRPicker picker, MotionEvent event, boolean active)
         {
             mPicker = picker;
             mEvent = event;
@@ -1152,8 +1152,6 @@ public abstract class GVRCursorController implements IEventReceiver
         }
     }
 
-    protected ControllerPick mControllerPick = new ControllerPick();
-
     /**
      * Update the state of the picker. If it has an owner, the picker
      * will use that object to derive its position and orientation.
@@ -1162,9 +1160,9 @@ public abstract class GVRCursorController implements IEventReceiver
      */
     protected void updatePicker(MotionEvent event, boolean isActive)
     {
-        MotionEvent newEvent = (event != null) ? MotionEvent.obtain(event) : null;
-        mControllerPick.init(mPicker, newEvent, isActive);
-        context.runOnGlThread(mControllerPick);
+        final MotionEvent newEvent = (event != null) ? event : null;
+        final ControllerPick controllerPick = new ControllerPick(mPicker, newEvent, isActive);
+        context.runOnGlThread(controllerPick);
     }
 
     /**
@@ -1193,11 +1191,6 @@ public abstract class GVRCursorController implements IEventReceiver
         synchronized (eventLock)
         {
             processedKeyEvent.clear();
-            // done processing, recycle
-            for (MotionEvent event : processedMotionEvent)
-            {
-                event.recycle();
-            }
             processedMotionEvent.clear();
         }
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRGazeCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRGazeCursorController.java
@@ -110,6 +110,9 @@ final public class GVRGazeCursorController extends GVRCursorController
                 setCursorDepth(eventZ);
             }
             break;
+            default:
+                event.recycle();
+                return;
         }
         setMotionEvent(event);
         invalidate();

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRGearCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRGearCursorController.java
@@ -424,8 +424,8 @@ public final class GVRGearCursorController extends GVRCursorController
     protected void updatePicker(MotionEvent event, boolean isActive)
     {
         MotionEvent newEvent = (event != null) ? MotionEvent.obtain(event) : null;
-        mControllerPick.init(mPicker, newEvent,isActive);
-        mControllerPick.run();
+        final ControllerPick controllerPick = new ControllerPick(mPicker, newEvent,isActive);
+        controllerPick.run();
     }
 
     private void handleControllerEvent(final ControllerEvent event)

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
@@ -533,13 +533,13 @@ public class GVRViewSceneObject extends GVRSceneObject {
         }
 
         public void dispatchPickerInputEvent(final MotionEvent e, final float x, final float y) {
+            final MotionEvent enew = MotionEvent.obtain(e);
+            enew.setLocation(x, y);
+
             mGVRContext.getActivity().runOnUiThread(new Runnable()
             {
                 public void run()
                 {
-                    MotionEvent enew = MotionEvent.obtain(e);
-
-                    enew.setLocation(x, y);
                     RootViewGroup.super.dispatchTouchEvent(enew);
                     enew.recycle();
                 }
@@ -698,7 +698,10 @@ public class GVRViewSceneObject extends GVRSceneObject {
 
         }
 
+        @Override
         public void onEnter(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo) { }
+
+        @Override
         public void onExit(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo)
         {
             if (sceneObject == mSelected)
@@ -708,10 +711,9 @@ public class GVRViewSceneObject extends GVRSceneObject {
            }
         }
 
-        public void onTouchStart(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo)
-        {
-            if ((mSelected == null) && (pickInfo.motionEvent != null))
-            {
+        @Override
+        public void onTouchStart(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo) {
+            if ((mSelected == null) && (pickInfo.motionEvent != null)) {
                 final MotionEvent event = pickInfo.motionEvent;
                 final float[] texCoords = pickInfo.getTextureCoords();
 
@@ -722,16 +724,16 @@ public class GVRViewSceneObject extends GVRSceneObject {
                 mSelected = sceneObject;
                 dispatchPickerInputEvent(event, mHitX, mHitY);
             }
-       }
+        }
 
-        public void onInside(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo)
-        {
-            if (sceneObject == mSelected)
-            {
+        @Override
+        public void onInside(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo) {
+            if (sceneObject == mSelected) {
                 onDrag(pickInfo);
             }
         }
 
+        @Override
         public void onTouchEnd(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo)
         {
             if (mSelected != null)
@@ -775,8 +777,17 @@ public class GVRViewSceneObject extends GVRSceneObject {
             }
         }
 
+        @Override
         public void onMotionOutside(GVRPicker picker, MotionEvent event)
         {
+            switch (event.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_MOVE:
+                    break;
+                default:
+                    return;
+            }
             dispatchPickerInputEvent(event, event.getX(), event.getY());
         }
     }


### PR DESCRIPTION
Fix for issue #1786, "GVRViewSceneObject on click not fired"

There is more to it but makes gvr-events for example usable again (when docked).

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>