### PR TITLE
framework: can't load libjav8.so; uses static standard lib

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/Android.mk
+++ b/GVRf/Framework/framework/src/main/jni/Android.mk
@@ -87,7 +87,7 @@ FILE_LIST := $(wildcard $(LOCAL_PATH)/vulkan/*.cpp)
 LOCAL_SRC_FILES += $(FILE_LIST:$(LOCAL_PATH)/%=%)
 
 LOCAL_SHARED_LIBRARIES += assimp
-LOCAL_SHARED_LIBRARIES += jav8
+#LOCAL_SHARED_LIBRARIES += jav8
 LOCAL_STATIC_LIBRARIES += shaderc
 
 ifeq ($(TARGET_ARCH_ABI),$(filter $(TARGET_ARCH_ABI), armeabi-v7a x86))


### PR DESCRIPTION
Can't load; the static standard lib breaks other modules.

@mwitchwilliams Until @xcaostagit rebuilds jav8 to use the shared standard library it cannot be used. Meaning x3d scripting will be broken.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>