### PR TITLE
Makes collider a not exclusive component

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRComponent.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRComponent.java
@@ -40,7 +40,11 @@ public class GVRComponent extends GVRHybridObject {
 
     protected boolean mIsEnabled;
     protected long mType = 0;
-    protected GVRComponent mParent = null;
+    protected boolean mExclusive = true;
+    /* mNex is used by scene object to handle the collision of not
+       exclusive components attached to the same scene object.
+     */
+    protected GVRComponent mNext = null;
 
     /**
      * Constructor for a component that is not attached to a scene object.
@@ -186,6 +190,24 @@ public class GVRComponent extends GVRHybridObject {
     }
 
     /**
+     * @return true whether it is a exclusive component type, otherwise returns false.
+     */
+    public boolean isExclusive() {
+        if (getNative() != 0)
+            return NativeComponent.isExclusive(getNative());
+
+        return mExclusive;
+    }
+
+    /**
+     * @return The next component of same type attached to the same scene object
+     *      if it is not a component of type exclusivej, otherwise returns null.
+     */
+    public GVRComponent next() {
+        return mNext;
+    }
+
+    /**
      * Get the transform of the scene object this component is attached to.
      * 
      * @return GVRTransform of scene object
@@ -253,4 +275,5 @@ class NativeComponent {
     static native void setEnable(long component, boolean flag);
     static native void addChildComponent(long component, long child);
     static native void removeChildComponent(long component, long child);
+    static native boolean isExclusive(long component);
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/collider.h
@@ -111,6 +111,8 @@ public:
     virtual void onRemovedFromScene(Scene* scene);
     static void transformSphere(const glm::mat4& model_matrix, float* sphere);
 
+    virtual bool is_exclusive() const { return false;}
+
 protected:
     Collider() : Component(Collider::getComponentType()), pick_distance_(0) {}
     explicit Collider(long long type) : Component(type), pick_distance_(0) {}

--- a/GVRf/Framework/framework/src/main/jni/objects/components/component.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/component.h
@@ -48,6 +48,11 @@ public:
     bool enabled() const;
     virtual void set_enable(bool enable);
 
+    Component *next() const;
+    void set_next(Component *next);
+
+    virtual bool is_exclusive() const { return true;}
+
 private:
     Component(const Component& component) = delete;
     Component(Component&& component) = delete;
@@ -60,6 +65,7 @@ protected:
 
 private:
     long long    type_;
+    Component *next_;
 
 };
 

--- a/GVRf/Framework/framework/src/main/jni/objects/components/component.inl
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/component.inl
@@ -18,27 +18,30 @@
 
 namespace gvr {
 inline Component::Component() :
-        HybridObject(), type_(0), owner_object_(0), enabled_(true) {
+        HybridObject(), type_(0), owner_object_(0), enabled_(true), next_(nullptr) {
 }
 
 inline Component::Component(long long type) :
-        HybridObject(), type_(type), owner_object_(0), enabled_(true) {
+        HybridObject(), type_(type), owner_object_(0), enabled_(true), next_(nullptr) {
 }
 
 inline Component::Component(SceneObject* owner_object) :
     type_(0),
     enabled_(true),
-    owner_object_(owner_object) {
+    owner_object_(owner_object),
+    next_(nullptr) {
 }
 
 inline Component::Component(long long type, SceneObject* owner_object) :
         type_(type),
-         enabled_(true),
-        owner_object_(owner_object) {
+        enabled_(true),
+        owner_object_(owner_object),
+        next_(nullptr) {
 }
 
 inline Component::~Component() {
     owner_object_ = nullptr;
+    next_ = nullptr;
 }
 
 inline SceneObject *Component::owner_object() const {
@@ -67,6 +70,14 @@ inline bool Component::enabled() const {
 
 inline void Component::set_enable(bool enable) {
     enabled_ = enable;
+}
+
+inline Component *Component::next() const {
+    return next_;
+}
+
+inline void Component::set_next(Component *next) {
+    next_ = next;
 }
 
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/components/component_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/components/component_jni.cpp
@@ -41,6 +41,9 @@ extern "C" {
     JNIEXPORT void JNICALL
     Java_org_gearvrf_NativeComponent_removeChildComponent(JNIEnv * env, jobject obj,
                                                           jlong jgroup, jlong jcomponent);
+    JNIEXPORT bool JNICALL
+    Java_org_gearvrf_NativeComponent_isExclusive(JNIEnv * env,
+                                         jobject obj, jlong jcomponent);
 }
 
 JNIEXPORT jlong JNICALL
@@ -92,5 +95,13 @@ Java_org_gearvrf_NativeComponent_removeChildComponent(JNIEnv * env, jobject obj,
     Component* component = reinterpret_cast<Component*>(jcomponent);
     group->removeChildComponent(component);
 }
+
+JNIEXPORT bool JNICALL
+Java_org_gearvrf_NativeComponent_isExclusive(JNIEnv * env,
+                                             jobject obj, jlong jcomponent) {
+    Component* component = reinterpret_cast<Component*>(jcomponent);
+    return component->is_exclusive();
+}
+
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
@@ -123,12 +123,14 @@ void Scene::clearAllColliders() {
 }
 
 void Scene::pick(SceneObject* sceneobj) {
-    if (pick_visible_) {
-         Collider* collider = static_cast<Collider*>(sceneobj->getComponent(Collider::getComponentType()));
-        if (collider) {
-            visibleColliders.push_back(collider);
-        }
-     }
+    if (!pick_visible_)
+        return;
+
+    Collider* collider = static_cast<Collider*>(sceneobj->getComponent(Collider::getComponentType()));
+    while (collider != nullptr) {
+        visibleColliders.push_back(collider);
+        collider = static_cast<Collider*>(collider->next());
+    }
 }
 
 void Scene::addCollider(Collider* collider) {

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.cpp
@@ -43,12 +43,30 @@ SceneObject::~SceneObject() {
 }
 
 bool SceneObject::attachComponent(Component* component) {
+    Component *front_component = nullptr;
     for (auto it = components_.begin(); it != components_.end(); ++it) {
-        if ((*it)->getType() == component->getType())
-            return false;
+        if ((*it)->getType() == component->getType()) {
+            front_component = static_cast<Component*>(*it);
+            break;
+        }
     }
+
+    if (front_component != nullptr) {
+        if (front_component->is_exclusive() || front_component == component) {
+            return false;
+        }
+        while (front_component->next() != nullptr) {
+            if (front_component->next() == component) {
+                return false;
+            }
+            front_component = front_component->next();
+        }
+        front_component->set_next(component);
+    } else {
+        components_.push_back(component);
+    }
+
     component->set_owner_object(this);
-    components_.push_back(component);
     SceneObject* par = parent();
     if (par)
     {
@@ -70,38 +88,91 @@ bool SceneObject::attachComponent(Component* component) {
     return true;
 }
 
-
-Component* SceneObject::detachComponent(long long type)
+bool SceneObject::detachComponent(Component* component)
 {
-    for (auto it = components_.begin(); it != components_.end(); ++it)
-    {
-        if ((*it)->getType() == type)
-        {
-            Component* component = *it;
-            SceneObject* par = parent();
-            if (par)
-            {
-                Scene* scene = Scene::main_scene();
-                SceneObject* root = scene->getRoot();
-                if (scene != NULL)
-                {
-                    while (par)
-                    {
-                        if (par == root)
-                        {
-                            component->onRemovedFromScene(scene);
-                            break;
-                        }
-                        par = par->parent();
-                    }
-                }
-            }
-            component->set_owner_object(NULL);
+    Component *front_component = nullptr;
+    for (auto it = components_.begin(); it != components_.end(); ++it) {
+        if ((*it)->getType() == component->getType()) {
+            front_component = static_cast<Component*>(*it);
             components_.erase(it);
-            return component;
+            break;
         }
     }
-    return (Component*) NULL;
+
+    if (front_component == nullptr) {
+        return false;
+    }
+
+    if (front_component == component) {
+        if (front_component->next() != nullptr) {
+            components_.push_back(front_component->next());
+        }
+    } else {
+        components_.push_back(front_component);
+        while (front_component->next() != component) {
+            if (front_component->next() == nullptr) {
+                return false;
+            }
+        }
+        front_component->set_next(component->next());
+    }
+
+    component->set_next(nullptr);
+
+    SceneObject* par = parent();
+    if (par) {
+        Scene* scene = Scene::main_scene();
+        SceneObject* root = scene->getRoot();
+        if (scene != nullptr) {
+            while (par) {
+                if (par == root) {
+                    component->onRemovedFromScene(scene);
+                    break;
+                }
+                par = par->parent();
+            }
+        }
+    }
+    component->set_owner_object(nullptr);
+    return true;
+}
+
+bool SceneObject::detachComponents(long long type)
+{
+    Component *front_component = nullptr;
+    Component *component = nullptr;
+    for (auto it = components_.begin(); it != components_.end(); ++it) {
+        if ((*it)->getType() == component->getType()) {
+            front_component = static_cast<Component*>(*it);
+            components_.erase(it);
+            break;
+        }
+    }
+
+    component = front_component;
+
+    while (component != nullptr) {
+        SceneObject *par = parent();
+        if (par) {
+            Scene *scene = Scene::main_scene();
+            SceneObject *root = scene->getRoot();
+            if (scene != nullptr) {
+                while (par) {
+                    if (par == root) {
+                        component->onRemovedFromScene(scene);
+                        break;
+                    }
+                    par = par->parent();
+                }
+            }
+        }
+        front_component = component;
+        component = component->next();
+
+        front_component->set_next(nullptr);
+        front_component->set_owner_object(nullptr);
+    }
+    return front_component != nullptr;
 }
 
 Component* SceneObject::getComponent(long long type) const {

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object.h
@@ -80,7 +80,9 @@ public:
     }
 
     bool attachComponent(Component* component);
-    Component* detachComponent(long long type);
+    bool detachComponent(Component* component);
+    bool detachComponents(long long type);
+
     Component* getComponent(long long type) const;
     void getAllComponents(std::vector<Component*>& components, long long type);
 

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_object_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_object_jni.cpp
@@ -40,7 +40,11 @@ extern "C" {
             jobject obj, jlong jscene_object, jlong jcomponent);
 
     JNIEXPORT bool JNICALL
-    Java_org_gearvrf_NativeSceneObject_detachComponent(JNIEnv * env,
+    Java_org_gearvrf_NativeSceneObject_detachComponent(JNIEnv * env, jobject obj,
+            jlong jscene_object, jlong jcomponent);
+
+    JNIEXPORT bool JNICALL
+    Java_org_gearvrf_NativeSceneObject_detachComponents(JNIEnv * env,
             jobject obj, jlong jscene_object, jlong type);
 
     JNIEXPORT long JNICALL
@@ -123,10 +127,19 @@ Java_org_gearvrf_NativeSceneObject_attachComponent(JNIEnv * env,
 }
 
 JNIEXPORT bool JNICALL
-Java_org_gearvrf_NativeSceneObject_detachComponent(JNIEnv * env,
+Java_org_gearvrf_NativeSceneObject_detachComponent(JNIEnv * env, jobject obj,
+        jlong jscene_object, jlong jcomponent) {
+    SceneObject* scene_object = reinterpret_cast<SceneObject*>(jscene_object);
+    Component* component = reinterpret_cast<Component*>(jcomponent);
+    return scene_object->detachComponent(component);
+}
+
+
+JNIEXPORT bool JNICALL
+Java_org_gearvrf_NativeSceneObject_detachComponents(JNIEnv * env,
         jobject obj, jlong jscene_object, jlong type) {
     SceneObject* scene_object = reinterpret_cast<SceneObject*>(jscene_object);
-    return scene_object->detachComponent(type) != NULL;
+    return scene_object->detachComponents(type);
 }
 
 


### PR DESCRIPTION
Whether constraints PR  https://github.com/Samsung/GearVRf/pull/1893 looks good we could make the collider a not exclusive type also.

To test this just add multiple colliders to the same scene object. 

`GearVRf-DCO-1.0-Signed-off-by: Ragner Magalhaes <ragner.n@samsung.com>`