### PR TITLE
Enabled X3D Inline to retrieve remote fbx and x3d files.

### DIFF
--- a/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
+++ b/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/AnimationInteractivityManager.java
@@ -1253,18 +1253,13 @@ public class AnimationInteractivityManager {
             // if the objects required for this function were constructed, then
             //   check if this <SCRIPT> has an initialize() method that is run just once.
             if (gvrJavascriptV8FileFinal.getScriptText().contains(INITIALIZE_FUNCTION)) {
+                // <SCRIPT> node initialize() functions set inputOnly values
+                // so we don't continue to run the main script method.
+                // http://www.web3d.org/documents/specifications/19775-1/V3.2/Part01/components/scripting.html#Script
                 complete = gvrJavascriptV8FileFinal.invokeFunction(INITIALIZE_FUNCTION, parametersFinal, "");
-
-                if (complete) {
-                    // The JavaScript initialize() function ran ok.
-                    // Now set any values (such as X3D data types such as SFColor)
-                    //  stored in 'localBindings'.
-                    //  Then call SetResultsFromScript() to set the GearVR values
-                    Bindings bindings = gvrJavascriptV8FileFinal.getLocalBindings();
-                    SetResultsFromScript(interactiveObjectFinal, bindings);
-                } else {
-                    Log.e(TAG, "Error in SCRIPT node '"+  interactiveObjectFinal.getScriptObject().getName() +
-                            "' JavaScript initialize() function.");
+                if ( !complete ) {
+                    Log.e(TAG, "Error with initialize() function in SCRIPT '" +
+                            interactiveObjectFinal.getScriptObject().getName() + "'");
                 }
             }
         } else {
@@ -1851,8 +1846,10 @@ public class AnimationInteractivityManager {
                 }  //  end OUTPUT-ONLY or INPUT_OUTPUT
             }  // end for-loop list of fields for a single script
         } catch (Exception e) {
-            Log.e(TAG, "Error setting values returned from JavaScript in SCRIPT node." +
-                    "  Check JavaScript or ROUTE's.  Exception: " + e);
+
+            Log.e(TAG, "Error setting values returned from JavaScript in SCRIPT node " +
+                    interactiveObjectFinal.getScriptObject().getName() +
+                    ".  Check JavaScript or ROUTE's.  Exception: " + e);
         }
     }  //  end  SetResultsFromScript
 

--- a/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/ShaderSettings.java
+++ b/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/ShaderSettings.java
@@ -41,7 +41,7 @@ public class ShaderSettings
   private String nameAppearance = ""; // set if there is a DEF in Appearance
                                       // node
   private String nameMaterial = ""; // set if there is a DEF in Material node
-  private String nameTextureTransform = null; // set if there is a DEF in
+  private String nameTextureTransform = ""; // set if there is a DEF in
   // TextureTransform node
 
   private SFVec2f textureCenter = new SFVec2f( 0, 0 );
@@ -80,7 +80,7 @@ public class ShaderSettings
 	material = m;
     nameAppearance = ""; // set if there is a DEF in Appearance node
     nameMaterial = ""; // set if there is a DEF in Material node
-    nameTextureTransform = null; // set if there is a DEF in TextureTransform
+    nameTextureTransform = ""; // set if there is a DEF in TextureTransform
     // node
 
     // initialize texture values


### PR DESCRIPTION
X3D files with <Inline> can import FBX and X3D files from the internet into an existing scene.

Demo shows main X3D file importing an FBX and X3D file from web. The textured teapot is a remote FBX file. The sphere, from a remote X3D file, changes the light color by clicking (not hover) on it. Light color is initialized to white, changes from green to purple to green, etc.
[X3D_Inline_FBXfromNet.zip](https://github.com/Samsung/GearVRf/files/1830620/X3D_Inline_FBXfromNet.zip)

Also fixed misc. issues with TextureTransform and Initialize() function in  &lt;Script&gt; node.

GearVRf-DCO-1.0-Signed-off-by: Mitch Williams
m1.williams@partner.samsung.com
