### PR TITLE
Constraints API refactor

### DIFF
--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRConeTwistConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRConeTwistConstraint.java
@@ -22,16 +22,17 @@ import org.gearvrf.GVRContext;
  */
 
 /**
- * Represents a constraint for two {@linkplain GVRRigidBody bodies} in which the first one (the
- * owner) swings constrained to a right circular conic trajectory around a vortex while the other
- * body is simply fixed to this vortex (meaning that the vortex will move if the second body moves).
+ * Represents a constraint between two {@linkplain GVRRigidBody bodies} in which the first one
+ * swings constrained to a right circular conic trajectory around a vortex while the other body
+ * is simply fixed to this vortex (meaning that the vortex will move if the second body moves).
  */
 public class GVRConeTwistConstraint extends GVRConstraint {
     /**
      * Construct a new instance of a conic twist constraint.
      *
      * @param gvrContext the context of the app
-     * @param rigidBodyB the second rigid body (not the owner) in this constraint
+     * @param rigidBodyA the first rigid body in this constraint
+     * @param rigidBodyB the second rigid body in this constraint
      * @param vortex the vortex position (x, y and z coordinates) of the conic swing relative to
      *               first body (the owner)
      * @param bodyRotation a vector containing the elements of the 3x3 rotation matrix for the
@@ -39,10 +40,11 @@ public class GVRConeTwistConstraint extends GVRConstraint {
      * @param coneRotation a vector containing the elements of the 3x3 rotation matrix for the conic
      *                     trajectory
      */
-    public GVRConeTwistConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyB, final float vortex[],
-                           final float bodyRotation[], final float coneRotation[]) {
-        super(gvrContext, Native3DConeTwistConstraint.ctor(rigidBodyB.getNative(), vortex,
-                bodyRotation, coneRotation));
+    public GVRConeTwistConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
+                                  GVRRigidBody rigidBodyB, final float vortex[],
+                                  final float bodyRotation[], final float coneRotation[]) {
+        super(gvrContext, Native3DConeTwistConstraint.ctor(rigidBodyA.getNative(),
+                rigidBodyB.getNative(), vortex, bodyRotation, coneRotation));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
@@ -88,8 +90,8 @@ public class GVRConeTwistConstraint extends GVRConstraint {
 }
 
 class Native3DConeTwistConstraint {
-    static native long ctor(long rigidBody, final float pivot[], final float bodyRotation[],
-                            final float coneRotation[]);
+    static native long ctor(long rigidBodyA, long rigidBodyB, final float pivot[],
+                            final float bodyRotation[], final float coneRotation[]);
 
     static native void setSwingLimit(long jconstraint, float limit);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRConeTwistConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRConeTwistConstraint.java
@@ -43,13 +43,15 @@ public class GVRConeTwistConstraint extends GVRConstraint {
     public GVRConeTwistConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
                                   GVRRigidBody rigidBodyB, final float vortex[],
                                   final float bodyRotation[], final float coneRotation[]) {
-        super(gvrContext, Native3DConeTwistConstraint.ctor(rigidBodyA.getNative(),
-                rigidBodyB.getNative(), vortex, bodyRotation, coneRotation));
+        super(gvrContext, rigidBodyA, rigidBodyB,
+                Native3DConeTwistConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative(),
+                        vortex, bodyRotation, coneRotation));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
-    GVRConeTwistConstraint(GVRContext gvrContext, long nativeConstraint) {
-        super(gvrContext, nativeConstraint);
+    GVRConeTwistConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA, GVRRigidBody rigidBodyB,
+                           long nativeConstraint) {
+        super(gvrContext, rigidBodyA, rigidBodyB, nativeConstraint);
     }
 
     /**

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRConstraint.java
@@ -16,6 +16,7 @@
 package org.gearvrf.physics;
 
 import org.gearvrf.GVRContext;
+import org.gearvrf.GVRHybridObject;
 
 import java.util.List;
 
@@ -23,11 +24,10 @@ import java.util.List;
  * Base class to represent a constraint for the movement of two
  * {@linkplain GVRRigidBody rigid bodies}.
  * <p>
- * After created anf fully configured a constraint must be attached to a
- * {@linkplain org.gearvrf.GVRSceneObject scene object} containing a rigid body that will become
- * the owner of this constraint (body A).
+ * After created anf fully configured a constraint must be
+ * {@linkplain GVRWorld#addConstraint(GVRConstraint)} added to the world.
  */
-abstract class GVRConstraint extends GVRPhysicsWorldObject {
+abstract class GVRConstraint extends GVRHybridObject {
 
     static final int fixedConstraintId = 1;
     static final int point2pointConstraintId = 2;
@@ -42,20 +42,6 @@ abstract class GVRConstraint extends GVRPhysicsWorldObject {
 
     protected GVRConstraint(GVRContext gvrContext, long nativePointer, List<NativeCleanupHandler> cleanupHandlers) {
         super(gvrContext, nativePointer, cleanupHandlers);
-    }
-
-    @Override
-    protected void addToWorld(GVRWorld world) {
-        if (world != null) {
-            world.addConstraint(this);
-        }
-    }
-
-    @Override
-    protected void removeFromWorld(GVRWorld world) {
-        if (world != null) {
-            world.removeConstraint(this);
-        }
     }
 
     /**
@@ -76,17 +62,18 @@ abstract class GVRConstraint extends GVRPhysicsWorldObject {
         return Native3DConstraint.getBreakingImpulse(getNative());
     }
 
-    static public long getComponentType() {
-        return Native3DConstraint.getComponentType();
+    /** Used only by {@link GVRPhysicsLoader} to avoid the constraint being deleted */
+    void mark() {
+        Native3DConstraint.mark(getNative());
     }
 }
 
 class Native3DConstraint {
-    static native long getComponentType();
-
     static native int getConstraintType(long nativeConstraint);
 
     static native void setBreakingImpulse(long nativeConstraint, float impulse);
 
     static native float getBreakingImpulse(long nativeConstraint);
+
+    static native void mark(long nativeConstraint);
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRConstraint.java
@@ -23,9 +23,6 @@ import java.util.List;
 /**
  * Base class to represent a constraint for the movement of two
  * {@linkplain GVRRigidBody rigid bodies}.
- * <p>
- * After created anf fully configured a constraint must be
- * {@linkplain GVRWorld#addConstraint(GVRConstraint)} added to the world.
  */
 abstract class GVRConstraint extends GVRHybridObject {
 
@@ -36,16 +33,31 @@ abstract class GVRConstraint extends GVRHybridObject {
     static final int coneTwistConstraintId = 5;
     static final int genericConstraintId = 6;
 
-    protected GVRConstraint(GVRContext gvrContext, long nativePointer) {
-        super(gvrContext, nativePointer);
+    private final GVRRigidBody mBodyA, mBodyB;
+
+    private boolean mIsEnabled;
+
+    private String mName;
+
+    protected GVRConstraint(GVRContext gvrContext, GVRRigidBody bodyA, GVRRigidBody bodyB,
+                            long nativePointer) {
+        this(gvrContext, bodyA, bodyB, nativePointer, null);
+
     }
 
-    protected GVRConstraint(GVRContext gvrContext, long nativePointer, List<NativeCleanupHandler> cleanupHandlers) {
+    protected GVRConstraint(GVRContext gvrContext, GVRRigidBody bodyA, GVRRigidBody bodyB,
+                            long nativePointer, List<NativeCleanupHandler> cleanupHandlers) {
         super(gvrContext, nativePointer, cleanupHandlers);
+
+        mBodyA = bodyA;
+        mBodyB = bodyB;
+        mBodyA.addConstraint(this);
+        mBodyB.addConstraint(this);
+        mIsEnabled = true;
     }
 
     /**
-     * Sets the breaking impulse for a constraint.
+     * Set the breaking impulse for a constraint.
      *
      * @param impulse the breaking impulse value.
      */
@@ -54,12 +66,79 @@ abstract class GVRConstraint extends GVRHybridObject {
     }
 
     /**
-     * Gets the breaking impulse for a constraint.
+     * Get the breaking impulse for a constraint.
      *
      * @return the breaking impulse value for the constraint.
      */
     public float getBreakingImpulse() {
         return Native3DConstraint.getBreakingImpulse(getNative());
+    }
+
+    /**
+     * Set a name for this constraint.
+     *
+     * @param name The name of the constraint.
+     */
+    public void setName(String name) {
+        mName = name;
+    }
+
+    /**
+     *  Get the name of the constraint.
+     *
+     * @return the name of the constraint (null if no name was set).
+     */
+    public String getName() {
+        return mName;
+    }
+
+    /**
+     * Enable the constraint so it will be active in the scene.
+     */
+    public void enable() {
+        if (!mIsEnabled) {
+            mBodyA.addConstraint(this);
+            mBodyB.addConstraint(this);
+            mIsEnabled = true;
+        }
+    }
+
+    /**
+     * Disable the constraint so it will not be active in the scene.
+     */
+    public void disable() {
+        if (mIsEnabled) {
+            mBodyA.removeConstraint(this);
+            mBodyB.removeConstraint(this);
+            mIsEnabled = false;
+        }
+    }
+
+    /**
+     * Get the enable/disable status for the constraint.
+     *
+     * @return true if constraint is enabled, false if constraint is disabled.
+     */
+    public boolean isEnabled() {
+        return mIsEnabled;
+    }
+
+    /**
+     * Get the first rigid body linked by this constraint.
+     *
+     * @return linked rigid body.
+     */
+    public GVRRigidBody getBodyA() {
+        return mBodyA;
+    }
+
+    /**
+     * Get the second rigid body linked by this constraint.
+     *
+     * @return linked rigid body.
+     */
+    public GVRRigidBody getBodyB() {
+        return mBodyB;
     }
 
     /** Used only by {@link GVRPhysicsLoader} to avoid the constraint being deleted */

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRFixedConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRFixedConstraint.java
@@ -27,10 +27,12 @@ public class GVRFixedConstraint extends GVRConstraint {
      * Constructs new instance of fixed constraint.
      *
      * @param gvrContext the context of the app
-     * @param rigidBodyB the second rigid body (not the owner) in this constraint
+     * @param rigidBodyA the first rigid body in this constraints
+     * @param rigidBodyB the second rigid body in this constraint
      */
-    public GVRFixedConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyB) {
-        super(gvrContext, Native3DFixedConstraint.ctor(rigidBodyB.getNative()));
+    public GVRFixedConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
+                              GVRRigidBody rigidBodyB) {
+        super(gvrContext, Native3DFixedConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative()));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
@@ -40,5 +42,5 @@ public class GVRFixedConstraint extends GVRConstraint {
 }
 
 class Native3DFixedConstraint {
-    static native long ctor( long rbB);
+    static native long ctor(long rbA, long rbB);
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRFixedConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRFixedConstraint.java
@@ -16,6 +16,7 @@
 package org.gearvrf.physics;
 
 import org.gearvrf.GVRContext;
+import org.gearvrf.GVRSceneObject;
 
 /**
  * Represents a constraint that forces two {@linkplain GVRRigidBody rigid bodies} to keep same
@@ -32,12 +33,14 @@ public class GVRFixedConstraint extends GVRConstraint {
      */
     public GVRFixedConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
                               GVRRigidBody rigidBodyB) {
-        super(gvrContext, Native3DFixedConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative()));
+        super(gvrContext, rigidBodyA, rigidBodyB,
+                Native3DFixedConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative()));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
-    GVRFixedConstraint(GVRContext gvrContext, long nativeConstraint) {
-        super(gvrContext, nativeConstraint);
+    GVRFixedConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA, GVRRigidBody rigidBodyB,
+                       long nativeConstraint) {
+        super(gvrContext, rigidBodyA, rigidBodyB, nativeConstraint);
     }
 }
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRGenericConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRGenericConstraint.java
@@ -46,13 +46,15 @@ public class GVRGenericConstraint extends GVRConstraint {
     public GVRGenericConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
                                 GVRRigidBody rigidBodyB, final float joint[],
                                 final float rotationA[], final float rotationB[]) {
-        super(gvrContext, Native3DGenericConstraint.ctor(rigidBodyA.getNative(),
-                rigidBodyB.getNative(), joint, rotationA, rotationB));
+        super(gvrContext, rigidBodyA, rigidBodyB,
+                Native3DGenericConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative(),
+                        joint, rotationA, rotationB));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
-    GVRGenericConstraint(GVRContext gvrContext, long nativeConstraint) {
-        super(gvrContext, nativeConstraint);
+    GVRGenericConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA, GVRRigidBody rigidBodyB,
+                         long nativeConstraint) {
+        super(gvrContext, rigidBodyA, rigidBodyB, nativeConstraint);
     }
 
     /**

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRGenericConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRGenericConstraint.java
@@ -23,18 +23,19 @@ import org.gearvrf.GVRTransform;
  */
 
 /**
- * Represents a generic constraint for two {@linkplain GVRRigidBody rigid bodies} that are linked by
- * a joint point related to the first one (the owner of the constraint). Though it can be moved the
- * first body can be referred as "fixed" since it will keep same distance and rotation from this
- * joint point while the second is the "moving" because one can explicitly set restriction for each
- * translation and rotation axis.
+ * Represents a generic constraint between two {@linkplain GVRRigidBody rigid bodies} that are
+ * linked by a joint point related to the first one. Though it can be moved the first body can be
+ * referred as "fixed" since it will keep same distance and rotation from this joint point while the
+ * second is the "moving" because one can explicitly set restriction for each translation and
+ * rotation axis.
  */
 public class GVRGenericConstraint extends GVRConstraint {
     /**
      * Construct a new instance of a generic constraint.
      *
      * @param gvrContext the context of the app
-     * @param rigidBodyB the "moving" body (not the owner) in this constraint
+     * @param rigidBodyA the "fixed" body in this constraint
+     * @param rigidBodyB the "moving" body in this constraint
      * @param joint the joint point (x, y and z coordinates) in this constraint relative to "fixed"
      *              body
      * @param rotationA the rotation of the constraint (an array containing the elements of 3x3
@@ -42,9 +43,10 @@ public class GVRGenericConstraint extends GVRConstraint {
      * @param rotationB the rotation of the constraint (an array containing the elements of 3x3
      *                  rotation matrix) related to "moving" body
      */
-    public GVRGenericConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyB, final float joint[],
+    public GVRGenericConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
+                                GVRRigidBody rigidBodyB, final float joint[],
                                 final float rotationA[], final float rotationB[]) {
-        super(gvrContext, Native3DGenericConstraint.ctor(
+        super(gvrContext, Native3DGenericConstraint.ctor(rigidBodyA.getNative(),
                 rigidBodyB.getNative(), joint, rotationA, rotationB));
     }
 
@@ -135,8 +137,8 @@ public class GVRGenericConstraint extends GVRConstraint {
 }
 
 class Native3DGenericConstraint {
-    static native long ctor(long rigidBodyB, final float joint[], final float rotationA[],
-                            final float rotationB[]);
+    static native long ctor(long rigidBodyA, long rigidBodyB, final float joint[],
+                            final float rotationA[], final float rotationB[]);
 
     static native void setLinearLowerLimits(long jconstr, float limX, float limY, float limZ);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRHingeConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRHingeConstraint.java
@@ -41,13 +41,15 @@ public class GVRHingeConstraint extends GVRConstraint {
     public GVRHingeConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
                               GVRRigidBody rigidBodyB, float pivotInA[], float pivotInB[],
                               float axisInA[], float axisInB[]) {
-        super(gvrContext, Native3DHingeConstraint.ctor(rigidBodyA.getNative(),
-                rigidBodyB.getNative(), pivotInA, pivotInB, axisInA, axisInB));
+        super(gvrContext, rigidBodyA, rigidBodyB,
+                Native3DHingeConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative(),
+                        pivotInA, pivotInB, axisInA, axisInB));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
-    GVRHingeConstraint(GVRContext gvrContext, long nativeConstraint) {
-        super(gvrContext, nativeConstraint);
+    GVRHingeConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA, GVRRigidBody rigidBodyB,
+                       long nativeConstraint) {
+        super(gvrContext, rigidBodyA, rigidBodyB, nativeConstraint);
     }
 
     /**

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRHingeConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRHingeConstraint.java
@@ -31,16 +31,18 @@ public class GVRHingeConstraint extends GVRConstraint {
      * Constructs a new instance of hinge constraint.
      *
      * @param gvrContext the context of the app
-     * @param rigidBodyB the second rigid body (not the owner) in this constraint
+     * @param rigidBodyA the first rigid body in this constraint
+     * @param rigidBodyB the second rigid body in this constraint
      * @param pivotInA the pivot point related to body A (the owner)
      * @param pivotInB the pivot point related to body B
      * @param axisInA the axis around which body A can rotate
      * @param axisInB the axis around which body B can rotate
      */
-    public GVRHingeConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyB, float pivotInA[],
-                                 float pivotInB[], float axisInA[], float axisInB[]) {
-        super(gvrContext, Native3DHingeConstraint.ctor(rigidBodyB.getNative(), pivotInA, pivotInB,
-                axisInA, axisInB));
+    public GVRHingeConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
+                              GVRRigidBody rigidBodyB, float pivotInA[], float pivotInB[],
+                              float axisInA[], float axisInB[]) {
+        super(gvrContext, Native3DHingeConstraint.ctor(rigidBodyA.getNative(),
+                rigidBodyB.getNative(), pivotInA, pivotInB, axisInA, axisInB));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
@@ -79,7 +81,7 @@ public class GVRHingeConstraint extends GVRConstraint {
 }
 
 class Native3DHingeConstraint {
-    static native long ctor(long rbB, float pivotInA[], float pivotInB[], float axisInA[],
+    static native long ctor(long rbA, long rbB, float pivotInA[], float pivotInB[], float axisInA[],
                             float axisInB[]);
 
     static native void setLimits(long nativeConstraint, float lower, float upper);

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
@@ -15,13 +15,18 @@
 
 package org.gearvrf.physics;
 
-import android.content.res.AssetManager;
 import android.util.ArrayMap;
 import android.util.Log;
 
+import org.gearvrf.GVRAndroidResource;
 import org.gearvrf.GVRContext;
+import org.gearvrf.GVRResourceVolume;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 public class GVRPhysicsLoader {
     static private final String TAG = GVRPhysicsLoader.class.getSimpleName();
@@ -31,7 +36,7 @@ public class GVRPhysicsLoader {
     }
 
     /**
-     * Loads a physics settings file from 'assets' directory of the application.
+     * Loads a physics settings file.
      *
      * @param gvrContext The context of the app.
      * @param fileName Physics settings file name.
@@ -42,7 +47,7 @@ public class GVRPhysicsLoader {
     }
 
     /**
-     * Loads a physics settings file from 'assets' directory of the application.
+     * Loads a physics settings file.
      *
      * Use this if you want the up-axis information from physics file to be ignored.
      *
@@ -52,7 +57,24 @@ public class GVRPhysicsLoader {
      * @param scene The scene containing the objects to attach physics components.
      */
     public static void loadPhysicsFile(GVRContext gvrContext, String fileName, boolean ignoreUpAxis, GVRScene scene) {
-        long loader = NativePhysics3DLoader.ctor(fileName, ignoreUpAxis, gvrContext.getActivity().getAssets());
+        byte[] inputData = null;
+        try {
+            inputData = toByteArray(toAndroidResource(gvrContext, fileName));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        if (inputData == null || inputData.length == 0) {
+            Log.e(TAG, "Fail to load bullet file " + fileName);
+            return;
+        }
+
+        long loader = NativePhysics3DLoader.ctor(inputData, inputData.length, ignoreUpAxis);
+
+        if (loader == 0) {
+            Log.e(TAG, "Fail to parse bullet file " + fileName);
+            return;
+        }
 
         GVRSceneObject sceneRoot = scene.getRoot();
         ArrayMap<Long, GVRSceneObject> rbObjects = new ArrayMap<>();
@@ -108,10 +130,33 @@ public class GVRPhysicsLoader {
         NativePhysics3DLoader.delete(loader);
     }
 
+    private static byte[] toByteArray(GVRAndroidResource resource) throws IOException {
+        resource.openStream();
+        InputStream is = resource.getStream();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        for (int read; (read = is.read(buffer, 0, buffer.length)) != -1; ) {
+            baos.write(buffer, 0, read);
+        }
+        baos.flush();
+        resource.closeStream();
+        return  baos.toByteArray();
+    }
+
+    private static GVRAndroidResource toAndroidResource(GVRContext context, String fileName) throws IOException {
+        GVRResourceVolume resVol = new GVRResourceVolume(context, fileName);
+
+        final int i = fileName.lastIndexOf("/");
+        if (i > 0) {
+            fileName = fileName.substring(i + 1);
+        }
+
+        return resVol.openResource(fileName);
+    }
 }
 
 class NativePhysics3DLoader {
-    static native long ctor(String file_name, boolean ignoreUpAxis, AssetManager assetManager);
+    static native long ctor(byte[] bytes, int len, boolean ignoreUpAxis);
 
     static native long delete(long loader);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
@@ -58,7 +58,8 @@ public class GVRPhysicsLoader {
      * @param ignoreUpAxis Set to true if up-axis information from file must be ignored.
      * @param scene The scene containing the objects to attach physics components.
      */
-    public static void loadPhysicsFile(GVRContext gvrContext, String fileName, boolean ignoreUpAxis, GVRScene scene) {
+    public static void loadPhysicsFile(GVRContext gvrContext, String fileName, boolean ignoreUpAxis,
+                                       GVRScene scene) {
         byte[] inputData = null;
         try {
             inputData = toByteArray(toAndroidResource(gvrContext, fileName));
@@ -100,9 +101,6 @@ public class GVRPhysicsLoader {
             rbObjects.put(nativeRigidBody, sceneObject);
         }
 
-
-        GVRWorld world = (GVRWorld)sceneRoot.getComponent(GVRWorld.getComponentType());
-
         long nativeConstraint;
         long nativeRigidBodyB;
         while ((nativeConstraint = NativePhysics3DLoader.getNextConstraint(loader)) != 0) {
@@ -117,27 +115,27 @@ public class GVRPhysicsLoader {
                 continue;
             }
 
+            GVRRigidBody rbA =(GVRRigidBody)sceneObject.getComponent(GVRRigidBody.getComponentType());
+            GVRRigidBody rbB =(GVRRigidBody)sceneObjectB.getComponent(GVRRigidBody.getComponentType());
             int constraintType = Native3DConstraint.getConstraintType(nativeConstraint);
             GVRConstraint constraint = null;
             if (constraintType == GVRConstraint.fixedConstraintId) {
-                constraint = new GVRFixedConstraint(gvrContext, nativeConstraint);
+                constraint = new GVRFixedConstraint(gvrContext, rbA, rbB, nativeConstraint);
             } else if (constraintType == GVRConstraint.point2pointConstraintId) {
-                constraint = new GVRPoint2PointConstraint(gvrContext, nativeConstraint);
+                constraint = new GVRPoint2PointConstraint(gvrContext, rbA, rbB, nativeConstraint);
             } else if (constraintType == GVRConstraint.sliderConstraintId) {
-                constraint = new GVRSliderConstraint(gvrContext, nativeConstraint);
+                constraint = new GVRSliderConstraint(gvrContext, rbA, rbB, nativeConstraint);
             } else if (constraintType == GVRConstraint.hingeConstraintId) {
-                constraint = new GVRHingeConstraint(gvrContext, nativeConstraint);
+                constraint = new GVRHingeConstraint(gvrContext, rbA, rbB, nativeConstraint);
             } else if (constraintType == GVRConstraint.coneTwistConstraintId) {
-                constraint = new GVRConeTwistConstraint(gvrContext, nativeConstraint);
+                constraint = new GVRConeTwistConstraint(gvrContext, rbA, rbB, nativeConstraint);
             } else if (constraintType == GVRConstraint.genericConstraintId) {
-                constraint = new GVRGenericConstraint(gvrContext, nativeConstraint);
+                constraint = new GVRGenericConstraint(gvrContext, rbA, rbB, nativeConstraint);
             }
 
             if (constraint != null) {
                 // Mark this constraint so it will not be deleted
                 constraint.mark();
-
-                world.addConstraint(constraint);
             }
         }
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
@@ -19,7 +19,9 @@ import android.util.ArrayMap;
 import android.util.Log;
 
 import org.gearvrf.GVRAndroidResource;
+import org.gearvrf.GVRCollider;
 import org.gearvrf.GVRContext;
+import org.gearvrf.GVRMeshCollider;
 import org.gearvrf.GVRResourceVolume;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
@@ -85,11 +87,17 @@ public class GVRPhysicsLoader {
             GVRSceneObject sceneObject = sceneRoot.getSceneObjectByName(name);
             if (sceneObject == null) {
                 Log.d(TAG, "Did not found scene object for rigid body '" + name + "'");
-            } else {
-                GVRRigidBody rigidBody = new GVRRigidBody(gvrContext, nativeRigidBody);
-                sceneObject.attachComponent(rigidBody);
-                rbObjects.put(nativeRigidBody, sceneObject);
+                continue;
             }
+
+            if (sceneObject.getComponent(GVRCollider.getComponentType()) == null) {
+                // Set mesh collider as default.
+                sceneObject.attachComponent(new GVRMeshCollider(gvrContext, true));
+            }
+
+            GVRRigidBody rigidBody = new GVRRigidBody(gvrContext, nativeRigidBody);
+            sceneObject.attachComponent(rigidBody);
+            rbObjects.put(nativeRigidBody, sceneObject);
         }
 
         long nativeConstraint;

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
@@ -100,6 +100,9 @@ public class GVRPhysicsLoader {
             rbObjects.put(nativeRigidBody, sceneObject);
         }
 
+
+        GVRWorld world = (GVRWorld)sceneRoot.getComponent(GVRWorld.getComponentType());
+
         long nativeConstraint;
         long nativeRigidBodyB;
         while ((nativeConstraint = NativePhysics3DLoader.getNextConstraint(loader)) != 0) {
@@ -131,7 +134,10 @@ public class GVRPhysicsLoader {
             }
 
             if (constraint != null) {
-                sceneObject.attachComponent(constraint);
+                // Mark this constraint so it will not be deleted
+                constraint.mark();
+
+                world.addConstraint(constraint);
             }
         }
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPoint2PointConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPoint2PointConstraint.java
@@ -31,14 +31,16 @@ public class GVRPoint2PointConstraint extends GVRConstraint {
      * Constructs new instance of point-to-point constraint.
      *
      * @param gvrContext the context of the app
-     * @param rigidBodyB the second rigid body (not the owner) in this constraint
-     * @param pivotInA the pivot point (x, y and z coordinates) related to body A (the owner)
+     * @param rigidBodyA the first rigid body in this constraint
+     * @param rigidBodyB the second rigid body in this constraint
+     * @param pivotInA the pivot point (x, y and z coordinates) related to body A
      * @param pivotInB the pivot point related to body B
      */
-    public GVRPoint2PointConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyB,
-                                    float pivotInA[], float pivotInB[]) {
+    public GVRPoint2PointConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
+                                    GVRRigidBody rigidBodyB, float pivotInA[], float pivotInB[]) {
         super(gvrContext,
-                Native3DPoint2PointConstraint.ctor(rigidBodyB.getNative(), pivotInA, pivotInB));
+                Native3DPoint2PointConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative(),
+                        pivotInA, pivotInB));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
@@ -84,7 +86,7 @@ public class GVRPoint2PointConstraint extends GVRConstraint {
 }
 
 class Native3DPoint2PointConstraint {
-    static native long ctor(long rbB, float pivotInA[], float pivotInB[]);
+    static native long ctor(long rbA, long rbB, float pivotInA[], float pivotInB[]);
 
     static native void setPivotInA(long nativeConstraint, float x, float y, float z);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPoint2PointConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPoint2PointConstraint.java
@@ -38,14 +38,15 @@ public class GVRPoint2PointConstraint extends GVRConstraint {
      */
     public GVRPoint2PointConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
                                     GVRRigidBody rigidBodyB, float pivotInA[], float pivotInB[]) {
-        super(gvrContext,
+        super(gvrContext, rigidBodyA, rigidBodyB,
                 Native3DPoint2PointConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative(),
                         pivotInA, pivotInB));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
-    GVRPoint2PointConstraint(GVRContext gvrContext, long nativeConstraint) {
-        super(gvrContext, nativeConstraint);
+    GVRPoint2PointConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
+                             GVRRigidBody rigidBodyB, long nativeConstraint) {
+        super(gvrContext, rigidBodyA, rigidBodyB, nativeConstraint);
     }
 
     /**

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRRigidBody.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRRigidBody.java
@@ -20,6 +20,8 @@ import org.gearvrf.GVRContext;
 import org.gearvrf.GVRRenderData;
 import org.gearvrf.GVRSceneObject;
 
+import java.util.ArrayList;
+
 /**
  * Represents a rigid body that can be static or dynamic. You can set a mass and apply some
  * physics forces.

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRSliderConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRSliderConstraint.java
@@ -36,13 +36,14 @@ public class GVRSliderConstraint extends GVRConstraint {
      */
     public GVRSliderConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
                                GVRRigidBody rigidBodyB) {
-        super(gvrContext,
+        super(gvrContext, rigidBodyA, rigidBodyB,
                 Native3DSliderConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative()));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
-    GVRSliderConstraint(GVRContext gvrContext, long nativeConstraint) {
-        super(gvrContext, nativeConstraint);
+    GVRSliderConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA, GVRRigidBody rigidBodyB,
+                        long nativeConstraint) {
+        super(gvrContext, rigidBodyA, rigidBodyB, nativeConstraint);
     }
 
     /**

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRSliderConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRSliderConstraint.java
@@ -31,10 +31,13 @@ public class GVRSliderConstraint extends GVRConstraint {
      * Constructs a new instance of a slider constraint.
      *
      * @param gvrContext the context of the app
-     * @param rigidBody the second rigid body (not the owner) in this constraint.
+     * @param rigidBodyA the first rigid body in this constraint.
+     * @param rigidBodyB the second rigid body in this constraint.
      */
-    public GVRSliderConstraint(GVRContext gvrContext, GVRRigidBody rigidBody) {
-        super(gvrContext, Native3DSliderConstraint.ctor(rigidBody.getNative()));
+    public GVRSliderConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
+                               GVRRigidBody rigidBodyB) {
+        super(gvrContext,
+                Native3DSliderConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative()));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
@@ -117,7 +120,7 @@ public class GVRSliderConstraint extends GVRConstraint {
 
 
 class Native3DSliderConstraint {
-    static native long ctor(long rbB);
+    static native long ctor(long rbA, long rbB);
 
     static native void setAngularLowerLimit(long nativeConstraint, float limit);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRSliderConstraint.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRSliderConstraint.java
@@ -31,13 +31,18 @@ public class GVRSliderConstraint extends GVRConstraint {
      * Constructs a new instance of a slider constraint.
      *
      * @param gvrContext the context of the app
-     * @param rigidBodyA the first rigid body in this constraint.
-     * @param rigidBodyB the second rigid body in this constraint.
+     * @param rigidBodyA the first rigid body in this constraint
+     * @param rigidBodyB the second rigid body in this constraint
+     * @param rotationA the rotation of the constraint (an array containing the elements of 3x3
+     *                  rotation matrix) related to body A
+     * @param rotationB the rotation of the constraint (an array containing the elements of 3x3
+     *                  rotation matrix) related to body B
      */
     public GVRSliderConstraint(GVRContext gvrContext, GVRRigidBody rigidBodyA,
-                               GVRRigidBody rigidBodyB) {
+                               GVRRigidBody rigidBodyB, float[] rotationA, float[] rotationB) {
         super(gvrContext, rigidBodyA, rigidBodyB,
-                Native3DSliderConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative()));
+                Native3DSliderConstraint.ctor(rigidBodyA.getNative(), rigidBodyB.getNative(),
+                        rotationA, rotationB));
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
@@ -121,7 +126,7 @@ public class GVRSliderConstraint extends GVRConstraint {
 
 
 class Native3DSliderConstraint {
-    static native long ctor(long rbA, long rbB);
+    static native long ctor(long rbA, long rbB, final float[] rotationA, final float[] rotationB);
 
     static native void setAngularLowerLimit(long nativeConstraint, float limit);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRWorld.java
@@ -43,7 +43,8 @@ public class GVRWorld extends GVRComponent {
         System.loadLibrary("gvrf-physics");
     }
 
-    private final LongSparseArray<GVRRigidBody> mRigidBodies = new LongSparseArray<GVRRigidBody>();
+    private final LongSparseArray<GVRRigidBody> mRigidBodies = new LongSparseArray<>();
+    private final LongSparseArray<GVRConstraint> mConstraints = new LongSparseArray<>();
     private final GVRCollisionMatrix mCollisionMatrix;
 
     /**
@@ -104,7 +105,13 @@ public class GVRWorld extends GVRComponent {
         mPhysicsContext.runOnPhysicsThread(new Runnable() {
             @Override
             public void run() {
+                if (contains(gvrConstraint)) {
+                    return;
+                }
+
                 NativePhysics3DWorld.addConstraint(getNative(), gvrConstraint.getNative());
+
+                mConstraints.put(gvrConstraint.getNative(), gvrConstraint);
             }
         });
     }
@@ -118,7 +125,10 @@ public class GVRWorld extends GVRComponent {
         mPhysicsContext.runOnPhysicsThread(new Runnable() {
             @Override
             public void run() {
-                NativePhysics3DWorld.removeConstraint(getNative(), gvrConstraint.getNative());
+                if (contains(gvrConstraint)) {
+                    NativePhysics3DWorld.removeConstraint(getNative(), gvrConstraint.getNative());
+                    mConstraints.remove(gvrConstraint.getNative());
+                }
             }
         });
     }
@@ -131,6 +141,10 @@ public class GVRWorld extends GVRComponent {
      */
     public boolean contains(GVRRigidBody rigidBody) {
         return mRigidBodies.get(rigidBody.getNative()) != null;
+    }
+
+    public boolean contains(GVRConstraint constraint) {
+        return mConstraints.get(constraint.getNative()) != null;
     }
 
     /**

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_conetwistconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_conetwistconstraint.h
@@ -32,9 +32,9 @@ namespace gvr {
 
     class BulletConeTwistConstraint : public PhysicsConeTwistConstraint, BulletObject {
     public:
-        explicit BulletConeTwistConstraint(PhysicsRigidBody *rigidBodyB, PhysicsVec3 pivot,
-                                           PhysicsMat3x3 const &bodyRotation,
-                                           PhysicsMat3x3 const &coneRotation);
+        explicit BulletConeTwistConstraint(PhysicsRigidBody *rigidBodyA,
+                PhysicsRigidBody *rigidBodyB, PhysicsVec3 pivot, PhysicsMat3x3 const &bodyRotation,
+                PhysicsMat3x3 const &coneRotation);
 
         BulletConeTwistConstraint(btConeTwistConstraint *constraint);
 
@@ -60,15 +60,6 @@ namespace gvr {
     private:
 
         btConeTwistConstraint *mConeTwistConstraint;
-        BulletRigidBody *mRigidBodyB;
-
-        float mBreakingImpulse;
-        PhysicsVec3 mPivot;
-        PhysicsMat3x3 mBodyRotation;
-        PhysicsMat3x3 mConeRotation;
-
-        float mSwingLimit;
-        float mTwistLimit;
     };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fileloader.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fileloader.cpp
@@ -254,8 +254,8 @@ BulletFileLoader::~BulletFileLoader()
         PhysicsConstraint *phcons = static_cast<PhysicsConstraint*>(constraint->getUserConstraintPtr());
         if (nullptr != phcons && ((PhysicsConstraint*)-1) != phcons)
         {
-            // Constraint is valid, but was it attached?
-            if (nullptr != phcons->owner_object())
+            // Constraint is valid, but was it added?
+            if (phcons->marked)
             {
                 continue;
             }
@@ -270,7 +270,8 @@ BulletFileLoader::~BulletFileLoader()
         }
     }
 
-    for (i = 0; i < mImporter->getNumRigidBodies(); i++) {
+    for (i = 0; i < mImporter->getNumRigidBodies(); i++)
+    {
         btRigidBody *rb = static_cast<btRigidBody*>(mImporter->getRigidBodyByIndex(i));
         BulletRigidBody *brb = static_cast<BulletRigidBody*>(rb->getUserPointer());
         if (nullptr != brb)

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fixedconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fixedconstraint.h
@@ -31,7 +31,7 @@ namespace gvr {
                                          BulletObject  {
 
     public:
-        explicit BulletFixedConstraint(PhysicsRigidBody* rigidBodyB);
+        explicit BulletFixedConstraint(PhysicsRigidBody* rigidBodyA, PhysicsRigidBody* rigidBodyB);
 
         BulletFixedConstraint(btFixedConstraint *constraint);
 
@@ -49,9 +49,6 @@ namespace gvr {
 
     private:
         btFixedConstraint *mFixedConstraint;
-        BulletRigidBody *mRigidBodyB; //this is A
-
-        float mBreakingImpulse;
     };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_generic6dofconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_generic6dofconstraint.h
@@ -32,8 +32,9 @@ namespace gvr {
 
     class BulletGeneric6dofConstraint : public PhysicsGenericConstraint, BulletObject {
     public:
-        explicit BulletGeneric6dofConstraint(PhysicsRigidBody *rigidBodyB, float const joint[],
-                                             float const rotationA[], float const rotationB[]);
+        explicit BulletGeneric6dofConstraint(PhysicsRigidBody *rigidBodyA,
+                PhysicsRigidBody *rigidBodyB, float const joint[], float const rotationA[],
+                float const rotationB[]);
 
         BulletGeneric6dofConstraint(btGeneric6DofConstraint *constraint);
 
@@ -66,17 +67,6 @@ namespace gvr {
     private:
 
         btGeneric6DofConstraint *mGeneric6DofConstraint;
-        BulletRigidBody *mRigidBodyB;
-
-        float mBreakingImpulse;
-        PhysicsVec3 mLinearLowerLimits;
-        PhysicsVec3 mLinearUpperLimits;
-        PhysicsVec3 mAngularLowerLimits;
-        PhysicsVec3 mAngularUpperLimits;
-
-        PhysicsVec3 mPosition;
-        PhysicsMat3x3 mRotationA;
-        PhysicsMat3x3 mRotationB;
     };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_hingeconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_hingeconstraint.h
@@ -33,9 +33,9 @@ namespace gvr {
                                   BulletObject {
 
     public:
-        explicit BulletHingeConstraint(PhysicsRigidBody *rigidBodyB, float const pivotInA[],
-                                       float const pivotInB[], float const axisInA[],
-                                       float const axisInB[]);
+        explicit BulletHingeConstraint(PhysicsRigidBody *rigidBodyA,
+                PhysicsRigidBody *rigidBodyB, float const pivotInA[], float const pivotInB[],
+                float const axisInA[], float const axisInB[]);
 
         BulletHingeConstraint(btHingeConstraint *constraint);
 
@@ -53,20 +53,8 @@ namespace gvr {
 
         float getBreakingImpulse() const;
 
-        void updateConstructionInfo();
-
     private:
         btHingeConstraint *mHingeConstraint;
-        BulletRigidBody *mRigidBodyB;
-
-        float mBreakingImpulse;
-        float mTempLower;
-        float mTempUpper;
-
-        PhysicsVec3 mPivotInA;
-        PhysicsVec3 mPivotInB;
-        PhysicsVec3 mAxisInA;
-        PhysicsVec3 mAxisInB;
     };
 }
 #endif //EXTENSIONS_BULLET_HINGECONSTRAINT_H

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.cpp
@@ -7,82 +7,62 @@
 #include "bullet_rigidbody.h"
 #include "bullet_world.h"
 
-static const char tag[] = "BulletP2pConstrN";
+static const char tag[] = "BulletP2pConstr";
 
 namespace gvr {
 
-    BulletPoint2PointConstraint::BulletPoint2PointConstraint(PhysicsRigidBody* rigidBodyB,
-            float pivotInA[], float pivotInB[]) {
-        mPoint2PointConstraint = 0;
-        mRigidBodyB = reinterpret_cast<BulletRigidBody*>(rigidBodyB);
-        mBreakingImpulse = SIMD_INFINITY;
-        mPivotInA.set(pivotInA);
-        mPivotInB.set(pivotInB);
+    BulletPoint2PointConstraint::BulletPoint2PointConstraint(PhysicsRigidBody* rigidBodyA,
+            PhysicsRigidBody* rigidBodyB, float pivotInA[], float pivotInB[])
+    {
+        btVector3 pInA(pivotInA[0], pivotInA[1], pivotInA[2]);
+        btVector3 pInB(pivotInB[0], pivotInB[1], pivotInB[2]);
+        btRigidBody *rbA = reinterpret_cast<BulletRigidBody*>(rigidBodyA)->getRigidBody();
+        btRigidBody *rbB = reinterpret_cast<BulletRigidBody*>(rigidBodyB)->getRigidBody();
+
+        mPoint2PointConstraint = new btPoint2PointConstraint(*rbA, *rbB, pInA, pInB);
     };
 
     // This constructor is only used when loading physics from bullet file
-    BulletPoint2PointConstraint::BulletPoint2PointConstraint(btPoint2PointConstraint *constraint) {
+    BulletPoint2PointConstraint::BulletPoint2PointConstraint(btPoint2PointConstraint *constraint)
+    {
         mPoint2PointConstraint = constraint;
-        mRigidBodyB = static_cast<BulletRigidBody*>(constraint->getRigidBodyB().getUserPointer());
         constraint->setUserConstraintPtr(this);
     }
 
-    BulletPoint2PointConstraint::~BulletPoint2PointConstraint() {
-        if (0 != mPoint2PointConstraint) {
-            delete mPoint2PointConstraint;
-        }
+    BulletPoint2PointConstraint::~BulletPoint2PointConstraint()
+    {
+        delete mPoint2PointConstraint;
     };
 
     void BulletPoint2PointConstraint::setPivotInA(PhysicsVec3 pivot)
     {
-        mPivotInA = pivot;
-
         btVector3 p(pivot.x, pivot.y, pivot.z);
         mPoint2PointConstraint->setPivotA(p);
     }
 
+    PhysicsVec3 BulletPoint2PointConstraint::getPivotInA() const
+    {
+        return PhysicsVec3(mPoint2PointConstraint->getPivotInA().m_floats);
+    }
+
     void BulletPoint2PointConstraint::setPivotInB(PhysicsVec3 pivot)
     {
-        mPivotInB = pivot;
-
         btVector3 p(pivot.x, pivot.y, pivot.z);
         mPoint2PointConstraint->setPivotB(p);
     }
 
-    void BulletPoint2PointConstraint::setBreakingImpulse(float impulse) {
-        if (0 != mPoint2PointConstraint) {
-            mPoint2PointConstraint->setBreakingImpulseThreshold(impulse);
-        }
-        else {
-            mBreakingImpulse = impulse;
-        }
+    PhysicsVec3 BulletPoint2PointConstraint::getPivotInB() const
+    {
+        return PhysicsVec3(mPoint2PointConstraint->getPivotInB().m_floats);
     }
 
-    float BulletPoint2PointConstraint::getBreakingImpulse() const {
-        if (0 != mPoint2PointConstraint) {
-            return mPoint2PointConstraint->getBreakingImpulseThreshold();
-        }
-        else {
-            return mBreakingImpulse;
-        }
+    void BulletPoint2PointConstraint::setBreakingImpulse(float impulse)
+    {
+        mPoint2PointConstraint->setBreakingImpulseThreshold(impulse);
     }
 
-
-void BulletPoint2PointConstraint::updateConstructionInfo() {
-//    if (mPoint2PointConstraint != 0) {
-//        delete (mPoint2PointConstraint);
-//    }
-
-    if (mPoint2PointConstraint == nullptr) {
-        btVector3 pivotInA(mPivotInA.x, mPivotInA.y, mPivotInA.z);
-        btVector3 pivotInB(mPivotInB.x, mPivotInB.y, mPivotInB.z);
-        btRigidBody *rbA = ((BulletRigidBody *) owner_object()->
-                getComponent(COMPONENT_TYPE_PHYSICS_RIGID_BODY))->getRigidBody();
-
-        mPoint2PointConstraint = new btPoint2PointConstraint(*rbA, *mRigidBodyB->getRigidBody(),
-                                                             pivotInA, pivotInB);
-        mPoint2PointConstraint->setBreakingImpulseThreshold(mBreakingImpulse);
+    float BulletPoint2PointConstraint::getBreakingImpulse() const
+    {
+        return mPoint2PointConstraint->getBreakingImpulseThreshold();
     }
-}
-
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_point2pointconstraint.h
@@ -31,8 +31,8 @@ namespace gvr {
                                                BulletObject {
 
     public:
-        explicit BulletPoint2PointConstraint(PhysicsRigidBody* rigidBodyB, float pivotInA[],
-                                             float pivotInB[]);
+        explicit BulletPoint2PointConstraint(PhysicsRigidBody *rigidBodyA,
+                PhysicsRigidBody* rigidBodyB, float pivotInA[], float pivotInB[]);
 
         BulletPoint2PointConstraint(btPoint2PointConstraint *constraint);
 
@@ -48,21 +48,14 @@ namespace gvr {
 
         void setPivotInA(PhysicsVec3 pivot);
 
-        PhysicsVec3 getPivotInA() const { return mPivotInA; }
+        PhysicsVec3 getPivotInA() const;
 
         void setPivotInB(PhysicsVec3 pivot);
 
-        PhysicsVec3 getPivotInB() const { return mPivotInB; }
-
-        void updateConstructionInfo();
+        PhysicsVec3 getPivotInB() const;
 
     private:
         btPoint2PointConstraint *mPoint2PointConstraint;
-        BulletRigidBody *mRigidBodyB;
-
-        float mBreakingImpulse;
-        PhysicsVec3 mPivotInA;
-        PhysicsVec3 mPivotInB;
     };
 }
 #endif //BULLET_POINT2POINTCONSTRAINT_H

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.cpp
@@ -67,15 +67,15 @@ void BulletRigidBody::setSimulationType(PhysicsRigidBody::SimulationType type)
         break;
 
         case SimulationType::STATIC:
-        mRigidBody->setCollisionFlags(mRigidBody->getCollisionFlags() |
-                                      btCollisionObject::CollisionFlags::CF_STATIC_OBJECT &
+        mRigidBody->setCollisionFlags((mRigidBody->getCollisionFlags() |
+                                      btCollisionObject::CollisionFlags::CF_STATIC_OBJECT) &
                                       ~btCollisionObject::CollisionFlags::CF_KINEMATIC_OBJECT);
         mRigidBody->setActivationState(ISLAND_SLEEPING);
         break;
 
         case SimulationType::KINEMATIC:
-        mRigidBody->setCollisionFlags(mRigidBody->getCollisionFlags() |
-                                       btCollisionObject::CollisionFlags::CF_KINEMATIC_OBJECT &
+        mRigidBody->setCollisionFlags((mRigidBody->getCollisionFlags() |
+                                       btCollisionObject::CollisionFlags::CF_KINEMATIC_OBJECT) &
                                        ~btCollisionObject::CollisionFlags::CF_STATIC_OBJECT);
         mRigidBody->setActivationState(ISLAND_SLEEPING);
         break;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.cpp
@@ -22,145 +22,82 @@
 #include <BulletDynamics/ConstraintSolver/btSliderConstraint.h>
 #include <LinearMath/btTransform.h>
 
-static const char tag[] = "BulletSliderConstrN";
+static const char tag[] = "BulletSliderConstr";
 
 namespace gvr {
 
-    BulletSliderConstraint::BulletSliderConstraint(PhysicsRigidBody *rigidBodyB) {
-        mRigidBodyB = reinterpret_cast<BulletRigidBody*>(rigidBodyB);
-        mSliderConstraint = 0;
+    BulletSliderConstraint::BulletSliderConstraint(PhysicsRigidBody *rigidBodyA,
+            PhysicsRigidBody *rigidBodyB)
+    {
+        btRigidBody* rbA = reinterpret_cast<BulletRigidBody*>(rigidBodyA)->getRigidBody();
+        btRigidBody* rbB = reinterpret_cast<BulletRigidBody*>(rigidBodyB)->getRigidBody();
 
-        mBreakingImpulse = SIMD_INFINITY;
+        // FIXME: this only works if both bodies have same Y and Z coordinates
+        btTransform frameInA, frameInB;
+        frameInA = btTransform::getIdentity();
+        frameInB = btTransform::getIdentity();
 
-        // Default values from btSliderConstraint
-        mLowerAngularLimit = 0.0f;
-        mUpperAngularLimit = 0.0f;
-        mLowerLinearLimit = 1.0f;
-        mUpperLinearLimit = -1.0f;
+        mSliderConstraint = new btSliderConstraint(*rbA, *rbB, frameInA, frameInB, true);
     }
 
     BulletSliderConstraint::BulletSliderConstraint(btSliderConstraint *constraint)
     {
         mSliderConstraint = constraint;
-        mRigidBodyB = static_cast<BulletRigidBody*>(constraint->getRigidBodyB().getUserPointer());
         constraint->setUserConstraintPtr(this);
     }
 
-    BulletSliderConstraint::~BulletSliderConstraint() {
-        if (0 != mSliderConstraint) {
-            delete mSliderConstraint;
-        }
+    BulletSliderConstraint::~BulletSliderConstraint()
+    {
+        delete mSliderConstraint;
     }
 
-    void BulletSliderConstraint::setAngularLowerLimit(float limit) {
-        if (0 != mSliderConstraint) {
-            mSliderConstraint->setLowerAngLimit(limit);
-        }
-        else {
-            mLowerAngularLimit = limit;
-        }
+    void BulletSliderConstraint::setAngularLowerLimit(float limit)
+    {
+        mSliderConstraint->setLowerAngLimit(limit);
     }
 
-    float BulletSliderConstraint::getAngularLowerLimit() const {
-        if (0 != mSliderConstraint) {
-            return mSliderConstraint->getLowerAngLimit();
-        }
-        else {
-            return mLowerAngularLimit;
-        }
+    float BulletSliderConstraint::getAngularLowerLimit() const
+    {
+        return mSliderConstraint->getLowerAngLimit();
     }
 
-    void BulletSliderConstraint::setAngularUpperLimit(float limit) {
-        if (0 != mSliderConstraint) {
-            mSliderConstraint->setUpperAngLimit(limit);
-        }
-        else {
-            mUpperAngularLimit = limit;
-        }
+    void BulletSliderConstraint::setAngularUpperLimit(float limit)
+    {
+        mSliderConstraint->setUpperAngLimit(limit);
     }
 
-    float BulletSliderConstraint::getAngularUpperLimit() const {
-        if (0 != mSliderConstraint) {
-            return mSliderConstraint->getUpperAngLimit();
-        }
-        else {
-            return mUpperAngularLimit;
-        }
+    float BulletSliderConstraint::getAngularUpperLimit() const
+    {
+        return mSliderConstraint->getUpperAngLimit();
     }
 
-    void BulletSliderConstraint::setLinearLowerLimit(float limit) {
-        if (0 != mSliderConstraint) {
-            mSliderConstraint->setLowerLinLimit(limit);
-        }
-        else {
-            mLowerLinearLimit = limit;
-        }
+    void BulletSliderConstraint::setLinearLowerLimit(float limit)
+    {
+        mSliderConstraint->setLowerLinLimit(limit);
     }
 
-    float BulletSliderConstraint::getLinearLowerLimit() const {
-        if (0 != mSliderConstraint) {
-            return mSliderConstraint->getLowerLinLimit();
-        }
-        else {
-            return mLowerLinearLimit;
-        }
+    float BulletSliderConstraint::getLinearLowerLimit() const
+    {
+        return mSliderConstraint->getLowerLinLimit();
     }
 
-    void BulletSliderConstraint::setLinearUpperLimit(float limit) {
-        if (0 != mSliderConstraint) {
-            mSliderConstraint->setUpperLinLimit(limit);
-        }
-        else {
-            mUpperLinearLimit = limit;
-        }
+    void BulletSliderConstraint::setLinearUpperLimit(float limit)
+    {
+        mSliderConstraint->setUpperLinLimit(limit);
     }
 
-    void BulletSliderConstraint::setBreakingImpulse(float impulse) {
-        if (0 != mSliderConstraint) {
-            mSliderConstraint->setBreakingImpulseThreshold(impulse);
-        }
-        else {
-            mBreakingImpulse = impulse;
-        }
+    void BulletSliderConstraint::setBreakingImpulse(float impulse)
+    {
+        mSliderConstraint->setBreakingImpulseThreshold(impulse);
     }
 
-    float BulletSliderConstraint::getBreakingImpulse() const {
-        if (0 != mSliderConstraint) {
-            return mSliderConstraint->getBreakingImpulseThreshold();
-        }
-        else {
-            return mBreakingImpulse;
-        }
+    float BulletSliderConstraint::getBreakingImpulse() const
+    {
+        return mSliderConstraint->getBreakingImpulseThreshold();
     }
 
-    float BulletSliderConstraint::getLinearUpperLimit() const {
-        if (0 != mSliderConstraint) {
-            return mSliderConstraint->getUpperLinLimit();
-        }
-        else {
-            return mUpperLinearLimit;
-        }
+    float BulletSliderConstraint::getLinearUpperLimit() const
+    {
+        return mSliderConstraint->getUpperLinLimit();
     }
-
-void BulletSliderConstraint::updateConstructionInfo() {
-    if (mSliderConstraint != nullptr) {
-        return;
-    }
-
-    btRigidBody* rbA = ((BulletRigidBody*)this->owner_object()->getComponent(COMPONENT_TYPE_PHYSICS_RIGID_BODY))->getRigidBody();
-
-    btTransform frameInA, frameInB;
-    frameInA = btTransform::getIdentity();
-    frameInB = btTransform::getIdentity();
-
-    mSliderConstraint = new btSliderConstraint(*rbA, *mRigidBodyB->getRigidBody(), frameInA,
-                                               frameInB, true);
-
-    mSliderConstraint->setLowerAngLimit(mLowerAngularLimit);
-    mSliderConstraint->setUpperAngLimit(mUpperAngularLimit);
-    mSliderConstraint->setLowerLinLimit(mLowerLinearLimit);
-    mSliderConstraint->setUpperLinLimit(mUpperLinearLimit);
-    mSliderConstraint->setBreakingImpulseThreshold(mBreakingImpulse);
-}
-
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.cpp
@@ -27,15 +27,16 @@ static const char tag[] = "BulletSliderConstr";
 namespace gvr {
 
     BulletSliderConstraint::BulletSliderConstraint(PhysicsRigidBody *rigidBodyA,
-            PhysicsRigidBody *rigidBodyB)
+            PhysicsRigidBody *rigidBodyB, float const *rotationA, float const *rotationB)
     {
         btRigidBody* rbA = reinterpret_cast<BulletRigidBody*>(rigidBodyA)->getRigidBody();
         btRigidBody* rbB = reinterpret_cast<BulletRigidBody*>(rigidBodyB)->getRigidBody();
 
-        // FIXME: this only works if both bodies have same Y and Z coordinates
-        btTransform frameInA, frameInB;
-        frameInA = btTransform::getIdentity();
-        frameInB = btTransform::getIdentity();
+        btTransform frameInA(btMatrix3x3(rotationA[0], rotationA[1], rotationA[2], rotationA[3],
+                rotationA[4], rotationA[5], rotationA[6], rotationA[7], rotationA[8]));
+
+        btTransform frameInB(btMatrix3x3(rotationB[0], rotationB[1], rotationB[2], rotationB[3],
+                rotationB[4], rotationB[5], rotationB[6], rotationB[7], rotationB[8]));
 
         mSliderConstraint = new btSliderConstraint(*rbA, *rbB, frameInA, frameInB, true);
     }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.h
@@ -33,7 +33,8 @@ namespace gvr {
     class BulletSliderConstraint : public PhysicsSliderConstraint,
                                           BulletObject {
     public:
-        explicit BulletSliderConstraint(PhysicsRigidBody *rigidBodyA, PhysicsRigidBody *rigidBodyB);
+        explicit BulletSliderConstraint(PhysicsRigidBody *rigidBodyA, PhysicsRigidBody *rigidBodyB,
+                float const *rotationA, float const *rotationB);
 
         BulletSliderConstraint(btSliderConstraint *constraint);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_sliderconstraint.h
@@ -33,7 +33,7 @@ namespace gvr {
     class BulletSliderConstraint : public PhysicsSliderConstraint,
                                           BulletObject {
     public:
-        explicit BulletSliderConstraint(PhysicsRigidBody *rigidBodyB);
+        explicit BulletSliderConstraint(PhysicsRigidBody *rigidBodyA, PhysicsRigidBody *rigidBodyB);
 
         BulletSliderConstraint(btSliderConstraint *constraint);
 
@@ -61,17 +61,8 @@ namespace gvr {
 
         void *getUnderlying() { return mSliderConstraint; }
 
-        void updateConstructionInfo();
-
     private:
         btSliderConstraint *mSliderConstraint;
-        BulletRigidBody *mRigidBodyB;
-
-        float mBreakingImpulse;
-        float mLowerAngularLimit;
-        float mUpperAngularLimit;
-        float mLowerLinearLimit;
-        float mUpperLinearLimit;
     };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_world.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_world.cpp
@@ -79,8 +79,8 @@ void BulletWorld::finalize() {
 }
 
 void BulletWorld::addConstraint(PhysicsConstraint *constraint) {
-    constraint->updateConstructionInfo();
     btTypedConstraint *_constr = reinterpret_cast<btTypedConstraint*>(constraint->getUnderlying());
+    constraint->updateConstructionInfo();
     mPhysicsWorld->addConstraint(_constr);
 }
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_conetwistconstraint_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_conetwistconstraint_jni.cpp
@@ -26,9 +26,8 @@ namespace gvr {
     extern "C" {
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DConeTwistConstraint_ctor(JNIEnv *env, jobject obj,
-                                                              jlong rigidBodyB, jfloatArray pivot,
-                                                              const jfloatArray bodyRotation,
-                                                              const jfloatArray coneRotation);
+            jlong rigidBodyA, jlong rigidBodyB, jfloatArray pivot, const jfloatArray bodyRotation,
+            const jfloatArray coneRotation);
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_physics_Native3DConeTwistConstraint_setSwingLimit(JNIEnv *env, jobject obj,
@@ -52,17 +51,17 @@ namespace gvr {
 
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DConeTwistConstraint_ctor(JNIEnv *env, jobject obj,
-                                                              jlong rigidBodyB,
-                                                              const jfloatArray pivot,
-                                                              const jfloatArray bodyRotation,
-                                                              const jfloatArray coneRotation) {
+            jlong rigidBodyA, jlong rigidBodyB, const jfloatArray pivot,
+            const jfloatArray bodyRotation, const jfloatArray coneRotation)
+    {
+        PhysicsRigidBody *rbA = reinterpret_cast<PhysicsRigidBody*>(rigidBodyA);
+        PhysicsRigidBody *rbB = reinterpret_cast<PhysicsRigidBody*>(rigidBodyB);
         PhysicsVec3 _pivot(env->GetFloatArrayElements(pivot, 0));
         PhysicsMat3x3 _b_rot(env->GetFloatArrayElements(bodyRotation, 0));
         PhysicsMat3x3 _c_rot(env->GetFloatArrayElements(coneRotation, 0));
 
         return reinterpret_cast<jlong>(new
-                BulletConeTwistConstraint(reinterpret_cast<PhysicsRigidBody*>(rigidBodyB),
-                                          _pivot, _b_rot, _c_rot));
+                BulletConeTwistConstraint(rbA, rbB, _pivot, _b_rot, _c_rot));
     }
 
     JNIEXPORT void JNICALL

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_constraint.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_constraint.h
@@ -16,7 +16,7 @@
 #ifndef EXTENSIONS_PHYSICS_CONSTRAINT_H
 #define EXTENSIONS_PHYSICS_CONSTRAINT_H
 
-#include "../objects/scene_object.h"
+#include "../objects/hybrid_object.h"
 
 namespace gvr {
 
@@ -28,15 +28,13 @@ namespace gvr {
 
     };
 
-    class PhysicsConstraint : public Component {
+    class PhysicsRigidBody;
+
+    class PhysicsConstraint : public HybridObject {
     public:
-        PhysicsConstraint() : Component(PhysicsConstraint::getComponentType()){}
+        PhysicsConstraint() : HybridObject(), marked(false){}
 
         virtual ~PhysicsConstraint() {}
-
-        static long long getComponentType() {
-            return COMPONENT_TYPE_PHYSICS_CONSTRAINT;
-        }
 
         virtual int getConstraintType() const = 0;
 
@@ -47,9 +45,10 @@ namespace gvr {
     //virtual void setJointFeedback(JointFeedback const * feedback) = 0;
         virtual void *getUnderlying() = 0;
 
+        virtual void updateConstructionInfo() {}
+
         virtual void setBreakingImpulse(float impulse) = 0;
         virtual float getBreakingImpulse() const = 0;
-        virtual void updateConstructionInfo() = 0;
 
         enum ConstraintType {
             fixedConstraint = 1,
@@ -59,6 +58,8 @@ namespace gvr {
             coneTwistConstraint = 5,
             genericConstraint = 6,
         };
+
+        bool marked;
     };
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_constraint_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_constraint_jni.cpp
@@ -17,14 +17,12 @@
 // Created by c.bozzetto on 19/06/2017.
 //
 
+#include <jni.h>
 #include "physics_constraint.h"
 
 namespace gvr {
 
     extern "C" {
-    JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DConstraint_getComponentType(JNIEnv * env, jobject obj);
-
     JNIEXPORT jint JNICALL
     Java_org_gearvrf_physics_Native3DConstraint_getConstraintType(JNIEnv * env, jobject obj,
                                                                   jlong jconstraint);
@@ -37,11 +35,10 @@ namespace gvr {
     JNIEXPORT jfloat JNICALL
     Java_org_gearvrf_physics_Native3DConstraint_getBreakingImpulse(JNIEnv * env, jobject obj,
                                                                    jlong jconstraint);
-    }
 
-    JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DConstraint_getComponentType(JNIEnv * env, jobject obj) {
-        return PhysicsConstraint::getComponentType();
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_physics_Native3DConstraint_mark(JNIEnv *env, jobject obj,
+            jlong jconstraint);
     }
 
     JNIEXPORT jint JNICALL
@@ -61,6 +58,13 @@ namespace gvr {
     Java_org_gearvrf_physics_Native3DConstraint_getBreakingImpulse(JNIEnv * env, jobject obj,
                                                                    jlong jconstraint) {
         return reinterpret_cast<PhysicsConstraint*>(jconstraint)->getBreakingImpulse();
+    }
+
+    JNIEXPORT void JNICALL
+    Java_org_gearvrf_physics_Native3DConstraint_mark(JNIEnv *env, jobject obj,
+            jlong jconstraint)
+    {
+        reinterpret_cast<PhysicsConstraint*>(jconstraint)->marked = true;
     }
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_fixedconstraint_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_fixedconstraint_jni.cpp
@@ -20,13 +20,16 @@ namespace gvr {
 
     extern "C" {
     JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DFixedConstraint_ctor(JNIEnv * env, jobject obj, jlong rigidBodyB);
+    Java_org_gearvrf_physics_Native3DFixedConstraint_ctor(JNIEnv * env, jobject obj,
+                                                          jlong rigidBodyA, jlong rigidBodyB);
     }
 
     JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DFixedConstraint_ctor(JNIEnv * env, jobject obj, jlong rigidBodyB) {
+    Java_org_gearvrf_physics_Native3DFixedConstraint_ctor(JNIEnv * env, jobject obj,
+                                                          jlong rigidBodyA, jlong rigidBodyB) {
         return reinterpret_cast<jlong>(
-                new BulletFixedConstraint(reinterpret_cast<PhysicsRigidBody*>(rigidBodyB)));
+                new BulletFixedConstraint(reinterpret_cast<PhysicsRigidBody*>(rigidBodyA),
+                                          reinterpret_cast<PhysicsRigidBody*>(rigidBodyB)));
     }
 
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_genericconstraint_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_genericconstraint_jni.cpp
@@ -25,8 +25,8 @@ namespace gvr {
 
     extern "C" {
     JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DGenericConstraint_ctor(
-            JNIEnv *env, jobject obj, jlong rigidBodyB, jfloatArray const joint,
+    Java_org_gearvrf_physics_Native3DGenericConstraint_ctor(JNIEnv *env, jobject obj,
+            jlong rigidBodyA, jlong rigidBodyB, jfloatArray const joint,
             jfloatArray const rotationA, jfloatArray const rotationB);
 
     JNIEXPORT void JNICALL
@@ -63,15 +63,18 @@ namespace gvr {
     }
 
     JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DGenericConstraint_ctor(
-            JNIEnv *env, jobject obj, jlong rigidBodyB, jfloatArray const joint,
-            jfloatArray const rotationA, jfloatArray const rotationB) {
-        PhysicsRigidBody *body = reinterpret_cast<PhysicsRigidBody*>(rigidBodyB);
+    Java_org_gearvrf_physics_Native3DGenericConstraint_ctor(JNIEnv *env, jobject obj,
+            jlong rigidBodyA, jlong rigidBodyB, jfloatArray const joint,
+            jfloatArray const rotationA, jfloatArray const rotationB)
+    {
+        PhysicsRigidBody *rbA = reinterpret_cast<PhysicsRigidBody*>(rigidBodyA);
+        PhysicsRigidBody *rbB = reinterpret_cast<PhysicsRigidBody*>(rigidBodyB);
         float const *_joint = env->GetFloatArrayElements(joint, 0);
         float const *_rotA = env->GetFloatArrayElements(rotationA, 0);
         float const *_rotB = env->GetFloatArrayElements(rotationB, 0);
 
-        return reinterpret_cast<jlong>(new BulletGeneric6dofConstraint(body, _joint, _rotA, _rotB));
+        return reinterpret_cast<jlong>(new
+                BulletGeneric6dofConstraint(rbA, rbB, _joint, _rotA, _rotB));
     }
 
     JNIEXPORT void JNICALL

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_hingeconstraint_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_hingeconstraint_jni.cpp
@@ -25,12 +25,8 @@ namespace gvr {
     extern "C" {
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DHingeConstraint_ctor(JNIEnv *env, jobject obj,
-                                                          jlong rigidBodyB, jfloatArray pivotInA,
-                                                          jfloatArray pivotInB, jfloatArray axisInA,
-                                                          jfloatArray axisInB);
-
-    JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DHingeConstraint_getComponentType(JNIEnv *env, jobject obj);
+            jlong rigidBodyA, jlong rigidBodyB, jfloatArray pivotInA, jfloatArray pivotInB,
+            jfloatArray axisInA, jfloatArray axisInB);
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_physics_Native3DHingeConstraint_setLimits(JNIEnv * env , jobject obj,
@@ -48,20 +44,16 @@ namespace gvr {
 
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DHingeConstraint_ctor(JNIEnv * env, jobject obj,
-                                                          jlong rigidBodyB, jfloatArray pivotInA,
-                                                          jfloatArray pivotInB, jfloatArray axisInA,
-                                                          jfloatArray axisInB) {
+            jlong rigidBodyA, jlong rigidBodyB, jfloatArray pivotInA, jfloatArray pivotInB,
+            jfloatArray axisInA, jfloatArray axisInB)
+    {
         float *pA = env->GetFloatArrayElements(pivotInA, 0);
         float *pB = env->GetFloatArrayElements(pivotInB, 0);
         float *aA = env->GetFloatArrayElements(axisInA, 0);
         float *aB = env->GetFloatArrayElements(axisInB, 0);
         return reinterpret_cast<jlong>(new BulletHingeConstraint(
+                reinterpret_cast<PhysicsRigidBody*>(rigidBodyA),
                 reinterpret_cast<PhysicsRigidBody*>(rigidBodyB), pA, pB, aA, aB));
-    }
-
-    JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DHingeConstraint_getComponentType(JNIEnv * env, jobject obj) {
-        return PhysicsConstraint::getComponentType();
     }
 
     JNIEXPORT void JNICALL

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_loader_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_loader_jni.cpp
@@ -29,7 +29,7 @@ namespace gvr {
 extern "C" {
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_NativePhysics3DLoader_ctor(JNIEnv* env, jclass clazz,
-            jstring fname, jboolean ignoreUpAxis, jobject jassetmanager);
+            jbyteArray byteArr, jint arrLen, jboolean ignoreUpAxis);
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_physics_NativePhysics3DLoader_delete(JNIEnv* env, jclass clazz, jlong jloader);
@@ -57,20 +57,22 @@ extern "C" {
 
 JNIEXPORT jlong JNICALL
 Java_org_gearvrf_physics_NativePhysics3DLoader_ctor(JNIEnv* env, jclass clazz,
-        jstring fname, jboolean ignoreUpAxis, jobject jassetmanager)
+    jbyteArray byteArr, jint len, jboolean ignoreUpAxis)
 {
-    const char* cFilename = env->GetStringUTFChars(fname, NULL);
-    AAssetManager *assetmgr = AAssetManager_fromJava(env, jassetmanager);
-    AAsset *file = AAssetManager_open(assetmgr, cFilename, AASSET_MODE_UNKNOWN);
-    size_t assetsize = (size_t)AAsset_getLength(file);
-    char *buf = new char[assetsize];
-    int ret = AAsset_read(file, buf, assetsize);
-    __android_log_print(ANDROID_LOG_DEBUG, tag, "read %i bytes from asset '%s'", ret, cFilename);
-    AAsset_close(file);
+    jbyte* data = env->GetByteArrayElements(byteArr, NULL);
 
-    PhysicsLoader *loader = new BulletFileLoader(buf, assetsize, ignoreUpAxis);
+    if (data == NULL) {
+        return 0;
+    }
 
-    delete[] buf;
+    char *buffer = new char[len];
+    memcpy(buffer, data, len);
+
+    env->ReleaseByteArrayElements(byteArr, data, JNI_ABORT);
+
+    PhysicsLoader *loader = new BulletFileLoader(buffer, len, ignoreUpAxis);
+
+    delete[] buffer;
 
     return reinterpret_cast<jlong>(loader);
 }

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_loader_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_loader_jni.cpp
@@ -66,11 +66,11 @@ Java_org_gearvrf_physics_NativePhysics3DLoader_ctor(JNIEnv* env, jclass clazz,
     }
 
     char *buffer = new char[len];
-    memcpy(buffer, data, len);
+    memcpy(buffer, data, (size_t)len);
 
     env->ReleaseByteArrayElements(byteArr, data, JNI_ABORT);
 
-    PhysicsLoader *loader = new BulletFileLoader(buffer, len, ignoreUpAxis);
+    PhysicsLoader *loader = new BulletFileLoader(buffer, (size_t)len, ignoreUpAxis);
 
     delete[] buffer;
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_point2pointconstraint_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_point2pointconstraint_jni.cpp
@@ -21,7 +21,7 @@ namespace gvr {
     extern "C" {
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DPoint2PointConstraint_ctor(JNIEnv * env, jobject obj,
-        jlong rigidBodyB, jfloatArray pivotInA, jfloatArray pivotInB);
+            jlong rigidBodyA, jlong rigidBodyB, jfloatArray pivotInA, jfloatArray pivotInB);
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_physics_Native3DPoint2PointConstraint_setPivotInA(JNIEnv * env, jobject obj,
@@ -57,12 +57,13 @@ namespace gvr {
     }
 
     JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DPoint2PointConstraint_ctor(JNIEnv * env, jobject obj, 
-        jlong rigidBodyB, jfloatArray pivotInA, jfloatArray pivotInB) {
+    Java_org_gearvrf_physics_Native3DPoint2PointConstraint_ctor(JNIEnv * env, jobject obj,
+            jlong rigidBodyA, jlong rigidBodyB, jfloatArray pivotInA, jfloatArray pivotInB) {
         jfloat *pA = env->GetFloatArrayElements(pivotInA, 0);
         jfloat *pB = env->GetFloatArrayElements(pivotInB, 0);
         return reinterpret_cast<jlong>(new BulletPoint2PointConstraint(
-                    reinterpret_cast<PhysicsRigidBody*>(rigidBodyB), pA, pB));
+                reinterpret_cast<PhysicsRigidBody*>(rigidBodyA),
+                reinterpret_cast<PhysicsRigidBody*>(rigidBodyB), pA, pB));
     }
 
     JNIEXPORT void JNICALL

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_sliderconstraint_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_sliderconstraint_jni.cpp
@@ -26,7 +26,7 @@ namespace gvr {
     extern "C" {
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DSliderConstraint_ctor(JNIEnv * env, jobject obj,
-                                                           jlong rigidBodyB);
+            jlong rigidBodyA, jlong rigidBodyB);
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_physics_Native3DSliderConstraint_setAngularLowerLimit(JNIEnv * env,
@@ -75,9 +75,10 @@ namespace gvr {
 
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DSliderConstraint_ctor(JNIEnv * env, jobject obj,
-                                                           jlong rigidBodyB) {
+            jlong rigidBodyA, jlong rigidBodyB) {
         return reinterpret_cast<jlong>(new
-                BulletSliderConstraint(reinterpret_cast<PhysicsRigidBody*>(rigidBodyB)));
+                BulletSliderConstraint(reinterpret_cast<PhysicsRigidBody*>(rigidBodyA),
+                reinterpret_cast<PhysicsRigidBody*>(rigidBodyB)));
     }
 
     JNIEXPORT void JNICALL

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_sliderconstraint_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_sliderconstraint_jni.cpp
@@ -26,7 +26,8 @@ namespace gvr {
     extern "C" {
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DSliderConstraint_ctor(JNIEnv * env, jobject obj,
-            jlong rigidBodyA, jlong rigidBodyB);
+            jlong rigidBodyA, jlong rigidBodyB, jfloatArray const rotationA,
+            jfloatArray const rotationB);
 
     JNIEXPORT void JNICALL
     Java_org_gearvrf_physics_Native3DSliderConstraint_setAngularLowerLimit(JNIEnv * env,
@@ -75,10 +76,14 @@ namespace gvr {
 
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DSliderConstraint_ctor(JNIEnv * env, jobject obj,
-            jlong rigidBodyA, jlong rigidBodyB) {
+            jlong rigidBodyA, jlong rigidBodyB, jfloatArray const rotationA,
+            jfloatArray const rotationB) {
+        float const *_rotA = env->GetFloatArrayElements(rotationA, 0);
+        float const *_rotB = env->GetFloatArrayElements(rotationB, 0);
+
         return reinterpret_cast<jlong>(new
                 BulletSliderConstraint(reinterpret_cast<PhysicsRigidBody*>(rigidBodyA),
-                reinterpret_cast<PhysicsRigidBody*>(rigidBodyB)));
+                reinterpret_cast<PhysicsRigidBody*>(rigidBodyB), _rotA, _rotB));
     }
 
     JNIEXPORT void JNICALL


### PR DESCRIPTION
In order to make it easier to add multiple constraints in the same rigid body the constraints API was changed. Now the constructors receive both the rigid bodies and constraints are no longer derived from GVRComponent. Thus constraints are not attached to scene objects, instead they are viewed simply as rigid bodies links.

Some other changes contained in this pull request:

- slider constraint construction now receives rotation for both rigid bodies;
- physics loader now automatically adds mesh collider to scene objects that do not have this component;
- physics loader can now load bullet file not only from assets folder.
