### PR TITLE
backend_oculus: fix controller reader npe

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrViewManager.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrViewManager.java
@@ -134,6 +134,8 @@ class OvrViewManager extends GVRViewManager {
         mStatsLine.addColumn(mTracerDrawEyes1.getStatColumn());
         mStatsLine.addColumn(mTracerDrawEyes2.getStatColumn());
         mStatsLine.addColumn(mTracerAfterDrawEyes.getStatColumn());
+
+        mControllerReader = new OvrControllerReader(mActivity.getActivityNative().getNative());
     }
 
     /**
@@ -278,7 +280,6 @@ class OvrViewManager extends GVRViewManager {
     @Override
     void onSurfaceCreated() {
         super.onSurfaceCreated();
-        mControllerReader = new OvrControllerReader(mActivity.getActivityNative().getNative());
         GVRGearCursorController gearController = mInputManager.getGearController();
         if (gearController != null)
             gearController.attachReader(mControllerReader);


### PR DESCRIPTION
Looks like the NPE caused by the recent controller change is easy enough to fix. @roshanch Please review and verify though.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>