### PR TITLE
Fixing monoscopic gl and day dream backend 

### DIFF
--- a/GVRf/Framework/backend_monoscopic/src/main/java/org/gearvrf/MonoscopicViewManager.java
+++ b/GVRf/Framework/backend_monoscopic/src/main/java/org/gearvrf/MonoscopicViewManager.java
@@ -334,10 +334,9 @@ class MonoscopicViewManager extends GVRViewManager implements MonoscopicRotation
 
     GVRRenderTarget getRenderTarget(){
         if(mRenderTarget[0] == null) {
-            mRenderTarget[0] = new GVRRenderTarget(new GVRRenderTexture(getActivity().getGVRContext(),
-                    mViewportWidth, mViewportHeight, sampleCount), getMainScene());
-
             if(isVulkanInstance) {
+                mRenderTarget[0] = new GVRRenderTarget(new GVRRenderTexture(getActivity().getGVRContext(),
+                        mViewportWidth, mViewportHeight, sampleCount), getMainScene());
                 mRenderTarget[1] = new GVRRenderTarget(new GVRRenderTexture(getActivity().getGVRContext(),
                         mViewportWidth, mViewportHeight, sampleCount), getMainScene());
                 mRenderTarget[2] = new GVRRenderTarget(new GVRRenderTexture(getActivity().getGVRContext(),
@@ -346,6 +345,9 @@ class MonoscopicViewManager extends GVRViewManager implements MonoscopicRotation
                 mRenderBundle.addRenderTarget(mRenderTarget[0], GVRViewManager.EYE.LEFT, 0);
                 mRenderBundle.addRenderTarget(mRenderTarget[1], GVRViewManager.EYE.LEFT, 1);
                 mRenderBundle.addRenderTarget(mRenderTarget[2], GVRViewManager.EYE.LEFT, 2);
+            }
+            else{
+                mRenderTarget[0] = new GVRRenderTarget(getActivity().getGVRContext());
             }
         }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/components/render_target.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/render_target.cpp
@@ -47,6 +47,9 @@ RenderTarget::RenderTarget(RenderTexture* tex, bool is_multiview)
     }
 }
 void RenderTarget::beginRendering(Renderer *renderer) {
+    if(mRenderTexture == nullptr)
+        return;
+
     mRenderTexture->useStencil(renderer->useStencilBuffer());
     mRenderState.viewportWidth = mRenderTexture->width();
     mRenderState.viewportHeight = mRenderTexture->height();
@@ -60,6 +63,8 @@ void RenderTarget::beginRendering(Renderer *renderer) {
     mRenderTexture->beginRendering(renderer);
 }
 void RenderTarget::endRendering(Renderer *renderer) {
+    if(mRenderTexture == nullptr)
+        return;
     mRenderTexture->endRendering(renderer);
 }
 RenderTarget::RenderTarget(Scene* scene)


### PR DESCRIPTION
No render textures are created for monoscopic GL and day dream backend therefore adding checks at begin and end rendering.

GearVRF DCO signed off by: Abhijit Jagdale a.jagdale@samsung.com


