### PR TITLE
gradle: support "discovery" of extra_settings.gradle

### DIFF
--- a/GVRf/Framework/settings.gradle
+++ b/GVRf/Framework/settings.gradle
@@ -12,3 +12,11 @@ if (hasProperty('only_daydream') && (only_daydream == "true")) {
 if(file("../../../extra_settings.gradle").exists()) {
     apply from: '../../../extra_settings.gradle'
 }
+
+new File("../../../").eachDir {
+    def fn = it.toString() + "/extra_settings.gradle"
+    if (file(fn).exists()) {
+        apply from: fn
+        println "including modules from " + it.toString()
+    }
+}


### PR DESCRIPTION
Automatically include modules from other repos cloned in the same directory as GearVRf. Needed for the internal build system.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>