### PR TITLE
Do not modify loaded rigid bodies

### DIFF
--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRPhysicsLoader.java
@@ -90,11 +90,6 @@ public class GVRPhysicsLoader {
                 continue;
             }
 
-            if (sceneObject.getComponent(GVRCollider.getComponentType()) == null) {
-                // Set mesh collider as default.
-                sceneObject.attachComponent(new GVRMeshCollider(gvrContext, true));
-            }
-
             GVRRigidBody rigidBody = new GVRRigidBody(gvrContext, nativeRigidBody);
             sceneObject.attachComponent(rigidBody);
             rbObjects.put(nativeRigidBody, sceneObject);

--- a/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRRigidBody.java
+++ b/GVRf/Extensions/gvrf-physics/src/main/java/org/gearvrf/physics/GVRRigidBody.java
@@ -45,6 +45,8 @@ public class GVRRigidBody extends GVRPhysicsWorldObject {
     private final int mCollisionGroup;
     private final GVRPhysicsContext mPhysicsContext;
 
+    private final boolean mLoaded;
+
     /**
      * Constructs new instance to simulate a rigid body in {@link GVRWorld}.
      *
@@ -74,10 +76,10 @@ public class GVRRigidBody extends GVRPhysicsWorldObject {
      *                       everyone if {#collisionGroup} is out of the range 0...15.
      */
     public GVRRigidBody(GVRContext gvrContext, float mass, int collisionGroup) {
-        super(gvrContext, Native3DRigidBody.ctor());
-        Native3DRigidBody.setMass(getNative(), mass);
+        super(gvrContext, Native3DRigidBody.ctor(mass));
         mCollisionGroup = collisionGroup;
         mPhysicsContext = GVRPhysicsContext.getInstance();
+        mLoaded = false;
     }
 
     /** Used only by {@link GVRPhysicsLoader} */
@@ -85,6 +87,7 @@ public class GVRRigidBody extends GVRPhysicsWorldObject {
         super(gvrContext, nativeRigidBody);
         mCollisionGroup = -1;
         mPhysicsContext = GVRPhysicsContext.getInstance();
+        mLoaded = true;
     }
 
     static public long getComponentType() {
@@ -428,7 +431,7 @@ public class GVRRigidBody extends GVRPhysicsWorldObject {
 
     @Override
     public void onAttach(GVRSceneObject newOwner) {
-        if (newOwner.getCollider() == null) {
+        if (!mLoaded && newOwner.getCollider() == null) {
             throw new UnsupportedOperationException("You must have a collider attached to the scene object before attaching the rigid body");
         }
         final GVRRenderData renderData = newOwner.getRenderData();
@@ -454,7 +457,7 @@ public class GVRRigidBody extends GVRPhysicsWorldObject {
 }
 
 class Native3DRigidBody {
-    static native long ctor();
+    static native long ctor(float mass);
 
     static native long getComponentType();
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fileloader.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_fileloader.cpp
@@ -39,8 +39,6 @@
 #include "bullet_point2pointconstraint.h"
 #include "bullet_sliderconstraint.h"
 
-static char tag[] = "BulletLoaderN";
-
 static btMatrix3x3 matrixInvIdty(1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f);
 static btTransform transformInvIdty(matrixInvIdty);
 

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.h
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/bullet/bullet_rigidbody.h
@@ -141,7 +141,6 @@ class BulletRigidBody : public PhysicsRigidBody,
     void updateConstructionInfo();
 
 private:
-    void initialize();
 
     void finalize();
 
@@ -149,8 +148,8 @@ private:
 
 
 private:
-    btRigidBody *mRigidBody;
     btRigidBody::btRigidBodyConstructionInfo mConstructionInfo;
+    btRigidBody *mRigidBody;
     btTransform m_centerOfMassOffset;
     btTransform prevPos;
     btVector3 mScale;

--- a/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_rigidbody_jni.cpp
+++ b/GVRf/Extensions/gvrf-physics/src/main/jni/engine/physics_rigidbody_jni.cpp
@@ -21,7 +21,7 @@
 namespace gvr {
 extern "C" {
     JNIEXPORT jlong JNICALL
-    Java_org_gearvrf_physics_Native3DRigidBody_ctor(JNIEnv * env, jobject obj);
+    Java_org_gearvrf_physics_Native3DRigidBody_ctor(JNIEnv * env, jobject obj, jfloat mass);
 
     JNIEXPORT jlong JNICALL
     Java_org_gearvrf_physics_Native3DRigidBody_getComponentType(JNIEnv * env, jobject obj);
@@ -139,8 +139,10 @@ extern "C" {
 }
 
 JNIEXPORT jlong JNICALL
-Java_org_gearvrf_physics_Native3DRigidBody_ctor(JNIEnv * env, jobject obj) {
-    return reinterpret_cast<jlong>(new BulletRigidBody());
+Java_org_gearvrf_physics_Native3DRigidBody_ctor(JNIEnv * env, jobject obj, jfloat mass) {
+    PhysicsRigidBody *rb = new BulletRigidBody();
+    rb->setMass(mass);
+    return reinterpret_cast<jlong>(rb);
 }
 
 JNIEXPORT jlong JNICALL


### PR DESCRIPTION
Do not change collision form and other settings from loaded rigid bodies, increasing accuracy when authoring physics.