### PR TITLE
[maint_v3.x] Fix nullptr dereference crash

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/gl/gl_texture.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_texture.h
@@ -104,7 +104,7 @@ public:
             glBindTexture(target_, id_);
 
             const char* extension_string = (const char*)glGetString(GL_EXTENSIONS);
-            if(strstr(extension_string, "GL_EXT_texture_filter_anisotropic")) {
+            if(nullptr != extension_string && strstr(extension_string, "GL_EXT_texture_filter_anisotropic")) {
                 GLfloat anisotropic_level;
 
                 glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &anisotropic_level);


### PR DESCRIPTION
A crash Yufi encountered in her app.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>