### PR TITLE
Adding support in renderer for blend shapes

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRFloatImage.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRFloatImage.java
@@ -63,12 +63,12 @@ public class GVRFloatImage extends GVRImage
             throws IllegalArgumentException
     {
         super(gvrContext, NativeBitmapImage.constructor(ImageType.FLOAT_BITMAP.Value, GL_RG));
-        NativeFloatTexture.update(getNative(), width, height, data);
+        NativeFloatTexture.update(getNative(), width, height, GL_RG, data);
     }
 
-    public GVRFloatImage(GVRContext gvrContext)
+    public GVRFloatImage(GVRContext gvrContext, int pixelFormat)
     {
-        super(gvrContext, NativeBitmapImage.constructor(ImageType.FLOAT_BITMAP.Value, GL_RG));
+        super(gvrContext, NativeBitmapImage.constructor(ImageType.FLOAT_BITMAP.Value, pixelFormat));
     }
 
     /**
@@ -79,8 +79,7 @@ public class GVRFloatImage extends GVRImage
      * and some GL hardware handshaking. Reusing the texture reduces this
      * overhead (primarily by delaying garbage collection). Do be aware that
      * updating a texture will affect any and all {@linkplain GVRMaterial
-     * materials} (and/or post effects that use the
-     * texture!
+     * materials} (and/or post effects that use the texture!
      *
      * @param width
      *            Texture width, in pixels
@@ -105,10 +104,10 @@ public class GVRFloatImage extends GVRImage
         {
             throw new IllegalArgumentException();
         }
-        return NativeFloatTexture.update(getNative(), width, height, data);
+        return NativeFloatTexture.update(getNative(), width, height, 0, data);
     }
 }
 
 class NativeFloatTexture {
-    static native boolean update(long pointer, int width, int height, float[] data);
+    static native boolean update(long pointer, int width, int height, int pixelFormat, float[] data);
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRFloatImage.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRFloatImage.java
@@ -29,7 +29,9 @@
 
 package org.gearvrf;
 
+import static android.opengl.GLES20.GL_RGB;
 import static android.opengl.GLES30.GL_RG;
+import static android.opengl.GLES30.GL_RGB32F;
 
 /**
  * A specialized image, for doing computation on the GPU.
@@ -41,6 +43,7 @@ import static android.opengl.GLES30.GL_RG;
  */
 public class GVRFloatImage extends GVRImage
 {
+    protected int mFloatsPerPixel = 2;
     /**
      * Create a floating-point image.
      *
@@ -63,12 +66,16 @@ public class GVRFloatImage extends GVRImage
             throws IllegalArgumentException
     {
         super(gvrContext, NativeBitmapImage.constructor(ImageType.FLOAT_BITMAP.Value, GL_RG));
-        NativeFloatTexture.update(getNative(), width, height, GL_RG, data);
+        NativeFloatImage.update(getNative(), width, height, GL_RG, data);
     }
 
     public GVRFloatImage(GVRContext gvrContext, int pixelFormat)
     {
         super(gvrContext, NativeBitmapImage.constructor(ImageType.FLOAT_BITMAP.Value, pixelFormat));
+        if (pixelFormat == GL_RGB)
+        {
+            mFloatsPerPixel = 3;
+        }
     }
 
     /**
@@ -96,18 +103,18 @@ public class GVRFloatImage extends GVRImage
      *             {@code data} is {@code null}, or if
      *             {@code data.length < height * width * 2}
      */
-    public boolean update(int width, int height, float[] data)
+    public void update(int width, int height, float[] data)
             throws IllegalArgumentException
     {
         if ((width <= 0) || (height <= 0) ||
-            (data == null) || (data.length < height * width * 2))
+            (data == null) || (data.length < height * width * mFloatsPerPixel))
         {
             throw new IllegalArgumentException();
         }
-        return NativeFloatTexture.update(getNative(), width, height, 0, data);
+        NativeFloatImage.update(getNative(), width, height, 0, data);
     }
 }
 
-class NativeFloatTexture {
-    static native boolean update(long pointer, int width, int height, int pixelFormat, float[] data);
+class NativeFloatImage {
+    static native void update(long pointer, int width, int height, int pixelFormat, float[] data);
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshMorph.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshMorph.java
@@ -128,7 +128,7 @@ public class GVRMeshMorph extends GVRBehavior
         for (int i = 0; i < mNumVerts; ++i)
         {
             int b = i * mFloatsPerVertex + baseofs;
-            int s = (mNumVerts - i - 1) * mTexWidth + shapeofs;
+            int s = i * mTexWidth + shapeofs;
             mBlendShapeDiffs[s] = (vec3data[i * 3] - mBaseBlendShape[b]);
             mBlendShapeDiffs[s + 1] = (vec3data[i * 3 + 1] - mBaseBlendShape[b + 1]);
             mBlendShapeDiffs[s + 2] = (vec3data[i * 3 + 2] - mBaseBlendShape[b + 2]);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshMorph.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshMorph.java
@@ -68,12 +68,14 @@ public class GVRMeshMorph extends GVRBehavior
             throw new IllegalStateException("Cannot attach a morph to a scene object without a base mesh");
         }
         GVRShaderData mtl = getMaterial();
-        if ((mtl == null) || !mtl.getTextureDescriptor().contains("blendshapeTexture"))
+        if ((mtl == null) ||
+            !mtl.getTextureDescriptor().contains("blendshapeTexture"))
         {
             throw new IllegalStateException("Scene object shader does not support morphing");
         }
-        mtl.setInt("u_numblendshapes", mNumBlendShapes);
         copyBaseShape(mesh.getVertexBuffer());
+        mtl.setInt("u_numblendshapes", mNumBlendShapes);
+        mtl.setFloatArray("u_blendweights", mWeights);
     }
 
     public void onDetach(GVRSceneObject sceneObj)

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshMorph.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshMorph.java
@@ -1,0 +1,205 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf;
+
+import static android.opengl.GLES30.GL_RGB32F;
+
+public class GVRMeshMorph extends GVRBehavior
+{
+    static private long TYPE_MESHMORPH = newComponentType(GVRMeshMorph.class);
+
+    final protected int mNumBlendShapes;
+    final protected boolean mMorphNormals;
+    protected int mFloatsPerVertex;
+    protected int mTexWidth;
+    protected int mTexHeight;
+    protected float[] mWeights;
+    protected float[] mBlendShapeDiffs;
+    protected float[] mBaseBlendShape;
+
+    GVRMeshMorph(GVRContext ctx, int numBlendShapes, boolean morphNormals)
+    {
+        super(ctx, 0);
+        mType = getComponentType();
+        mNumBlendShapes = numBlendShapes;
+        mMorphNormals = morphNormals;
+        if (numBlendShapes <= 0)
+        {
+            throw new IllegalArgumentException("Number of blend shapes must be positive");
+        }
+        mFloatsPerVertex = 3;
+        mTexWidth = numBlendShapes * 3; // 3 floats for position
+        if (morphNormals)
+        {
+            mTexWidth *= 2;             // 3 more for normal
+            mFloatsPerVertex *= 3;
+        }
+    }
+
+    static public long getComponentType() { return TYPE_MESHMORPH; }
+
+    public void onAttach(GVRSceneObject sceneObj)
+    {
+        super.onAttach(sceneObj);
+        GVRComponent comp = getComponent(GVRRenderData.getComponentType());
+        if (comp == null)
+        {
+            throw new IllegalStateException("Cannot attach a morph to a scene object without a base mesh");
+        }
+        GVRMesh mesh = ((GVRRenderData) comp).getMesh();
+        if (mesh == null)
+        {
+            throw new IllegalStateException("Cannot attach a morph to a scene object without a base mesh");
+        }
+        GVRShaderData mtl = getMaterial();
+        if ((mtl == null) || !mtl.getTextureNames().contains("blendshapeTexture"))
+        {
+            throw new IllegalStateException("Scene object shader does not support morphing");
+        }
+        mtl.setFloat("u_numblendshapes", mNumBlendShapes);
+        initialize(mesh.getVertexBuffer());
+    }
+
+    public void onDetach(GVRSceneObject sceneObj)
+    {
+        mBlendShapeDiffs = null;
+        mBaseBlendShape = null;
+        mTexHeight = 0;
+    }
+
+    protected void initialize(GVRVertexBuffer baseShape)
+    {
+        mTexHeight = baseShape.getVertexCount();
+        if (mTexHeight <= 0)
+        {
+            throw new IllegalArgumentException("Base shape has no vertices");
+        }
+        mBaseBlendShape = new float[mFloatsPerVertex * mTexHeight];
+        mWeights = new float[mTexWidth];
+        mBlendShapeDiffs = new float[mTexWidth * mTexHeight];
+    }
+
+    protected void copyBlendShape(int shapeofs, int baseofs, float[] vec3data)
+    {
+        int numVerts = vec3data.length;
+        if (mBaseBlendShape == null)
+        {
+            throw new IllegalStateException("Must be attached to a scene object to set blend shapes");
+        }
+        if (mTexHeight != numVerts)
+        {
+            throw new IllegalArgumentException("All blend shapes must have the same number of vertices");
+        }
+
+        for (int i = 0; i < numVerts; ++i)
+        {
+            int b = i * mTexWidth;
+            int s = shapeofs + b;
+            b += baseofs;
+            mBlendShapeDiffs[s] = vec3data[i * 3] - mBaseBlendShape[b];
+            mBlendShapeDiffs[s + 1] = vec3data[i * 3 + 1] - mBaseBlendShape[b + 1];
+            mBlendShapeDiffs[s + 2] = vec3data[i * 3 + 2] - mBaseBlendShape[b + 2];
+        }
+    }
+
+    protected void copyBaseShape(GVRVertexBuffer vbuf)
+    {
+        float[] vec3data = vbuf.getFloatArray("a_position");
+        mTexHeight = vbuf.getVertexCount();
+        for (int i = 0; i < mTexHeight; ++i)
+        {
+            int t = i * mTexWidth;
+            mBaseBlendShape[t] = vec3data[i * 3];
+            mBaseBlendShape[t + 1] = vec3data[i * 3 + 1];
+            mBaseBlendShape[t + 2] = vec3data[i * 3 + 2];
+        }
+    }
+
+    public void setWeight(int index, float weight)
+    {
+        mWeights[index] = weight;
+    }
+
+    public float getWeight(int index)
+    {
+        return mWeights[index];
+    }
+
+    public void setWeights(float[] weights)
+    {
+        GVRMaterial mtl = getMaterial();
+        System.arraycopy(weights, 0, mWeights, 0, mWeights.length);
+        if (mtl != null)
+        {
+            mtl.setFloatArray("u_blendweights", mWeights);
+        }
+    }
+
+    public void setBlendShape(int index, GVRVertexBuffer vbuf)
+    {
+        copyBlendShape(index * mFloatsPerVertex, 0, vbuf.getFloatArray("a_position"));
+        if (mMorphNormals)
+        {
+            copyBlendShape(index * mFloatsPerVertex + 3, 3, vbuf.getFloatArray("a_normal"));
+        }
+    }
+
+    public void setBlendPositions(int index, float[] vec3data)
+    {
+        copyBlendShape(index * mFloatsPerVertex, 0, vec3data);
+    }
+
+    public void setBlendNormals(int index, float[] vec3data)
+    {
+        copyBlendShape(index * mFloatsPerVertex + 3, 3, vec3data);
+    }
+
+    private GVRMaterial getMaterial()
+    {
+        GVRComponent comp = getComponent(GVRRenderData.getComponentType());
+        if (comp == null)
+        {
+            return null;
+        }
+        return ((GVRRenderData) comp).getMaterial();
+    }
+
+    public boolean update()
+    {
+        GVRTexture blendshapeTex;
+        GVRFloatImage blendshapeImage;
+        GVRMaterial mtl = getMaterial();
+
+        if ((mBlendShapeDiffs == null) || (mtl == null))
+        {
+            return false;
+        }
+        if (mtl.hasTexture("blendshapeTexture"))
+        {
+            blendshapeTex = mtl.getTexture("blendShapeTexture");
+            blendshapeImage = (GVRFloatImage) blendshapeTex.getImage();
+        }
+        else
+        {
+            blendshapeImage = new GVRFloatImage(getGVRContext(), GL_RGB32F);
+            blendshapeTex = new GVRTexture(getGVRContext());
+            blendshapeTex.setImage(blendshapeImage);
+            mtl.setTexture("blendshapeTexture", blendshapeTex);
+        }
+        blendshapeImage.update(mTexWidth, mTexHeight, mBlendShapeDiffs);
+        return true;
+    }
+}

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshMorph.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRMeshMorph.java
@@ -30,7 +30,7 @@ public class GVRMeshMorph extends GVRBehavior
     protected float[] mBlendShapeDiffs;
     protected float[] mBaseBlendShape;
 
-    GVRMeshMorph(GVRContext ctx, int numBlendShapes, boolean morphNormals)
+    public GVRMeshMorph(GVRContext ctx, int numBlendShapes, boolean morphNormals)
     {
         super(ctx, 0);
         mType = getComponentType();
@@ -65,7 +65,7 @@ public class GVRMeshMorph extends GVRBehavior
             throw new IllegalStateException("Cannot attach a morph to a scene object without a base mesh");
         }
         GVRShaderData mtl = getMaterial();
-        if ((mtl == null) || !mtl.getTextureNames().contains("blendshapeTexture"))
+        if ((mtl == null) || !mtl.getTextureDescriptor().contains("blendshapeTexture"))
         {
             throw new IllegalStateException("Scene object shader does not support morphing");
         }
@@ -146,6 +146,21 @@ public class GVRMeshMorph extends GVRBehavior
         {
             mtl.setFloatArray("u_blendweights", mWeights);
         }
+    }
+
+    public void setBlendShape(int index, GVRSceneObject obj)
+    {
+        GVRRenderData rdata = obj.getRenderData();
+        GVRMesh mesh;
+        GVRVertexBuffer vbuf;
+
+        if ((rdata == null) ||
+            ((mesh = rdata.getMesh()) == null) ||
+            ((vbuf = mesh.getVertexBuffer()) == null))
+        {
+            throw new IllegalArgumentException("Scene object must have a mesh to be used as a blend shape");
+        }
+        setBlendShape(index, vbuf);
     }
 
     public void setBlendShape(int index, GVRVertexBuffer vbuf)

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/GVRAnimation.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/GVRAnimation.java
@@ -96,27 +96,27 @@ public abstract class GVRAnimation {
     public static final int DEFAULT_REPEAT_COUNT = 2;
 
     // Immutable values, passed to constructor
-    private final GVRHybridObject mTarget;
-    private final float mDuration;
+    protected final GVRHybridObject mTarget;
+    protected final float mDuration;
 
     // Defaulted values, which should be set before start()
-    private GVRInterpolator mInterpolator = null;
-    private int mRepeatMode = GVRRepeatMode.ONCE;
-    private int mRepeatCount = DEFAULT_REPEAT_COUNT;
-    private GVROnFinish mOnFinish = null;
+    protected GVRInterpolator mInterpolator = null;
+    protected int mRepeatMode = GVRRepeatMode.ONCE;
+    protected int mRepeatCount = DEFAULT_REPEAT_COUNT;
+    protected GVROnFinish mOnFinish = null;
 
     /**
      * This is derived from {@link #mOnFinish}. Doing the {@code instanceof}
      * test in {@link #setOnFinish(GVROnFinish)} means we <em>don't</em> have to
      * do it on every call, in {@link #onDrawFrame(float)}
      */
-    private GVROnRepeat mOnRepeat = null;
+    protected GVROnRepeat mOnRepeat = null;
 
     // Running state
-    private float mElapsedTime = 0f;
-    private int mIterations = 0;
-    
-    private boolean isFinished = false;
+    protected float mElapsedTime = 0f;
+    protected int mIterations = 0;
+
+    protected boolean isFinished = false;
 
     /**
      * Base constructor.

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/GVRMorphAnimation.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/GVRMorphAnimation.java
@@ -1,0 +1,54 @@
+package org.gearvrf.animation;
+
+import org.gearvrf.GVRHybridObject;
+import org.gearvrf.GVRMeshMorph;
+import org.gearvrf.PrettyPrint;
+import org.gearvrf.animation.keyframe.GVRFloatAnimation;
+import org.gearvrf.utility.Log;
+
+/** 
+ * Describes the animation of a set of floating point values.
+ */
+public final class GVRMorphAnimation extends GVRAnimation implements PrettyPrint
+{
+    private static final String TAG = GVRMorphAnimation.class.getSimpleName();
+    protected float[] mKeys;
+    protected GVRFloatAnimation mKeyInterpolator;
+    protected float[] mCurrentValues;
+
+    /**
+     * Constructor.
+     *
+     * @param keyData blend weight keys
+     * @param keySize number of floats per key
+     */
+    public GVRMorphAnimation(GVRMeshMorph target, float[] keyData, int keySize)
+    {
+        super(target, keyData[keyData.length - keySize] - keyData[0]);
+        mKeys = keyData;
+        mKeyInterpolator = new GVRFloatAnimation(keyData, keySize);
+        mCurrentValues = new float[keySize - 1];
+    }
+
+    public void animate(GVRHybridObject object, float animationTime)
+    {
+        GVRMeshMorph morph  = (GVRMeshMorph) mTarget;
+        mKeyInterpolator.animate(animationTime, mCurrentValues);
+        morph.setWeights(mCurrentValues);
+    }
+
+    @Override
+    public void prettyPrint(StringBuffer sb, int indent)
+    {
+        sb.append(Log.getSpaces(indent));
+        sb.append(GVRMorphAnimation.class.getSimpleName());
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        prettyPrint(sb, 0);
+        return sb.toString();
+    }
+}
+

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/keyframe/GVRAnimationController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/keyframe/GVRAnimationController.java
@@ -8,6 +8,8 @@ public abstract class GVRAnimationController {
         this.animation = animation;
     }
 
+    protected GVRAnimationController() { this.animation = null; }
+
     /**
      * Update animation to {@code timeInSeconds}. This function converts
      * time to ticks and invokes {@link #animateImpl}.

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/keyframe/GVRFloatAnimation.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/keyframe/GVRFloatAnimation.java
@@ -25,7 +25,7 @@ public final class GVRFloatAnimation implements PrettyPrint
             mKeyData = keyData;
             mFloatsPerKey = keySize;
             mLastKeyIndex = -1;
-            mDuration = keyData[keyData.length - keySize] - keyData[0];
+            mDuration = keyData[keyData.length - keySize] - keyData[0];Log.d("MORPH", "numkeys = %d floats per key = %d duration = %f ", getNumKeys(), mFloatsPerKey, mDuration);
         }
 
         protected float[] interpolate(float time, float[] destValues)
@@ -111,15 +111,9 @@ public final class GVRFloatAnimation implements PrettyPrint
             int firstOfs = getKeyOffset(keyIndex);
             int lastOfs = getKeyOffset(keyIndex + 1);
 
-            if ((firstOfs < 0) || (lastOfs < 0))
+            for (int i = 1; i < mFloatsPerKey; ++i)
             {
-                return false;
-            }
-            ++firstOfs;
-            ++lastOfs;
-            for (int i = 0; i < mFloatsPerKey - 1; ++i)
-            {
-                values[i] = factor * mKeyData[firstOfs + i] + (1.0f - factor) * mKeyData[lastOfs + i];
+                values[i - 1] = (1.0f - factor) * mKeyData[firstOfs + i] + factor * mKeyData[lastOfs + i];
             }
             return true;
         }
@@ -216,8 +210,6 @@ public final class GVRFloatAnimation implements PrettyPrint
         }
     };
 
-    final private int mFloatsPerKey;
-    final protected float[] mKeys;
     final private FloatKeyInterpolator mFloatInterpolator;
 
     /**
@@ -236,54 +228,7 @@ public final class GVRFloatAnimation implements PrettyPrint
         {
             throw new IllegalArgumentException("Not enough key data");
         }
-        mFloatsPerKey = keySize;
-        mKeys = keyData;
-        mFloatInterpolator = new FloatKeyInterpolator(mKeys, keySize);
-    }
-
-    /**
-     * Returns the number of keys.
-     * 
-     * @return the number of keys
-     */
-    public int getNumKeys() {
-        return mKeys.length / mFloatsPerKey;
-    }
-
-    /**
-     * Returns the time component of the specified key.
-     * 
-     * @param keyIndex the index of the position key
-     * @return the time component
-     */
-    public double getTime(int keyIndex) {
-        return mKeys[keyIndex * mFloatsPerKey];
-    }
-
-    /**
-     * Returns the scaling factor as vector.<p>
-     * 
-     * @param keyIndex the index of the scale key
-     * 
-     * @return the scaling factor as vector
-     */
-    public void getKey(int keyIndex, float[] values)
-    {
-        int index = keyIndex * mFloatsPerKey;
-        System.arraycopy(mKeys, index + 1, values, 0, values.length);
-    }
-
-    public void setKey(int keyIndex, float time, final float[] values)
-    {
-        int index = keyIndex * mFloatsPerKey;
-        Integer valSize = mFloatsPerKey - 1;
-
-        if (values.length != valSize)
-        {
-            throw new IllegalArgumentException("This key needs " + valSize.toString() + " float per value");
-        }
-        mKeys[index] = time;
-        System.arraycopy(values, 0, mKeys, index + 1, values.length);
+        mFloatInterpolator = new FloatKeyInterpolator(keyData, keySize);
     }
 
     /**
@@ -302,7 +247,7 @@ public final class GVRFloatAnimation implements PrettyPrint
     public void prettyPrint(StringBuffer sb, int indent) {
         sb.append(Log.getSpaces(indent));
         sb.append(GVRFloatAnimation.class.getSimpleName());
-        sb.append(" [ Keys=" + mKeys.length + "]");
+        sb.append(" [ Key[" + mFloatInterpolator.getNumKeys() + "]");
         sb.append(System.lineSeparator());
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/keyframe/GVRFloatAnimation.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/keyframe/GVRFloatAnimation.java
@@ -1,0 +1,216 @@
+package org.gearvrf.animation.keyframe;
+
+import org.gearvrf.PrettyPrint;
+import org.gearvrf.utility.Log;
+import org.joml.Matrix4f;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+/** 
+ * Describes the animation of a set of floating point values.
+ */
+public final class GVRFloatAnimation implements PrettyPrint
+{
+    private static final String TAG = GVRFloatAnimation.class.getSimpleName();
+
+    public static class FloatKeyInterpolator
+    {
+        private float[] mKeys;
+        private int mFloatsPerKey;
+        private int mLastKeyIndex;
+        private float[] mCurrentValues;
+
+        public FloatKeyInterpolator(float[] keys, int floatsPerKey)
+        {
+            mKeys = keys;
+            mFloatsPerKey = floatsPerKey;
+            mLastKeyIndex = -1;
+            mCurrentValues = new float[floatsPerKey - 1];
+        }
+
+        protected float[] interpolate(float time)
+        {
+            int index = getKeyIndex(time);
+            int nextIndex = index;
+
+            if (index != -1 &&
+                (mKeys[index] <= time) &&
+                (time < mKeys[nextIndex]))
+            {
+                // interpolate
+                float deltaTime = mKeys[nextIndex] - mKeys[index];
+                float factor = (time - mKeys[index] / deltaTime);
+                for (int i = 1; i < mFloatsPerKey; ++i)
+                {
+                    mCurrentValues[i] = factor * mKeys[index + i] + (1.0f - factor) * mKeys[nextIndex + i];
+                }
+            }
+            else
+            {
+                // time is out of range of animation time frame
+                if (time <= mKeys[0])
+                {
+                    System.arraycopy(mKeys, 1, mCurrentValues, 0, mFloatsPerKey - 1);
+                }
+                else
+                {
+                    System.arraycopy(mKeys, mKeys.length - mFloatsPerKey + 1, mCurrentValues, 0, mFloatsPerKey - 1);
+                }
+            }
+            return mCurrentValues;
+        }
+
+        protected int getKeyIndex(float time)
+        {
+            // Try cached key first
+            if (mLastKeyIndex != -1)
+            {
+                if ((mKeys[mLastKeyIndex] <= time) &&
+                    (time < mKeys[mLastKeyIndex + mFloatsPerKey]))
+                {
+                    return mLastKeyIndex;
+                }
+                // Try neighboring keys
+                if (((mLastKeyIndex + 2 * mFloatsPerKey) < mKeys.length) &&
+                     (mKeys[mLastKeyIndex + mFloatsPerKey] <= time) &&
+                     (time < mKeys[mLastKeyIndex + 2 * mFloatsPerKey]))
+                {
+                    return mLastKeyIndex += mFloatsPerKey;
+                }
+                if ((mLastKeyIndex >= 1) &&
+                    ((mKeys[mLastKeyIndex - mFloatsPerKey]) <= time) &&
+                    (time < mKeys[mLastKeyIndex]))
+                {
+                    return mLastKeyIndex -= mFloatsPerKey;
+                }
+            }
+
+            // Binary search for the interval
+            // Each of the index i represents an interval I(i) = [time(i), time(i + 1)).
+            int low = 0, high = mKeys.length - 2 * mFloatsPerKey;
+            // invariant: I(low)...I(high) contains time if time can be found
+            // post-condition: |high - low| <= 1, only need to check I(low) and I(low + 1)
+            while (high - low > 1)
+            {
+                int mid = ((low + high) / 2) * mFloatsPerKey;
+                if (time < mKeys[mid])
+                {
+                    high = mid;
+                }
+                else if (time >= mKeys[mid + mFloatsPerKey])
+                {
+                    low = mid + 1;
+                }
+                else
+                    {
+                    // time in I(mid) by definition
+                    return mLastKeyIndex = mid;
+                }
+            }
+            if ((mKeys[low] <= time) &&
+                (time < mKeys[low + mFloatsPerKey]))
+            {
+                return mLastKeyIndex = low;
+            }
+            if ((low + 2 * mFloatsPerKey < mKeys.length) &&
+                (mKeys[low + mFloatsPerKey] <= time) &&
+                (time < mKeys[low + 2 * mFloatsPerKey]))
+            {
+                return mLastKeyIndex = low + mFloatsPerKey;
+            }
+            Log.v(TAG, "Warning: interpolation failed at time " + time);
+            return mLastKeyIndex = -1;
+        }
+    };
+
+    private int mFloatsPerKey;
+    protected float[] mKeys;
+    private final FloatKeyInterpolator mFloatInterpolator;
+
+    /**
+     * Constructor.
+     *
+     * @param keyData animation key data
+     * @param keySize number of floats per key
+     */
+    public GVRFloatAnimation(float[] keyData, int keySize)
+    {
+        mFloatsPerKey = keySize;
+        mKeys = keyData;
+        mFloatInterpolator = new FloatKeyInterpolator(mKeys, keySize);
+    }
+
+    /**
+     * Returns the number of keys.
+     * 
+     * @return the number of keys
+     */
+    public int getNumKeys() {
+        return mKeys.length / mFloatsPerKey;
+    }
+
+    /**
+     * Returns the time component of the specified key.
+     * 
+     * @param keyIndex the index of the position key
+     * @return the time component
+     */
+    public double getTime(int keyIndex) {
+        return mKeys[keyIndex * mFloatsPerKey];
+    }
+
+    /**
+     * Returns the scaling factor as vector.<p>
+     * 
+     * @param keyIndex the index of the scale key
+     * 
+     * @return the scaling factor as vector
+     */
+    public void getKey(int keyIndex, float[] values)
+    {
+        int index = keyIndex * mFloatsPerKey;
+        System.arraycopy(mKeys, index + 1, values, 0, values.length);
+    }
+
+    public void setKey(int keyIndex, float time, final float[] values)
+    {
+        int index = keyIndex * mFloatsPerKey;
+        mKeys[index] = time;
+        System.arraycopy(values, 0, mKeys, index + 1, values.length);
+    }
+
+    public void setKeys(float[] keys)
+    {
+        mKeys = keys;
+    }
+
+    /**
+     * Obtains the transform for a specific time in animation.
+     * 
+     * @param animationTime The time in animation.
+     * 
+     * @return The transform.
+     */
+    public void animate(float animationTime, float[] destValues)
+    {
+        float[] currentValues = mFloatInterpolator.interpolate(animationTime);
+        System.arraycopy(currentValues, 0, destValues, 0, mFloatsPerKey - 1);
+    }
+
+    @Override
+    public void prettyPrint(StringBuffer sb, int indent) {
+        sb.append(Log.getSpaces(indent));
+        sb.append(GVRFloatAnimation.class.getSimpleName());
+        sb.append(" [ Keys=" + mKeys.length + "]");
+        sb.append(System.lineSeparator());
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        prettyPrint(sb, 0);
+        return sb.toString();
+    }
+
+}
+

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/keyframe/GVRMorphController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/keyframe/GVRMorphController.java
@@ -1,0 +1,49 @@
+package org.gearvrf.animation.keyframe;
+
+import org.gearvrf.GVRMeshMorph;
+import org.gearvrf.PrettyPrint;
+import org.gearvrf.utility.Log;
+
+/** 
+ * Describes the animation of a set of floating point values.
+ */
+public final class GVRMorphController implements PrettyPrint
+{
+    private static final String TAG = GVRMorphController.class.getSimpleName();
+    protected float[] mKeys;
+    protected GVRFloatAnimation mKeyInterpolator;
+    protected float[] mCurrentValues;
+
+    /**
+     * Constructor.
+     *
+     * @param keyData blend weight keys
+     * @param keySize number of floats per key
+     */
+    public GVRMorphController(GVRMeshMorph target, float[] keyData, int keySize)
+    {
+        mKeys = keyData;
+        mKeyInterpolator = new GVRFloatAnimation(keyData, keySize);
+        mCurrentValues = new float[keySize - 1];
+    }
+
+    public void animate(float animationTime)
+    {
+        mKeyInterpolator.animate(animationTime, mCurrentValues);
+    }
+
+    @Override
+    public void prettyPrint(StringBuffer sb, int indent)
+    {
+        sb.append(Log.getSpaces(indent));
+        sb.append(GVRMorphController.class.getSimpleName());
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        prettyPrint(sb, 0);
+        return sb.toString();
+    }
+}
+

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/shaders/GVRPhongShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/shaders/GVRPhongShader.java
@@ -46,7 +46,7 @@ import org.gearvrf.R;
 
        public GVRPhongShader(GVRContext gvrcontext)
        {
-            super("float4 ambient_color; float4 diffuse_color; float4 specular_color; float4 emissive_color; float3 u_color; float u_opacity; float specular_exponent; float line_width; float2 u_lightmap_offset; float2 u_lightmap_scale; float u_numblendshapes; float u_weights[20];",
+            super("float4 ambient_color; float4 diffuse_color; float4 specular_color; float4 emissive_color; float3 u_color; float u_opacity; float specular_exponent; float line_width; float2 u_lightmap_offset; float2 u_lightmap_scale; int u_numblendshapes; float u_blendweights[20];",
                    "sampler2D diffuseTexture; sampler2D ambientTexture; sampler2D specularTexture; sampler2D opacityTexture; sampler2D lightmapTexture; sampler2D normalTexture; sampler2D emissiveTexture; sampler2D blendshapeTexture",
                    "float3 a_position float2 a_texcoord float2 a_texcoord1 float2 a_texcoord2 float2 a_texcoord3 float3 a_normal float4 a_bone_weights int4 a_bone_indices float3 a_tangent float3 a_bitangent",
                    GLSLESVersion.VULKAN);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/shaders/GVRPhongShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/shaders/GVRPhongShader.java
@@ -42,34 +42,25 @@ import org.gearvrf.R;
        private static String vtxShader = null;
        private static String normalShader = null;
        private static String skinShader = null;
-       private boolean useMultitex = true;
+       private static String morphShader = null;
 
        public GVRPhongShader(GVRContext gvrcontext)
        {
-            super("float4 ambient_color; float4 diffuse_color; float4 specular_color; float4 emissive_color; float3 u_color; float u_opacity; float specular_exponent; float line_width; float2 u_lightmap_offset; float2 u_lightmap_scale",
-                   "sampler2D diffuseTexture; sampler2D ambientTexture; sampler2D specularTexture; sampler2D opacityTexture; sampler2D lightmapTexture; sampler2D normalTexture; sampler2D emissiveTexture",
+            super("float4 ambient_color; float4 diffuse_color; float4 specular_color; float4 emissive_color; float3 u_color; float u_opacity; float specular_exponent; float line_width; float2 u_lightmap_offset; float2 u_lightmap_scale; float u_numblendshapes; float u_weights[20];",
+                   "sampler2D diffuseTexture; sampler2D ambientTexture; sampler2D specularTexture; sampler2D opacityTexture; sampler2D lightmapTexture; sampler2D normalTexture; sampler2D emissiveTexture; sampler2D blendshapeTexture",
                    "float3 a_position float2 a_texcoord float2 a_texcoord1 float2 a_texcoord2 float2 a_texcoord3 float3 a_normal float4 a_bone_weights int4 a_bone_indices float3 a_tangent float3 a_bitangent",
                    GLSLESVersion.VULKAN);
 
            if (fragTemplate == null)
            {
                Context context = gvrcontext.getContext();
-               if (useMultitex)
-               {
-                   fragTemplate = TextFile.readTextFile(context, R.raw.fragment_template_multitex);
-                   vtxTemplate = TextFile.readTextFile(context, R.raw.vertex_template_multitex);
-                   surfaceShader = TextFile.readTextFile(context, R.raw.phong_surface_multitex);
-                   vtxShader = TextFile.readTextFile(context, R.raw.pos_norm_multitex);
-               }
-               else
-               {
-                   fragTemplate = TextFile.readTextFile(context, R.raw.fragment_template);
-                   vtxTemplate = TextFile.readTextFile(context, R.raw.vertex_template);
-                   surfaceShader = TextFile.readTextFile(context, R.raw.phong_surface);
-                   vtxShader = TextFile.readTextFile(context, R.raw.pos_norm_tex);
-               }
+               fragTemplate = TextFile.readTextFile(context, R.raw.fragment_template_multitex);
+               vtxTemplate = TextFile.readTextFile(context, R.raw.vertex_template_multitex);
+               surfaceShader = TextFile.readTextFile(context, R.raw.phong_surface_multitex);
+               vtxShader = TextFile.readTextFile(context, R.raw.pos_norm_multitex);
                normalShader = TextFile.readTextFile(context, R.raw.normalmap);
                skinShader = TextFile.readTextFile(context, R.raw.vertexskinning);
+               morphShader = TextFile.readTextFile(context, R.raw.vertexmorph);
                addLight = TextFile.readTextFile(context, R.raw.addlight);
            }
            setSegment("FragmentTemplate", fragTemplate);
@@ -77,6 +68,7 @@ import org.gearvrf.R;
            setSegment("FragmentSurface", surfaceShader);
            setSegment("FragmentAddLight", addLight);
            setSegment("VertexSkinShader", skinShader);
+           setSegment("VertexMorphShader", morphShader);
            setSegment("VertexShader", vtxShader);
            setSegment("VertexNormalShader", normalShader);
 

--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/gl_renderer.cpp
@@ -95,13 +95,13 @@ namespace gvr
         return new GLUniformBlock(desc, binding, name, maxelems);
     }
 
-    Image *GLRenderer::createImage(int type, int format)
+    Image* GLRenderer::createImage(int type, int format)
     {
         switch (type)
         {
             case Image::ImageType::BITMAP: return new GLBitmapImage(format);
             case Image::ImageType::CUBEMAP: return new GLCubemapImage(format);
-            case Image::ImageType::FLOAT_BITMAP: return new GLFloatImage();
+            case Image::ImageType::FLOAT_BITMAP: return new GLFloatImage(format);
         }
         return NULL;
     }

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
@@ -64,7 +64,6 @@ int GLBitmapImage::updateFromBitmap(JNIEnv *env, int target, jobject bitmap, boo
             case GL_RGBA16F:
                 dataFormat = GL_HALF_FLOAT;
                 break;
-
         }
         glTexImage2D(target, 0, internalFormat, info.width, info.height, 0, pixelFormat,
                      dataFormat, pixels);

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
@@ -27,7 +27,7 @@ namespace gvr {
     class GLFloatImage : public GLImage, public FloatImage
     {
     public:
-        GLFloatImage() : FloatImage(), GLImage(GL_TEXTURE_2D)
+        GLFloatImage(int pixelFormat = GL_RG) : FloatImage(pixelFormat), GLImage(GL_TEXTURE_2D)
         { }
         virtual ~GLFloatImage() {}
         virtual int getId() { return mId; }
@@ -58,7 +58,7 @@ namespace gvr {
             jfloatArray array = static_cast<jfloatArray>(env->NewLocalRef(mData));
             float* pixels = env->GetFloatArrayElements(array, 0);
             glBindTexture(mType, texid);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RG32F, mWidth, mHeight, 0, GL_RG, GL_FLOAT, pixels);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RG32F, mWidth, mHeight, 0, mFormat, GL_FLOAT, pixels);
             glGenerateMipmap(mType);
             env->ReleaseFloatArrayElements(array, pixels, 0);
             env->DeleteLocalRef(array);

--- a/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_float_image.h
@@ -43,23 +43,28 @@ namespace gvr {
                 mTexParamsDirty = true;
             }
         }
-        void updateTexParams() {
+
+        void updateTexParams()
+        {
             int min_filter = mTexParams.getMinFilter();
 
-            if(mIsCompressed && mLevels <= 1 && min_filter >= TextureParameters::NEAREST_MIPMAP_NEAREST)
+            if (mIsCompressed &&
+                (mLevels <= 1) &&
+                (min_filter >= TextureParameters::NEAREST_MIPMAP_NEAREST))
+            {
                 mTexParams.setMinFilter(GL_LINEAR);
-
+            }
             GLImage::updateTexParams(mTexParams);
         }
     protected:
         virtual void update(int texid)
         {
-            JNIEnv *env = getCurrentEnv(mJava);
+            JNIEnv* env = getCurrentEnv(mJava);
             jfloatArray array = static_cast<jfloatArray>(env->NewLocalRef(mData));
             float* pixels = env->GetFloatArrayElements(array, 0);
+            int internalFormat = (mFormat == GL_RGB) ? GL_RGB32F : GL_RG32F;
             glBindTexture(mType, texid);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RG32F, mWidth, mHeight, 0, mFormat, GL_FLOAT, pixels);
-            glGenerateMipmap(mType);
+            glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, mWidth, mHeight, 0, mFormat, GL_FLOAT, pixels);
             env->ReleaseFloatArrayElements(array, pixels, 0);
             env->DeleteLocalRef(array);
             clearData(env);

--- a/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/bounding_volume.cpp
@@ -149,7 +149,7 @@ void BoundingVolume::transform(const BoundingVolume &in_volume, glm::mat4 matrix
 
     for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++) {
-            scratch_abs_matrix[i][j] = abs(matrix[i][j]);
+            scratch_abs_matrix[i][j] = fabs(matrix[i][j]);
         }
     }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/float_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/float_image.cpp
@@ -16,7 +16,7 @@
 #include "float_image.h"
 
 namespace gvr {
-    FloatImage::FloatImage() : Image(ImageType::FLOAT_BITMAP, GL_RG),
+    FloatImage::FloatImage(int pixelFormat) : Image(ImageType::FLOAT_BITMAP, pixelFormat),
                                mJava(NULL), mData(NULL)
     {
     }
@@ -31,13 +31,17 @@ namespace gvr {
         }
     }
 
-    void FloatImage::update(JNIEnv* env, int width, int height, jfloatArray data)
+    void FloatImage::update(JNIEnv* env, int width, int height, jfloatArray data, int pixelFormat)
     {
         std::lock_guard<std::mutex> lock(mUpdateLock);
         env->GetJavaVM(&mJava);
         clearData(env);
         mWidth = width;
         mHeight = height;
+        if (pixelFormat)
+        {
+            mFormat = pixelFormat;
+        }
         if (data != NULL)
         {
             mData = static_cast<jfloatArray>(env->NewGlobalRef(data));

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/float_image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/float_image.h
@@ -28,9 +28,9 @@ namespace gvr {
     class FloatImage : public Image
     {
     public:
-        FloatImage();
+        FloatImage(int pixelFormat = GL_RG);
         virtual ~FloatImage();
-        void update(JNIEnv* env, int width, int height, jfloatArray data);
+        void update(JNIEnv* env, int width, int height, jfloatArray data, int pixelFormat = 0);
 
     protected:
         void clearData(JNIEnv* env);

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/float_image_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/float_image_jni.cpp
@@ -23,19 +23,19 @@ namespace gvr {
 extern "C"
 {
     JNIEXPORT void JNICALL
-    Java_org_gearvrf_NativeFloatImage_update(JNIEnv* env, jobject obj, jlong jtexture,
+    Java_org_gearvrf_NativeFloatImage_update(JNIEnv* env, jobject obj, jlong jimage,
                                              jint width, jint height,
                                              jint pixelFormat, jfloatArray jdata);
 };
 
 JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeFloatImage_update(JNIEnv * env, jobject obj, jlong jtexture,
+Java_org_gearvrf_NativeFloatImage_update(JNIEnv* env, jobject obj, jlong jimage,
                                          jint width, jint height,
                                          jint pixelFormat, jfloatArray jdata)
 {
-    FloatImage* texture = reinterpret_cast<FloatImage*>(jtexture);
+    FloatImage* image = reinterpret_cast<FloatImage*>(jimage);
     jfloat* data = env->GetFloatArrayElements(jdata, 0);
-    texture->update(env, width, height, jdata, pixelFormat);
+    image->update(env, width, height, jdata, pixelFormat);
     env->ReleaseFloatArrayElements(jdata, data, 0);
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/float_image_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/float_image_jni.cpp
@@ -20,20 +20,23 @@
 #include "float_image.h"
 
 namespace gvr {
-    extern "C" {
+extern "C"
+{
     JNIEXPORT void JNICALL
-            Java_org_gearvrf_NativeFloatImage_update(JNIEnv * env,
-                                                     jobject obj, jlong jtexture, jint width, jint height, jfloatArray jdata);
-    }
-    ;
+    Java_org_gearvrf_NativeFloatImage_update(JNIEnv* env, jobject obj, jlong jtexture,
+                                             jint width, jint height,
+                                             jint pixelFormat, jfloatArray jdata);
+};
 
-    JNIEXPORT void JNICALL
-    Java_org_gearvrf_NativeFloatImage_update(JNIEnv * env,
-                                             jobject obj, jlong jtexture, jint width, jint height, jfloatArray jdata) {
-        FloatImage* texture = reinterpret_cast<FloatImage*>(jtexture);
-        jfloat* data = env->GetFloatArrayElements(jdata, 0);
-        texture->update(env, width, height, jdata);
-        env->ReleaseFloatArrayElements(jdata, data, 0);
-    }
+JNIEXPORT void JNICALL
+Java_org_gearvrf_NativeFloatImage_update(JNIEnv * env, jobject obj, jlong jtexture,
+                                         jint width, jint height,
+                                         jint pixelFormat, jfloatArray jdata)
+{
+    FloatImage* texture = reinterpret_cast<FloatImage*>(jtexture);
+    jfloat* data = env->GetFloatArrayElements(jdata, 0);
+    texture->update(env, width, height, jdata, pixelFormat);
+    env->ReleaseFloatArrayElements(jdata, data, 0);
+}
 
 }

--- a/GVRf/Framework/framework/src/main/res/raw/phong_surface.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/phong_surface.fsh
@@ -1,14 +1,13 @@
 @MATERIAL_UNIFORMS
 
-layout ( set = 0, binding = 11 ) uniform sampler2D ambientTexture;
 layout ( set = 0, binding = 10 ) uniform sampler2D diffuseTexture;
+layout ( set = 0, binding = 11 ) uniform sampler2D ambientTexture;
 layout ( set = 0, binding = 12 ) uniform sampler2D specularTexture;
 layout ( set = 0, binding = 13 ) uniform sampler2D opacityTexture;
 layout ( set = 0, binding = 14 ) uniform sampler2D lightmapTexture;
-layout ( set = 0, binding = 16 ) uniform sampler2D emissiveTexture;
 layout ( set = 0, binding = 15 ) uniform sampler2D normalTexture;
-layout ( set = 0, binding = 8 ) uniform vec2 u_lightmap_offset;
-layout ( set = 0, binding = 9 ) uniform vec2 u_lightmap_scale;
+layout ( set = 0, binding = 16 ) uniform sampler2D emissiveTexture;
+layout ( set = 0, binding = 17 ) uniform sampler2D blendshapeTexture;
 
 struct Surface
 {

--- a/GVRf/Framework/framework/src/main/res/raw/phong_surface.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/phong_surface.fsh
@@ -7,7 +7,6 @@ layout ( set = 0, binding = 13 ) uniform sampler2D opacityTexture;
 layout ( set = 0, binding = 14 ) uniform sampler2D lightmapTexture;
 layout ( set = 0, binding = 15 ) uniform sampler2D normalTexture;
 layout ( set = 0, binding = 16 ) uniform sampler2D emissiveTexture;
-layout ( set = 0, binding = 17 ) uniform sampler2D blendshapeTexture;
 
 struct Surface
 {

--- a/GVRf/Framework/framework/src/main/res/raw/phong_surface_layertex.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/phong_surface_layertex.fsh
@@ -2,61 +2,62 @@
 @MATERIAL_UNIFORMS
 
 #ifdef HAS_ambientTexture
-layout(location = 5) in vec2 ambient_coord;
-#endif
-
-#ifdef HAS_opacityTexture
-layout(location = 9) in vec2 opacity_coord;
+layout(location = 11) in vec2 ambient_coord;
 #endif
 
 #ifdef HAS_specularTexture
-layout(location = 6) in vec2 specular_coord;
+layout(location = 12) in vec2 specular_coord;
 #endif
 
-#ifdef HAS_emissiveTexture
-layout(location = 7) in vec2 emissive_coord;
-#endif
-
-#ifdef HAS_normalTexture
-layout(location = 10) in vec2 normal_coord;
+#ifdef HAS_opacityTexture
+layout(location = 13) in vec2 opacity_coord;
 #endif
 
 #ifdef HAS_lightMapTexture
-layout(location = 8) in vec2 lightmap_coord;
+layout(location = 14) in vec2 lightmap_coord;
+#endif
+
+#ifdef HAS_normalTexture
+layout(location = 15) in vec2 normal_coord;
+#endif
+
+#ifdef HAS_emissiveTexture
+layout(location = 16) in vec2 emissive_coord;
 #endif
 
 #ifdef HAS_ambientTexture1
-layout(location = 12) in vec2 ambient_coord1;
-layout(set = 0, binding = 13) uniform sampler2D ambientTexture1;
+layout(location = 18) in vec2 ambient_coord1;
+layout(set = 0, binding = 18) uniform sampler2D ambientTexture1;
 #endif
 
 #ifdef HAS_diffuseTexture1
-layout(location = 11) in vec2 diffuse_coord1;
-layout(set = 0, binding = 12) uniform sampler2D diffuseTexture1;
+layout(location = 19) in vec2 diffuse_coord1;
+layout(set = 0, binding = 19) uniform sampler2D diffuseTexture1;
 #endif
 
 #ifdef HAS_specularTexture1
-layout(location = 13) in vec2 specular_coord1;
-layout(set = 0, binding = 14) uniform sampler2D specularTexture1;
+layout(location = 20) in vec2 specular_coord1;
+layout(set = 0, binding = 20) uniform sampler2D specularTexture1;
 #endif
 
 #ifdef HAS_emissiveTexture1
-layout(location = 14) in vec2 emissive_coord1;
-layout(set = 0, binding = 15) uniform sampler2D emissiveTexture1;
+layout(location = 21) in vec2 emissive_coord1;
+layout(set = 0, binding = 21) uniform sampler2D emissiveTexture1;
 #endif
 
 #ifdef HAS_lightMapTexture1
 in vec2 lightmap_coord1;
 #endif
 
+layout ( set = 0, binding = 10 ) uniform sampler2D diffuseTexture;
+layout ( set = 0, binding = 11 ) uniform sampler2D ambientTexture;
+layout ( set = 0, binding = 12 ) uniform sampler2D specularTexture;
+layout ( set = 0, binding = 13 ) uniform sampler2D opacityTexture;
+layout ( set = 0, binding = 14 ) uniform sampler2D lightmapTexture;
+layout ( set = 0, binding = 15 ) uniform sampler2D normalTexture;
+layout ( set = 0, binding = 16 ) uniform sampler2D emissiveTexture;
+layout ( set = 0, binding = 17 ) uniform sampler2D blendshapeTexture;
 
-layout(set = 0, binding = 6) uniform sampler2D ambientTexture;
-layout(set = 0, binding = 5) uniform sampler2D diffuseTexture;
-layout(set = 0, binding = 7) uniform sampler2D specularTexture;
-layout(set = 0, binding = 8) uniform sampler2D opacityTexture;
-layout(set = 0, binding = 9) uniform sampler2D lightmapTexture;
-layout(set = 0, binding = 11) uniform sampler2D emissiveTexture;
-layout(set = 0, binding = 10) uniform sampler2D normalTexture;
 
 struct Surface
 {

--- a/GVRf/Framework/framework/src/main/res/raw/phong_surface_multitex.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/phong_surface_multitex.fsh
@@ -2,36 +2,39 @@
 @MATERIAL_UNIFORMS
 
 #ifdef HAS_ambientTexture
-layout(location = 5) in vec2 ambient_coord;
-#endif
-
-#ifdef HAS_opacityTexture
-layout(location = 9) in vec2 opacity_coord;
+layout(location = 11) in vec2 ambient_coord;
 #endif
 
 #ifdef HAS_specularTexture
-layout(location = 6) in vec2 specular_coord;
+layout(location = 12) in vec2 specular_coord;
 #endif
 
-#ifdef HAS_emissiveTexture
-layout(location = 7) in vec2 emissive_coord;
-#endif
-
-#ifdef HAS_normalTexture
-layout(location = 10) in vec2 normal_coord;
+#ifdef HAS_opacityTexture
+layout(location = 13) in vec2 opacity_coord;
 #endif
 
 #ifdef HAS_lightMapTexture
-layout(location = 8) in vec2 lightmap_coord;
+layout(location = 14) in vec2 lightmap_coord;
 #endif
 
-layout(set = 0, binding = 6) uniform sampler2D ambientTexture;
-layout(set = 0, binding = 5) uniform sampler2D diffuseTexture;
-layout(set = 0, binding = 7) uniform sampler2D specularTexture;
-layout(set = 0, binding = 8) uniform sampler2D opacityTexture;
-layout(set = 0, binding = 9) uniform sampler2D lightmapTexture;
-layout(set = 0, binding = 11) uniform sampler2D emissiveTexture;
-layout(set = 0, binding = 10) uniform sampler2D normalTexture;
+#ifdef HAS_normalTexture
+layout(location = 15) in vec2 normal_coord;
+#endif
+
+#ifdef HAS_emissiveTexture
+layout(location = 16) in vec2 emissive_coord;
+#endif
+
+
+layout ( set = 0, binding = 10 ) uniform sampler2D diffuseTexture;
+layout ( set = 0, binding = 11 ) uniform sampler2D ambientTexture;
+layout ( set = 0, binding = 12 ) uniform sampler2D specularTexture;
+layout ( set = 0, binding = 13 ) uniform sampler2D opacityTexture;
+layout ( set = 0, binding = 14 ) uniform sampler2D lightmapTexture;
+layout ( set = 0, binding = 15 ) uniform sampler2D normalTexture;
+layout ( set = 0, binding = 16 ) uniform sampler2D emissiveTexture;
+layout ( set = 0, binding = 17 ) uniform sampler2D blendshapeTexture;
+
 
 struct Surface
 {

--- a/GVRf/Framework/framework/src/main/res/raw/pos_norm_multitex.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/pos_norm_multitex.vsh
@@ -4,19 +4,14 @@
 #else
   vec4 pos = u_mv * vertex.local_position;
 #endif
-
-vertex.viewspace_position = pos.xyz / pos.w;
-#ifdef HAS_a_normal
-   vertex.local_normal = vec4(normalize(a_normal), 0.0);
-#endif
+   vertex.viewspace_position = pos.xyz / pos.w;
 
 #ifdef HAS_MULTIVIEW
 	vertex.viewspace_normal = normalize((u_mv_it_[gl_ViewID_OVR] * vertex.local_normal).xyz);
 #else
 	vertex.viewspace_normal = normalize((u_mv_it * vertex.local_normal).xyz);
 #endif
-
-vertex.view_direction = normalize(-vertex.viewspace_position);
+    vertex.view_direction = normalize(-vertex.viewspace_position);
 #ifdef HAS_a_texcoord
 //
 // Default to using the first set of texture coordinates

--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
@@ -9,7 +9,10 @@ layout(num_views = 2) in;
 #endif
 precision highp float;
 precision lowp int;
+
 @MATRIX_UNIFORMS
+
+@MATERIAL_UNIFORMS
 
 layout(location = 0) in vec3 a_position;
 
@@ -48,6 +51,9 @@ layout(location = 14) out vec2 lightmap_coord;
 layout(location = 15) out vec2 normal_coord;
 layout(location = 16) out vec2 emissive_coord;
 
+#ifdef HAS_blendshapeTexture
+layout (set = 0, binding = 17) uniform sampler2D blendshapeTexture;
+#endif
 
 struct Vertex
 {

--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
@@ -72,17 +72,23 @@ void main() {
 	Vertex vertex;
 
 	vertex.local_position = vec4(a_position.xyz, 1.0);
-	vertex.local_normal = vec4(0.0, 0.0, 1.0, 0.0);
-	@VertexShader
+#ifdef HAS_a_normal
+    vertex.local_normal = vec4(normalize(a_normal), 0.0);
+#endif
 #ifdef HAS_VertexMorphShader
-    @VertexMorphShader
+@VertexMorphShader
 #endif
+
+@VertexShader
+
 #ifdef HAS_VertexSkinShader
-	@VertexSkinShader
+@VertexSkinShader
 #endif
+
 #ifdef HAS_VertexNormalShader
-	@VertexNormalShader
+@VertexNormalShader
 #endif
+
 #ifdef HAS_LIGHTSOURCES
 	LightVertex(vertex);
 #endif
@@ -95,7 +101,7 @@ void main() {
 #ifdef HAS_MULTIVIEW
     bool render_mask = (u_render_mask & (gl_ViewID_OVR + uint(1))) > uint(0) ? true : false;
     mat4 mvp = u_mvp_[gl_ViewID_OVR];
-    if(!render_mask)
+    if (!render_mask)
         mvp = mat4(0.0);  //  if render_mask is not set for particular eye, dont render that object
     gl_Position = mvp  * vertex.local_position;
 #else

--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template.vsh
@@ -40,11 +40,15 @@ layout(location = 0) out vec3 view_direction;
 layout(location = 1) out vec3 viewspace_position;
 layout(location = 2) out vec3 viewspace_normal;
 layout(location = 3) out vec4 local_position;
-layout(location = 4) out vec2 diffuse_coord;
-layout(location = 5) out vec2 ambient_coord;
-layout(location = 6) out vec2 specular_coord;
-layout(location = 7) out vec2 emissive_coord;
-layout(location = 8) out vec2 lightmap_coord;
+
+layout(location = 10) out vec2 diffuse_coord;
+layout(location = 11) out vec2 ambient_coord;
+layout(location = 12) out vec2 specular_coord;
+layout(location = 13) out vec2 opacity_coord;
+layout(location = 14) out vec2 lightmap_coord;
+layout(location = 15) out vec2 normal_coord;
+layout(location = 16) out vec2 emissive_coord;
+
 
 struct Vertex
 {
@@ -65,6 +69,9 @@ void main() {
 	vertex.local_position = vec4(a_position.xyz, 1.0);
 	vertex.local_normal = vec4(0.0, 0.0, 1.0, 0.0);
 	@VertexShader
+#ifdef HAS_VertexMorphShader
+    @VertexMorphShader
+#endif
 #ifdef HAS_VertexSkinShader
 	@VertexSkinShader
 #endif

--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
@@ -43,17 +43,18 @@ layout(location = 1) out vec3 viewspace_position;
 layout(location = 2) out vec3 viewspace_normal;
 layout(location = 3) out vec4 local_position;
 
-layout(location = 4) out vec2 diffuse_coord;
-layout(location = 5) out vec2 ambient_coord;
-layout(location = 6) out vec2 specular_coord;
-layout(location = 7) out vec2 emissive_coord;
-layout(location = 8) out vec2 lightmap_coord;
-layout(location = 9) out vec2 opacity_coord;
-layout(location = 10) out vec2 normal_coord;
-layout(location = 11) out vec2 diffuse_coord1;
-layout(location = 12) out vec2 ambient_coord1;
-layout(location = 13) out vec2 specular_coord1;
-layout(location = 14) out vec2 emissive_coord1;
+layout(location = 10) out vec2 diffuse_coord;
+layout(location = 11) out vec2 ambient_coord;
+layout(location = 12) out vec2 specular_coord;
+layout(location = 13) out vec2 opacity_coord;
+layout(location = 14) out vec2 lightmap_coord;
+layout(location = 15) out vec2 normal_coord;
+layout(location = 16) out vec2 emissive_coord;
+
+layout(location = 18) out vec2 diffuse_coord1;
+layout(location = 19) out vec2 ambient_coord1;
+layout(location = 20) out vec2 specular_coord1;
+layout(location = 21) out vec2 emissive_coord1;
 
 //
 // The Phong vertex shader supports up to 4 sets of texture coordinates.
@@ -96,6 +97,9 @@ void main() {
 	vertex.local_position = vec4(a_position.xyz, 1.0);
 	vertex.local_normal = vec4(0.0, 0.0, 1.0, 0.0);
 	@VertexShader
+#ifdef HAS_VertexMorphShader
+    @VertexMorphShader
+#endif
 #ifdef HAS_VertexSkinShader
 	@VertexSkinShader
 #endif

--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
@@ -8,8 +8,10 @@ layout(num_views = 2) in;
 #endif
 precision highp float;
 precision lowp int;
+
 @MATRIX_UNIFORMS
 
+@MATERIAL_UNIFORMS
 
 layout(location = 0) in vec3 a_position;
 
@@ -54,6 +56,10 @@ layout(location = 18) out vec2 diffuse_coord1;
 layout(location = 19) out vec2 ambient_coord1;
 layout(location = 20) out vec2 specular_coord1;
 layout(location = 21) out vec2 emissive_coord1;
+
+#ifdef HAS_blendshapeTexture
+layout (set = 0, binding = 17) uniform sampler2D blendshapeTexture;
+#endif
 
 //
 // The Phong vertex shader supports up to 4 sets of texture coordinates.

--- a/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertex_template_multitex.vsh
@@ -100,17 +100,24 @@ void main() {
 	Vertex vertex;
 
 	vertex.local_position = vec4(a_position.xyz, 1.0);
-	vertex.local_normal = vec4(0.0, 0.0, 1.0, 0.0);
-	@VertexShader
+#ifdef HAS_a_normal
+    vertex.local_normal = vec4(normalize(a_normal), 0.0);
+#endif
+
 #ifdef HAS_VertexMorphShader
-    @VertexMorphShader
+@VertexMorphShader
 #endif
+
+@VertexShader
+
 #ifdef HAS_VertexSkinShader
-	@VertexSkinShader
+@VertexSkinShader
 #endif
+
 #ifdef HAS_VertexNormalShader
-	@VertexNormalShader
+@VertexNormalShader
 #endif
+
 #ifdef HAS_LIGHTSOURCES
 //
 // This section contains code to compute
@@ -130,11 +137,11 @@ void main() {
 	viewspace_normal = vertex.viewspace_normal;
 	view_direction = vertex.view_direction;
 #ifdef HAS_MULTIVIEW
-	    bool render_mask = (u_render_mask & (gl_ViewID_OVR + uint(1))) > uint(0) ? true : false;
-        mat4 mvp = u_mvp_[gl_ViewID_OVR];
-        if(!render_mask)
-            mvp = mat4(0.0);  //  if render_mask is not set for particular eye, dont render that object
-        gl_Position = mvp  * vertex.local_position;
+	 bool render_mask = (u_render_mask & (gl_ViewID_OVR + uint(1))) > uint(0) ? true : false;
+     mat4 mvp = u_mvp_[gl_ViewID_OVR];
+     if(!render_mask)
+         mvp = mat4(0.0);  //  if render_mask is not set for particular eye, dont render that object
+     gl_Position = mvp  * vertex.local_position;
 #else
 	gl_Position = u_mvp * vertex.local_position;	
 #endif

--- a/GVRf/Framework/framework/src/main/res/raw/vertexmorph.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertexmorph.vsh
@@ -1,9 +1,8 @@
 #if defined(HAS_blendshapeTexture)
 	for (int i = 0; i < u_numblendshapes; ++i)
 	{
-	    float x = float(i);
-	    float y = float(gl_VertexID);
-
-	    vertex.local_position += u_weights[i] * texture(blendshapeTexture, vec2(x, y));
+	    //vertex.local_position += u_blendweights[i] * texelFetch(blendshapeTexture, ivec2(i, gl_VertexID), 0);
 	}
+	vertex.local_position =  texelFetch(blendshapeTexture, ivec2(0, gl_VertexID), 0);
+
 #endif

--- a/GVRf/Framework/framework/src/main/res/raw/vertexmorph.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertexmorph.vsh
@@ -1,7 +1,7 @@
 #if defined(HAS_blendshapeTexture)
 	for (int i = 0; i < u_numblendshapes; ++i)
 	{
-	    vertex.local_position += u_blendweights[i] * texelFetch(blendshapeTexture, ivec2(i, gl_VertexID), 0);
+	    vertex.local_position.xyz += u_blendweights[i] * texelFetch(blendshapeTexture, ivec2(i, gl_VertexID), 0).rgb;
 	}
 
 #endif

--- a/GVRf/Framework/framework/src/main/res/raw/vertexmorph.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertexmorph.vsh
@@ -1,8 +1,7 @@
 #if defined(HAS_blendshapeTexture)
 	for (int i = 0; i < u_numblendshapes; ++i)
 	{
-	    //vertex.local_position += u_blendweights[i] * texelFetch(blendshapeTexture, ivec2(i, gl_VertexID), 0);
+	    vertex.local_position += u_blendweights[i] * texelFetch(blendshapeTexture, ivec2(i, gl_VertexID), 0);
 	}
-	vertex.local_position =  texelFetch(blendshapeTexture, ivec2(0, gl_VertexID), 0);
 
 #endif

--- a/GVRf/Framework/framework/src/main/res/raw/vertexmorph.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/vertexmorph.vsh
@@ -1,0 +1,9 @@
+#if defined(HAS_blendshapeTexture)
+	for (int i = 0; i < u_numblendshapes; ++i)
+	{
+	    float x = float(i);
+	    float y = float(gl_VertexID);
+
+	    vertex.local_position += u_weights[i] * texture(blendshapeTexture, vec2(x, y));
+	}
+#endif


### PR DESCRIPTION
1. Added GVRMeshMorph component which accepts a set of blend shapes and constructs a texture from them to use with the morphing shader
2. Added morphing support to GVRPhongShader
3. Added GVRFloatAnimator to interpolate through a set of floating point keys
4. Add GVRMorphAnimator to support animation of morphing blend weights

Added gvr-morph demo and morphing tests in separate pull requests

GearVRF DCO signed off by: Nola Donato nola.donato@samsung.com