### PR TITLE
framework, video scene object: fix random immersivepedia crash during shutdown

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRVideoSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRVideoSceneObject.java
@@ -517,7 +517,12 @@ public class GVRVideoSceneObject extends GVRSceneObject {
 
             @Override
             public void pause() {
-                mediaPlayer.pause();
+                try {
+                    mediaPlayer.pause();
+                } catch (final IllegalStateException exc) {
+                    //intentionally ignored; might have been released already or never got to be
+                    //initialized
+                }
             }
 
             @Override


### PR DESCRIPTION
```
06-19 07:45:00.899 27287 27287 E AndroidRuntime: FATAL EXCEPTION: main
06-19 07:45:00.899 27287 27287 E AndroidRuntime: Process: org.gearvrf.immersivepedia, PID: 27287
06-19 07:45:00.899 27287 27287 E AndroidRuntime: java.lang.RuntimeException: Unable to pause activity {org.gearvrf.immersivepedia/org.gearvrf.immersivepedia.MainActivity}: java.lang.IllegalStateException
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:4208)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4174)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4148)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:4122)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.ActivityThread.-wrap18(ActivityThread.java)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1671)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:102)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:154)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:6823)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1557)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1445)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: Caused by: java.lang.IllegalStateException
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.media.MediaPlayer._pause(Native Method)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.media.MediaPlayer.pause(MediaPlayer.java:1512)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at org.gearvrf.scene_objects.GVRVideoSceneObject$4.pause(GVRVideoSceneObject.java:522)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at org.gearvrf.scene_objects.GVRVideoSceneObject$1.onPause(GVRVideoSceneObject.java:55)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at org.gearvrf.GVREventManager.invokeMethod(GVREventManager.java:307)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at org.gearvrf.GVREventManager.sendEventWithMaskParamArray(GVREventManager.java:147)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at org.gearvrf.GVREventManager.sendEventWithMask(GVREventManager.java:113)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at org.gearvrf.GVRActivity.onPause(GVRActivity.java:197)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at org.gearvrf.immersivepedia.MainActivity.onPause(MainActivity.java:43)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.Activity.performPause(Activity.java:7185)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1330)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:4197)
06-19 07:45:00.899 27287 27287 E AndroidRuntime: 	... 11 more
06-19 07:45:29.422  1295  3168 I ActivityManager: Killing 27287:org.gearvrf.immersivepedia/u0a1050 (adj 900): crash
```

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>