### PR TITLE
framework: add null checks for the pause/resume of the controller reader

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -69,11 +69,15 @@ abstract class GVRViewManager extends GVRContext {
     }
 
     void onPause() {
-        mControllerReader.onPause();
+        if (null != mControllerReader) {
+            mControllerReader.onPause();
+        }
     }
 
     void onResume() {
-        mControllerReader.onResume();
+        if (null != mControllerReader) {
+            mControllerReader.onResume();
+        }
     }
 
     void onDestroy() {


### PR DESCRIPTION
Backend_monoscopic crashes otherwise.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>