### PR TITLE
Add GVRApplication allowing making apps not derived from GVRActivity

### DIFF
--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/BaseView.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/BaseView.java
@@ -15,6 +15,7 @@
 
 package org.gearvrf.io.cursor3d.settings;
 
+import android.app.Activity;
 import android.graphics.Color;
 import android.os.Handler;
 import android.os.Looper;
@@ -22,7 +23,6 @@ import android.view.GestureDetector;
 import android.view.View;
 import android.widget.FrameLayout;
 
-import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRScene;
 import org.gearvrf.scene_objects.GVRViewSceneObject;
@@ -37,7 +37,7 @@ abstract class BaseView {
     private float quadHeight;
     private float quadWidth;
     GVRScene scene;
-    GVRActivity activity;
+    final Activity activity;
     GVRContext context;
     private GVRViewSceneObject layoutSceneObject;
     private Handler glThreadHandler;

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/CursorConfigView.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/CursorConfigView.java
@@ -15,6 +15,7 @@
 
 package org.gearvrf.io.cursor3d.settings;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
@@ -28,7 +29,6 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRScene;
 import org.gearvrf.io.GVRTouchPadGestureListener;
@@ -73,7 +73,7 @@ class CursorConfigView extends BaseView implements View.OnClickListener {
             currentCursor, final GVRScene scene, int
                              settingsCursorId, SettingsChangeListener changeListener) {
         super(context, scene, settingsCursorId, R.layout.cursor_configuration_layout);
-        final GVRActivity activity = context.getActivity();
+        final Activity activity = context.getActivity();
         loadDrawables(activity);
         layoutInflater = (LayoutInflater) activity.getSystemService(Context
                 .LAYOUT_INFLATER_SERVICE);

--- a/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/SettingsView.java
+++ b/GVRf/Extensions/3DCursor/3DCursorLibrary/src/main/java/org/gearvrf/io/cursor3d/settings/SettingsView.java
@@ -15,6 +15,7 @@
 
 package org.gearvrf.io.cursor3d.settings;
 
+import android.app.Activity;
 import android.content.Context;
 import android.view.GestureDetector;
 import android.view.LayoutInflater;
@@ -29,16 +30,15 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.ToggleButton;
 
-import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRScene;
+import org.gearvrf.io.GVRTouchPadGestureListener;
 import org.gearvrf.io.cursor3d.Cursor;
 import org.gearvrf.io.cursor3d.CursorManager;
 import org.gearvrf.io.cursor3d.CursorType;
 import org.gearvrf.io.cursor3d.IoDevice;
 import org.gearvrf.io.cursor3d.R;
 import org.gearvrf.utility.Log;
-import org.gearvrf.io.GVRTouchPadGestureListener;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -75,7 +75,7 @@ public class SettingsView extends BaseView implements OnCheckedChangeListener
     {
         super(context, scene, settingsCursorId, R.layout.settings_layout);
         Log.d(TAG, "new SettingsView, hash=" + this.hashCode());
-        final GVRActivity activity = context.getActivity();
+        final Activity activity = context.getActivity();
         this.changeListener = changeListener;
         this.cursorManager = cursorManager;
         cursorList = (ListView) findViewById(R.id.lvCursors);

--- a/GVRf/Extensions/MixedReality/src/main/java/org/gearvrf/mixedreality/GVRMixedReality.java
+++ b/GVRf/Extensions/MixedReality/src/main/java/org/gearvrf/mixedreality/GVRMixedReality.java
@@ -15,23 +15,16 @@
 
 package org.gearvrf.mixedreality;
 
-import android.content.Intent;
-import android.content.res.Configuration;
 import android.graphics.Bitmap;
-import android.graphics.PointF;
-import android.view.KeyEvent;
-import android.view.MotionEvent;
 
 import org.gearvrf.GVRBehavior;
 import org.gearvrf.GVRContext;
-import org.gearvrf.GVRMain;
+import org.gearvrf.GVREventListeners;
 import org.gearvrf.GVRPicker;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.IActivityEvents;
 import org.gearvrf.mixedreality.arcore.ARCoreSession;
-import org.joml.Quaternionf;
-import org.joml.Vector3f;
 
 import java.util.ArrayList;
 
@@ -223,7 +216,7 @@ public class GVRMixedReality extends GVRBehavior implements IMRCommon {
         return mSession.getAllAugmentedImages();
     }
 
-    private class ActivityEventsHandler implements IActivityEvents {
+    private class ActivityEventsHandler extends GVREventListeners.ActivityEvents {
         @Override
         public void onPause() {
             pause();
@@ -233,35 +226,7 @@ public class GVRMixedReality extends GVRBehavior implements IMRCommon {
         public void onResume() {
             resume();
         }
-
-        @Override
-        public void onDestroy() {}
-
-        @Override
-        public void onSetMain(GVRMain script) {}
-
-        @Override
-        public void onWindowFocusChanged(boolean hasFocus) {}
-
-        @Override
-        public void onConfigurationChanged(Configuration config) {}
-
-        @Override
-        public void onActivityResult(int requestCode, int resultCode, Intent data) {}
-
-        @Override
-        public void onTouchEvent(MotionEvent event) {}
-
-        @Override
-        public void dispatchTouchEvent(MotionEvent event) {}
-
-        @Override
-        public void onControllerEvent(Vector3f position, Quaternionf orientation, PointF touchpadPoint, boolean touched, Vector3f angularAcceleration, Vector3f angularVelocity) {}
-
-        @Override
-        public void dispatchKeyEvent(KeyEvent keyEvent) {}
     }
-
 
     private enum SessionState {
         ON_RESUME,

--- a/GVRf/Extensions/ResonanceAudio/resonanceaudio/src/main/java/org/gearvrf/resonanceaudio/GVRAudioManager.java
+++ b/GVRf/Extensions/ResonanceAudio/resonanceaudio/src/main/java/org/gearvrf/resonanceaudio/GVRAudioManager.java
@@ -15,9 +15,10 @@
 
 package org.gearvrf.resonanceaudio;
 
+import android.app.Activity;
+
 import com.google.vr.sdk.audio.GvrAudioEngine;
 
-import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRCameraRig;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRDrawFrameListener;
@@ -77,13 +78,13 @@ public class GVRAudioManager extends GVREventListeners.ActivityEvents
         if (flag)
         {
             mContext.registerDrawFrameListener(this);
-            mContext.getActivity().getEventReceiver().addListener(this);
+            mContext.getApplication().getEventReceiver().addListener(this);
             mAudioEngine.resume();
         }
         else
         {
             mContext.unregisterDrawFrameListener(this);
-            mContext.getActivity().getEventReceiver().removeListener(this);
+            mContext.getApplication().getEventReceiver().removeListener(this);
             mAudioEngine.pause();
         }
     }
@@ -231,7 +232,7 @@ public class GVRAudioManager extends GVREventListeners.ActivityEvents
     public void onDestroy()
     {
         super.onDestroy();
-        GVRActivity activity = mContext.getActivity();
+        Activity activity = mContext.getActivity();
         if (activity.isFinishing())
         {
             setEnable(false);

--- a/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/AnchorImplementation.java
+++ b/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/AnchorImplementation.java
@@ -362,7 +362,7 @@ public class AnchorImplementation {
                 public void run() {
 
                     // Launch a new WebView window and place the web page there.
-                    gvrWebView = new GVRWebView(gvrContext.getActivity());
+                    gvrWebView = new GVRWebView(gvrContext.getApplication());
                     gvrWebView.setInitialScale(100);
                     gvrWebView.measure(1600, 1200);
                     gvrWebView.layout(0, 0, 1600, 1200);

--- a/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DayDreamControllerReader.java
+++ b/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DayDreamControllerReader.java
@@ -2,15 +2,15 @@ package org.gearvrf;
 
 import android.graphics.PointF;
 
+import com.google.vr.sdk.controller.Controller;
+import com.google.vr.sdk.controller.Controller.ConnectionStates;
+import com.google.vr.sdk.controller.ControllerManager;
+import com.google.vr.sdk.controller.Orientation;
+
 import org.gearvrf.io.GVRGearCursorController;
 import org.joml.Math;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
-
-import com.google.vr.sdk.controller.Controller;
-import com.google.vr.sdk.controller.ControllerManager;
-import com.google.vr.sdk.controller.Orientation;
-import com.google.vr.sdk.controller.Controller.ConnectionStates;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -22,16 +22,16 @@ class DayDreamControllerReader extends GVRGearCursorController.ControllerReaderS
     private Controller mController;
     private int mConnectionState = ConnectionStates.DISCONNECTED;
     private FloatBuffer readbackBuffer = null;
-    private GVRActivity mActivity = null;
+    private GVRApplication mApplication;
     private final float OCULUS_SCALE = 256.0f;
 
-    DayDreamControllerReader(GVRActivity gvrActivity) {
+    DayDreamControllerReader(GVRApplication application) {
         EventListener listener = new EventListener();
-        mControllerManager = new ControllerManager(gvrActivity, listener);
+        mControllerManager = new ControllerManager(application.getActivity(), listener);
         mController = mControllerManager.getController();
         mController.setEventListener(listener);
         mControllerManager.start();
-        mActivity = gvrActivity;
+        mApplication = application;
     }
 
     @Override
@@ -48,7 +48,7 @@ class DayDreamControllerReader extends GVRGearCursorController.ControllerReaderS
         ByteBuffer readbackBufferB = ByteBuffer.allocateDirect(4);
         readbackBufferB.order(ByteOrder.nativeOrder());
         readbackBuffer = readbackBufferB.asFloatBuffer();
-        GVRViewManager gvrViewManager = mActivity.getViewManager();
+        GVRViewManager gvrViewManager = mApplication.getViewManager();
         DaydreamViewManager viewManager = (DaydreamViewManager)gvrViewManager;
         setNativeBuffer(viewManager.getNativeRenderer(), readbackBufferB);
         updateHandedness(viewManager.getNativeRenderer());

--- a/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DaydreamActivityDelegate.java
+++ b/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DaydreamActivityDelegate.java
@@ -22,13 +22,13 @@ import org.gearvrf.utility.VrAppSettings;
 /**
  * {@inheritDoc}
  */
-final class DaydreamActivityDelegate extends GVRActivity.ActivityDelegateStubs implements IActivityNative {
-    private GVRActivity mActivity;
+final class DaydreamActivityDelegate extends GVRApplication.ActivityDelegateStubs implements IActivityNative {
+    private GVRApplication mApplication;
     private DaydreamViewManager daydreamViewManager;
 
     @Override
-    public void onCreate(GVRActivity activity) {
-        mActivity = activity;
+    public void onCreate(GVRApplication application) {
+        mApplication = application;
     }
 
     @Override
@@ -38,7 +38,7 @@ final class DaydreamActivityDelegate extends GVRActivity.ActivityDelegateStubs i
 
     @Override
     public GVRViewManager makeViewManager() {
-        return new DaydreamViewManager(mActivity, mActivity.getMain());
+        return new DaydreamViewManager(mApplication, mApplication.getMain());
     }
 
     @Override
@@ -47,8 +47,8 @@ final class DaydreamActivityDelegate extends GVRActivity.ActivityDelegateStubs i
     }
 
     @Override
-    public GVRConfigurationManager makeConfigurationManager(GVRActivity activity) {
-        return new GVRConfigurationManager(activity) {
+    public GVRConfigurationManager makeConfigurationManager() {
+        return new GVRConfigurationManager(mApplication) {
             @Override
             public boolean isHmtConnected() {
                 return false;
@@ -64,12 +64,12 @@ final class DaydreamActivityDelegate extends GVRActivity.ActivityDelegateStubs i
     public void onInitAppSettings(VrAppSettings appSettings) {
         // This is the only place where the setDockListenerRequired flag can be set before
         // the check in GVRActivity.
-        mActivity.getConfigurationManager().setDockListenerRequired(false);
+        mApplication.getConfigurationManager().setDockListenerRequired(false);
     }
 
     @Override
     public void parseXmlSettings(AssetManager assetManager, String dataFilename) {
-        new DaydreamXMLParser(assetManager, dataFilename, mActivity.getAppSettings());
+        new DaydreamXMLParser(assetManager, dataFilename, mApplication.getAppSettings());
     }
 
     @Override

--- a/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DaydreamViewManager.java
+++ b/GVRf/Framework/backend_daydream/src/main/java/org/gearvrf/DaydreamViewManager.java
@@ -41,13 +41,13 @@ class DaydreamViewManager extends GVRViewManager {
                 }
             };
 
-    DaydreamViewManager(final GVRActivity gvrActivity, GVRMain gvrMain) {
-        super(gvrActivity, gvrMain);
+    DaydreamViewManager(final GVRApplication application, GVRMain gvrMain) {
+        super(application, gvrMain);
 
         // Initialize GvrLayout and the native renderer.
-        gvrLayout = new GvrLayout(gvrActivity);
+        gvrLayout = new GvrLayout(application.getActivity());
 
-        surfaceView = new GLSurfaceView(gvrActivity);
+        surfaceView = new GLSurfaceView(application.getActivity());
         surfaceView.setEGLContextClientVersion(3);
         surfaceView.setEGLConfigChooser(8, 8, 8, 8, 24, 8);
         surfaceView.setPreserveEGLContextOnPause(true);
@@ -58,22 +58,22 @@ class DaydreamViewManager extends GVRViewManager {
         gvrLayout.setPresentationView(surfaceView);
 
         // Add the GvrLayout to the View hierarchy.
-        gvrActivity.setContentView(gvrLayout);
+        application.getActivity().setContentView(gvrLayout);
 
         // Enable scan line racing.
         if (gvrLayout.setAsyncReprojectionEnabled(true)) {
             // Scanline racing decouples the app framerate from the display framerate,
             // allowing immersive interaction even at the throttled clockrates set by
             // sustained performance mode.
-            AndroidCompat.setSustainedPerformanceMode(gvrActivity, true);
+            AndroidCompat.setSustainedPerformanceMode(application.getActivity(), true);
         }
 
         // Enable VR Mode.
-        AndroidCompat.setVrModeEnabled(gvrActivity, true);
+        AndroidCompat.setVrModeEnabled(application.getActivity(), true);
 
         // Prevent screen from dimming/locking.
-        gvrActivity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        mControllerReader = new DayDreamControllerReader(gvrActivity);
+        application.getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        mControllerReader = new DayDreamControllerReader(application);
 
     }
 
@@ -82,7 +82,7 @@ class DaydreamViewManager extends GVRViewManager {
     }
     public GVRRenderTarget getRenderTarget(){
         if(null == mDaydreamRenderTarget){
-            mDaydreamRenderTarget = new GVRRenderTarget(getActivity().getGVRContext());
+            mDaydreamRenderTarget = new GVRRenderTarget(mApplication.getGVRContext());
         }
         return mDaydreamRenderTarget;
     }

--- a/GVRf/Framework/backend_daydream/src/main/jni/daydream_renderer_jni.cpp
+++ b/GVRf/Framework/backend_daydream/src/main/jni/daydream_renderer_jni.cpp
@@ -21,6 +21,7 @@
   JNIEXPORT return_type JNICALL              \
       Java_org_gearvrf_DaydreamRenderer_##method_name
 
+
 namespace {
 
 inline jlong jptr(DaydreamRenderer *native_daydream_renderer) {

--- a/GVRf/Framework/backend_monoscopic/src/main/java/org/gearvrf/MonoscopicActivityDelegate.java
+++ b/GVRf/Framework/backend_monoscopic/src/main/java/org/gearvrf/MonoscopicActivityDelegate.java
@@ -22,19 +22,19 @@ import org.gearvrf.utility.VrAppSettings;
 /**
  * {@inheritDoc}
  */
-final class MonoscopicActivityDelegate extends GVRActivity.ActivityDelegateStubs {
+final class MonoscopicActivityDelegate extends GVRApplication.ActivityDelegateStubs {
     @Override
-    public void onCreate(GVRActivity activity) {
+    public void onCreate(GVRApplication activity) {
         if (null == activity) {
             throw new IllegalArgumentException();
         }
 
-        mActivity = activity;
+        mApplication = activity;
     }
 
     @Override
     public GVRViewManager makeViewManager() {
-        return new MonoscopicViewManager(mActivity, mActivity.getMain(), mXmlParser);
+        return new MonoscopicViewManager(mApplication, mApplication.getMain(), mXmlParser);
     }
 
     @Override
@@ -43,13 +43,13 @@ final class MonoscopicActivityDelegate extends GVRActivity.ActivityDelegateStubs
     }
 
     @Override
-    public GVRConfigurationManager makeConfigurationManager(GVRActivity activity) {
-        return new MonoscopicConfigurationManager(activity);
+    public GVRConfigurationManager makeConfigurationManager() {
+        return new MonoscopicConfigurationManager(mApplication);
     }
 
     @Override
     public void parseXmlSettings(AssetManager assetManager, String dataFilename) {
-        mXmlParser = new MonoscopicXMLParser(assetManager, dataFilename, mActivity.getAppSettings());
+        mXmlParser = new MonoscopicXMLParser(assetManager, dataFilename, mApplication.getAppSettings());
     }
 
     @Override
@@ -67,6 +67,6 @@ final class MonoscopicActivityDelegate extends GVRActivity.ActivityDelegateStubs
         return new MonoscopicVrAppSettings();
     }
 
-    private GVRActivity mActivity;
+    private GVRApplication mApplication;
     private MonoscopicXMLParser mXmlParser;
 }

--- a/GVRf/Framework/backend_monoscopic/src/main/java/org/gearvrf/MonoscopicConfigurationManager.java
+++ b/GVRf/Framework/backend_monoscopic/src/main/java/org/gearvrf/MonoscopicConfigurationManager.java
@@ -17,8 +17,8 @@ package org.gearvrf;
 
 final class MonoscopicConfigurationManager extends GVRConfigurationManager {
 
-    MonoscopicConfigurationManager(GVRActivity gvrActivity) {
-        super(gvrActivity);
+    MonoscopicConfigurationManager(GVRApplication application) {
+        super(application);
     }
 
     @Override

--- a/GVRf/Framework/backend_monoscopic/src/main/java/org/gearvrf/MonoscopicRotationSensor.java
+++ b/GVRf/Framework/backend_monoscopic/src/main/java/org/gearvrf/MonoscopicRotationSensor.java
@@ -15,13 +15,12 @@
 
 package org.gearvrf;
 
-import org.gearvrf.GVRActivity.DockListener;
-import org.gearvrf.utility.Log;
-
 import android.app.Activity;
 import android.content.Context;
 import android.hardware.Sensor;
 import android.hardware.SensorManager;
+
+import org.gearvrf.utility.Log;
 
 /**
  * Wrapper class for rotation-related sensors. Combines handling a device's
@@ -46,7 +45,7 @@ class MonoscopicRotationSensor {
      *            A {@link MonoscopicRotationSensorListener} implementation to receive
      *            rotation data.
      */
-    MonoscopicRotationSensor(GVRActivity activity, MonoscopicRotationSensorListener listener) {
+    MonoscopicRotationSensor(Activity activity, MonoscopicRotationSensorListener listener) {
         mListener = listener;
         mApplicationContext = activity.getApplicationContext();
 

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityDelegate.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityDelegate.java
@@ -22,17 +22,17 @@ import org.gearvrf.utility.VrAppSettings;
 /**
  * {@inheritDoc}
  */
-final class OvrActivityDelegate extends GVRActivity.ActivityDelegateStubs {
-    private GVRActivity mActivity;
+final class OvrActivityDelegate extends GVRApplication.ActivityDelegateStubs {
+    private GVRApplication mApplication;
     private OvrViewManager mActiveViewManager;
     private OvrActivityNative mActivityNative;
 
     @Override
-    public void onCreate(GVRActivity activity) {
-        mActivity = activity;
+    public void onCreate(GVRApplication application) {
+        mApplication = application;
 
-        mActivityNative = new OvrActivityNative(mActivity, mActivity.getAppSettings());
-        mActivityHandler = new OvrVrapiActivityHandler(activity, mActivityNative);
+        mActivityNative = new OvrActivityNative(mApplication);
+        mActivityHandler = new OvrVrapiActivityHandler(application, mActivityNative);
     }
 
     @Override
@@ -42,7 +42,7 @@ final class OvrActivityDelegate extends GVRActivity.ActivityDelegateStubs {
 
     @Override
     public GVRViewManager makeViewManager() {
-        return new OvrViewManager(mActivity, mActivity.getMain(), mXmlParser);
+        return new OvrViewManager(mApplication, mApplication.getMain(), mXmlParser);
     }
 
     @Override
@@ -51,13 +51,13 @@ final class OvrActivityDelegate extends GVRActivity.ActivityDelegateStubs {
     }
 
     @Override
-    public GVRConfigurationManager makeConfigurationManager(GVRActivity activity) {
-        return new OvrConfigurationManager(activity);
+    public GVRConfigurationManager makeConfigurationManager() {
+        return new OvrConfigurationManager(mApplication);
     }
 
     @Override
     public void parseXmlSettings(AssetManager assetManager, String dataFilename) {
-        mXmlParser = new OvrXMLParser(assetManager, dataFilename, mActivity.getAppSettings());
+        mXmlParser = new OvrXMLParser(assetManager, dataFilename, mApplication.getAppSettings());
     }
 
     @Override

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityNative.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrActivityNative.java
@@ -26,8 +26,8 @@ class OvrActivityNative implements IActivityNative {
 
     private final long mPtr;
 
-    OvrActivityNative(Activity act, VrAppSettings vrAppSettings) {
-        mPtr = onCreate(act, vrAppSettings);
+    OvrActivityNative(GVRApplication application) {
+        mPtr = onCreate(application.getActivity(), application.getAppSettings());
     }
 
     @Override

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrConfigurationManager.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrConfigurationManager.java
@@ -17,18 +17,18 @@ package org.gearvrf;
 
 final class OvrConfigurationManager extends GVRConfigurationManager {
 
-    OvrConfigurationManager(GVRActivity gvrActivity) {
-        super(gvrActivity);
+    OvrConfigurationManager(GVRApplication application) {
+        super(application);
     }
 
     @Override
     public boolean isHmtConnected() {
 
-        final GVRActivity activity = (GVRActivity) mActivity.get();
-        if (null == activity) {
+        final GVRApplication application = (GVRApplication) mApplication.get();
+        if (null == application) {
             return false;
         }
-        return nativeIsHmtConnected(activity.getNative());
+        return nativeIsHmtConnected(application.getNative());
     }
 
     private static native boolean nativeIsHmtConnected(long ptr);

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrViewManager.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrViewManager.java
@@ -80,13 +80,13 @@ class OvrViewManager extends GVRViewManager {
      * Constructs OvrViewManager object with GVRMain which controls GL
      * activities
      *
-     * @param gvrActivity
+     * @param application
      *            Current activity object
      * @param gvrMain
      *            {@link GVRMain} which describes
      */
-    OvrViewManager(GVRActivity gvrActivity, GVRMain gvrMain, OvrXMLParser xmlParser) {
-        super(gvrActivity, gvrMain);
+    OvrViewManager(GVRApplication application, GVRMain gvrMain, OvrXMLParser xmlParser) {
+        super(application, gvrMain);
 
         // Apply view manager preferences
         GVRPreference prefs = GVRPreference.get();
@@ -103,14 +103,14 @@ class OvrViewManager extends GVRViewManager {
          * Sets things with the numbers in the xml.
          */
         DisplayMetrics metrics = new DisplayMetrics();
-        gvrActivity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        application.getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
 
         final float INCH_TO_METERS = 0.0254f;
         int screenWidthPixels = metrics.widthPixels;
         int screenHeightPixels = metrics.heightPixels;
         float screenWidthMeters = (float) screenWidthPixels / metrics.xdpi * INCH_TO_METERS;
         float screenHeightMeters = (float) screenHeightPixels / metrics.ydpi * INCH_TO_METERS;
-        VrAppSettings vrAppSettings = gvrActivity.getAppSettings();
+        VrAppSettings vrAppSettings = application.getAppSettings();
         mLensInfo = new OvrLensInfo(screenWidthPixels, screenHeightPixels, screenWidthMeters, screenHeightMeters,
                 vrAppSettings);
 
@@ -135,7 +135,7 @@ class OvrViewManager extends GVRViewManager {
         mStatsLine.addColumn(mTracerDrawEyes2.getStatColumn());
         mStatsLine.addColumn(mTracerAfterDrawEyes.getStatColumn());
 
-        mControllerReader = new OvrControllerReader(mActivity.getActivityNative().getNative());
+        mControllerReader = new OvrControllerReader(mApplication.getActivityNative().getNative());
     }
 
     /**
@@ -145,8 +145,8 @@ class OvrViewManager extends GVRViewManager {
     void onSurfaceChanged(int width, int height) {
         Log.v(TAG, "onSurfaceChanged");
 
-        final VrAppSettings.EyeBufferParams.DepthFormat depthFormat = getActivity().getAppSettings().getEyeBufferParams().getDepthFormat();
-        getActivity().getConfigurationManager().configureRendering(VrAppSettings.EyeBufferParams.DepthFormat.DEPTH_24_STENCIL_8 == depthFormat);
+        final VrAppSettings.EyeBufferParams.DepthFormat depthFormat = mApplication.getAppSettings().getEyeBufferParams().getDepthFormat();
+        mApplication.getConfigurationManager().configureRendering(VrAppSettings.EyeBufferParams.DepthFormat.DEPTH_24_STENCIL_8 == depthFormat);
     }
 
     @Override
@@ -251,7 +251,7 @@ class OvrViewManager extends GVRViewManager {
 
     /** Called once per frame */
     protected void onDrawFrame() {
-        drawEyes(mActivity.getActivityNative().getNative());
+        drawEyes(mApplication.getActivityNative().getNative());
         afterDrawEyes();
     }
 
@@ -286,22 +286,22 @@ class OvrViewManager extends GVRViewManager {
 
     }
     void createSwapChain(){
-        boolean isMultiview = mActivity.getAppSettings().isMultiviewSet();
-        int width = mActivity.getAppSettings().getFramebufferPixelsWide();
-        int height= mActivity.getAppSettings().getFramebufferPixelsHigh();
+        boolean isMultiview = mApplication.getAppSettings().isMultiviewSet();
+        int width = mApplication.getAppSettings().getFramebufferPixelsWide();
+        int height= mApplication.getAppSettings().getFramebufferPixelsHigh();
         for(int i=0;i < 3; i++){
 
             if(isMultiview){
-                long renderTextureInfo = getRenderTextureInfo(mActivity.getActivityNative().getNative(), i, EYE.MULTIVIEW.ordinal());
-                mRenderBundle.createRenderTarget(i, EYE.MULTIVIEW, new GVRRenderTexture(mActivity.getGVRContext(),  width , height,
+                long renderTextureInfo = getRenderTextureInfo(mApplication.getActivityNative().getNative(), i, EYE.MULTIVIEW.ordinal());
+                mRenderBundle.createRenderTarget(i, EYE.MULTIVIEW, new GVRRenderTexture(mApplication.getGVRContext(),  width , height,
                         GVRRenderBundle.getRenderTextureNative(renderTextureInfo)));
             }
             else {
-                long renderTextureInfo = getRenderTextureInfo(mActivity.getActivityNative().getNative(), i, EYE.LEFT.ordinal());
-                mRenderBundle.createRenderTarget(i, EYE.LEFT, new GVRRenderTexture(mActivity.getGVRContext(),  width , height,
+                long renderTextureInfo = getRenderTextureInfo(mApplication.getActivityNative().getNative(), i, EYE.LEFT.ordinal());
+                mRenderBundle.createRenderTarget(i, EYE.LEFT, new GVRRenderTexture(mApplication.getGVRContext(),  width , height,
                         GVRRenderBundle.getRenderTextureNative(renderTextureInfo)));
-                renderTextureInfo = getRenderTextureInfo(mActivity.getActivityNative().getNative(), i, EYE.RIGHT.ordinal());
-                mRenderBundle.createRenderTarget(i, EYE.RIGHT, new GVRRenderTexture(mActivity.getGVRContext(),  width , height,
+                renderTextureInfo = getRenderTextureInfo(mApplication.getActivityNative().getNative(), i, EYE.RIGHT.ordinal());
+                mRenderBundle.createRenderTarget(i, EYE.RIGHT, new GVRRenderTexture(mApplication.getGVRContext(),  width , height,
                         GVRRenderBundle.getRenderTextureNative(renderTextureInfo)));
             }
         }

--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrVrapiActivityHandler.java
@@ -45,7 +45,7 @@ import javax.microedition.khronos.opengles.GL10;
  */
 final class OvrVrapiActivityHandler implements OvrActivityHandler {
 
-    private final GVRActivity mActivity;
+    private final GVRApplication mApplication;
     private long mPtr;
     private GLSurfaceView mSurfaceView;
     private EGLSurface mPixelBuffer;
@@ -55,21 +55,21 @@ final class OvrVrapiActivityHandler implements OvrActivityHandler {
     private OvrViewManager mViewManager;
     private int mCurrentSurfaceWidth, mCurrentSurfaceHeight;
 
-    OvrVrapiActivityHandler(final GVRActivity activity, final OvrActivityNative activityNative) throws VrapiNotAvailableException {
-        if (null == activity) {
+    OvrVrapiActivityHandler(final GVRApplication application, final OvrActivityNative activityNative) throws VrapiNotAvailableException {
+        if (null == application) {
             throw new IllegalArgumentException();
         }
         try {
-            activity.getPackageManager().getPackageInfo("com.oculus.systemdriver", PackageManager.GET_SIGNATURES);
+            application.getActivity().getPackageManager().getPackageInfo("com.oculus.systemdriver", PackageManager.GET_SIGNATURES);
         } catch (final PackageManager.NameNotFoundException e) {
             try {
-                activity.getPackageManager().getPackageInfo("com.oculus.systemactivities", PackageManager.GET_SIGNATURES);
+                application.getActivity().getPackageManager().getPackageInfo("com.oculus.systemactivities", PackageManager.GET_SIGNATURES);
             } catch (PackageManager.NameNotFoundException e1) {
                 Log.e(TAG, "oculus packages missing, assuming vrapi will not work");
                 throw new VrapiNotAvailableException();
             }
         }
-        mActivity = activity;
+        mApplication = application;
         mPtr = activityNative.getNative();
 
         if (null != sVrapiOwner.get()) {
@@ -145,12 +145,12 @@ final class OvrVrapiActivityHandler implements OvrActivityHandler {
 
     @Override
     public void onSetScript() {
-        mSurfaceView = new GLSurfaceView(mActivity);
+        mSurfaceView = new GLSurfaceView(mApplication.getActivity());
         mSurfaceView.setZOrderOnTop(true);
 
         final DisplayMetrics metrics = new DisplayMetrics();
-        mActivity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
-        final VrAppSettings appSettings = mActivity.getAppSettings();
+        mApplication.getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        final VrAppSettings appSettings = mApplication.getAppSettings();
         int defaultWidthPixels = Math.max(metrics.widthPixels, metrics.heightPixels);
         int defaultHeightPixels = Math.min(metrics.widthPixels, metrics.heightPixels);
         final int frameBufferWidth = appSettings.getFramebufferPixelsWide();
@@ -179,7 +179,7 @@ final class OvrVrapiActivityHandler implements OvrActivityHandler {
         mSurfaceView.setRenderer(mRenderer);
         mSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_CONTINUOUSLY);
 
-        mActivity.setContentView(mSurfaceView);
+        mApplication.getActivity().setContentView(mSurfaceView);
     }
 
     private final EGLContextFactory mContextFactory = new EGLContextFactory() {
@@ -263,7 +263,7 @@ final class OvrVrapiActivityHandler implements OvrActivityHandler {
             configAttribs[counter++] = 0;
 
             Log.v(TAG, "--- window surface configuration ---");
-            final VrAppSettings appSettings = mActivity.getAppSettings();
+            final VrAppSettings appSettings = mApplication.getAppSettings();
             if (appSettings.useSrgbFramebuffer) {
                 final int EGL_GL_COLORSPACE_KHR = 0x309D;
                 final int EGL_GL_COLORSPACE_SRGB_KHR = 0x3089;

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.h
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.h
@@ -31,10 +31,10 @@ namespace gvr {
     class GVRActivity
     {
     public:
-        GVRActivity(JNIEnv& jni, jobject activity, jobject vrAppSettings, jobject callbacks);
+        GVRActivity(JNIEnv& jni, jobject activity, jobject vrAppSettings);
         ~GVRActivity();
 
-        bool updateSensoredScene();
+        bool updateSensoredScene(jobject jViewManager);
         void setCameraRig(jlong cameraRig);
 
         CameraRig* cameraRig_ = nullptr;   // this needs a global ref on the java object; todo
@@ -43,6 +43,7 @@ namespace gvr {
     private:
         JNIEnv* envMainThread_ = nullptr;           // for use by the Java UI thread
         jclass activityClass_ = nullptr;            // must be looked up from main thread or FindClass() will fail
+        jclass applicationClass_ = nullptr;
 
         jmethodID onDrawEyeMethodId = nullptr;
         jmethodID onBeforeDrawEyesMethodId = nullptr;

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity_jni.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity_jni.cpp
@@ -20,9 +20,10 @@
 namespace gvr {
     extern "C" {
 
-    JNIEXPORT long JNICALL Java_org_gearvrf_OvrActivityNative_onCreate(JNIEnv* jni, jclass clazz,
-                                                                       jobject activity, jobject vrAppSettings, jobject callbacks) {
-        GVRActivity* gvrActivity = new GVRActivity(*jni, activity, vrAppSettings, callbacks);
+    JNIEXPORT long JNICALL Java_org_gearvrf_OvrActivityNative_onCreate(JNIEnv *jni, jclass,
+                                                                       jobject activity,
+                                                                       jobject vrAppSettings) {
+        GVRActivity *gvrActivity = new GVRActivity(*jni, activity, vrAppSettings);
         return reinterpret_cast<long>(gvrActivity);
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRApplication.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRApplication.java
@@ -1,0 +1,866 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf;
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+import android.content.res.AssetManager;
+import android.content.res.Configuration;
+import android.media.AudioManager;
+import android.util.DisplayMetrics;
+import android.view.GestureDetector;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+
+import org.gearvrf.io.GVRTouchPadGestureListener;
+import org.gearvrf.scene_objects.GVRViewSceneObject;
+import org.gearvrf.scene_objects.view.GVRView;
+import org.gearvrf.script.IScriptable;
+import org.gearvrf.utility.DockEventReceiver;
+import org.gearvrf.utility.GrowBeforeQueueThreadPoolExecutor;
+import org.gearvrf.utility.Log;
+import org.gearvrf.utility.Threads;
+import org.gearvrf.utility.VrAppSettings;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * GVRApplication is where GVRf apps start from. Provides lifecycle control and events control.
+ * Consider using GVRActivity which would calls into the correct GVRApplication methods.
+ * GVRApplication is meant for use-cases where are apps can't use GVRActivity.
+ *
+ * User is responsible to call pass standard Android events to the GVRApplication.
+ * Mapping should be pretty obvious but there it is just in case:
+ * OnCreate -> instantiate the GVRApplication
+ * OnPause -> GVRApplication.pause
+ * OnResume -> GVRApplication.resume
+ * OnDestroy -> GVRApplication.destroy
+ * dispatchKeyEvent -> GVRApplication.dispatchKeyEvent
+ * OnKeyLongPress -> GVRApplication.keyLongPress
+ * OnKeyUp -> GVRApplication.keyUp
+ * OnKeyDown -> GVRApplication.keyDown
+ * dispatchGenericMotionEvent -> GVRApplication.dispatchGenericMotionEvent
+ * dispatchTouchEvent -> GVRApplication.dispatchTouchEvent
+ * onConfigurationChanged -> GVRApplication.configurationChanged
+ * onTouchEvent -> GVRApplication.touchEvent
+ * onWindowFocusChanged -> GVRApplication.windowFocusChanged
+ */
+public final class GVRApplication implements IEventReceiver, IScriptable {
+
+    static {
+        System.loadLibrary("gvrf");
+    }
+    protected static final String TAG = "GVRApplication";
+
+    private final Activity mActivity;
+    private GVRViewManager mViewManager;
+    private volatile GVRConfigurationManager mConfigurationManager;
+    private GVRMain mGVRMain;
+    private VrAppSettings mAppSettings;
+    private static View mFullScreenView;
+
+    // Group of views that are going to be drawn
+    // by some GVRViewSceneObject to the scene.
+    private ViewGroup mRenderableViewGroup;
+    private IActivityNative mActivityNative;
+    private boolean mPaused = true;
+
+    // Send to listeners and scripts but not this object itself
+    private static final int SEND_EVENT_MASK =
+            GVREventManager.SEND_MASK_ALL & ~GVREventManager.SEND_MASK_OBJECT;
+
+    private GVREventReceiver mEventReceiver = new GVREventReceiver(this);
+
+    public GVRApplication(final Activity activity) {
+        android.util.Log.i(TAG, "GVRApplication " + Integer.toHexString(hashCode()));
+
+        mActivity = activity;
+        final int backendId = SystemPropertyUtil.getSystemProperty(DEBUG_GEARVRF_BACKEND);
+        if (-1 != backendId) {
+            mDelegate = tryBackend(backendId);
+        } else {
+            for (int i = 0; i <= MAX_BACKEND_ID; ++i) {
+                mDelegate = tryBackend(i);
+                if (null != mDelegate) {
+                    break;
+                }
+            }
+        }
+
+        if (null == mDelegate) {
+            throw new IllegalStateException("Fatal error: no backend available");
+        }
+
+        if (null != Threads.getThreadPool()) {
+            Threads.getThreadPool().shutdownNow();
+        }
+        Threads.setThreadPool(new GrowBeforeQueueThreadPoolExecutor("gvrf"));
+
+        /*
+         * Removes the title bar and the status bar.
+         */
+        activity.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
+        mRenderableViewGroup = (ViewGroup) activity.findViewById(android.R.id.content).getRootView();
+        mActivityNative = mDelegate.getActivityNative();
+    }
+
+    /**
+     *
+     * @param activity the current activity
+     * @param gvrMain GVRMain implementation to execute
+     */
+    public GVRApplication(final Activity activity, GVRMain gvrMain) {
+        this(activity, gvrMain, "_gvr.xml");
+    }
+
+    /**
+     *
+     * @param activity the current activity
+     * @param gvrMain GVRMain implementation to execute
+     * @param dataFileName alternate configuration file; see _gvr.xml that is part of the framework
+     *                     for reference
+     */
+    public GVRApplication(final Activity activity, GVRMain gvrMain, String dataFileName) {
+        this(activity);
+
+        setMain(gvrMain, dataFileName);
+    }
+
+    private final GVRActivityDelegate tryBackend(final int backendId) {
+        InputStream inputStream = null;
+        BufferedReader reader = null;
+        try {
+            AssetManager assets = mActivity.getAssets();
+            inputStream = assets.open("backend_" + backendId + ".txt");
+            reader = new BufferedReader(new InputStreamReader(inputStream));
+
+            final String line = reader.readLine();
+            Log.i(TAG, "trying backend " + line);
+            final Class<?> aClass = Class.forName(line);
+
+            GVRActivityDelegate delegate = (GVRActivityDelegate) aClass.newInstance();
+            mAppSettings = delegate.makeVrAppSettings();
+            delegate.onCreate(this);
+
+            return delegate;
+        } catch (final Exception exc) {
+            return null;
+        } finally {
+            if (null != reader) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                }
+            }
+            if (null != inputStream) {
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+    }
+
+    protected void onInitAppSettings(VrAppSettings appSettings) {
+        mDelegate.onInitAppSettings(appSettings);
+    }
+
+    private void onConfigure(final String dataFilename) {
+        mConfigurationManager = mDelegate.makeConfigurationManager();
+        mConfigurationManager.addDockListener(this);
+        mConfigurationManager.configureForHeadset(GVRConfigurationManager.DEFAULT_HEADSET_MODEL);
+        mDelegate.parseXmlSettings(mActivity.getAssets(), dataFilename);
+
+        onInitAppSettings(mAppSettings);
+    }
+
+    public final VrAppSettings getAppSettings() {
+        return mAppSettings;
+    }
+
+    final GVRViewManager getViewManager() {
+        return mViewManager;
+    }
+
+    final boolean isPaused() {
+        return mPaused;
+    }
+
+    /**
+     *
+     */
+    public void pause() {
+        android.util.Log.i(TAG, "pause " + Integer.toHexString(hashCode()));
+
+        mDelegate.onPause();
+        mPaused = true;
+        if (mViewManager != null) {
+            mViewManager.onPause();
+
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onPause");
+        }
+    }
+
+    /**
+     *
+     */
+    public void resume() {
+        android.util.Log.i(TAG, "resume " + Integer.toHexString(hashCode()));
+
+        mDelegate.onResume();
+        mPaused = false;
+
+        if (mViewManager != null) {
+            mViewManager.onResume();
+
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onResume");
+        }
+    }
+
+    /**
+     *
+     */
+    public void destroy() {
+        android.util.Log.i(TAG, "destroy " + Integer.toHexString(hashCode()));
+        mDelegate.onDestroy();
+
+        if (mViewManager != null) {
+            mViewManager.onDestroy();
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onDestroy");
+            mViewManager = null;
+        }
+        if (null != mDockEventReceiver) {
+            mDockEventReceiver.stop();
+        }
+
+        if (null != mConfigurationManager && !mConfigurationManager.isDockListenerRequired()) {
+            handleOnUndock();
+        }
+
+        if (null != mActivityNative) {
+            mActivityNative.onDestroy();
+            mActivityNative = null;
+        }
+
+        mDockListeners.clear();
+        mGVRMain = null;
+        mDelegate = null;
+        mAppSettings = null;
+        mRenderableViewGroup = null;
+        mConfigurationManager = null;
+    }
+
+    /**
+     * Invalidating just the GVRView associated with the GVRViewSceneObject
+     * incorrectly set the clip rectangle to just that view. To fix this,
+     * we have to create a full screen android View and invalidate this
+     * to restore the clip rectangle.
+     * @return full screen View object
+     */
+    public View getFullScreenView() {
+        if (mFullScreenView != null) {
+            return mFullScreenView;
+        }
+
+        final DisplayMetrics metrics = new DisplayMetrics();
+        mActivity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        final int screenWidthPixels = Math.max(metrics.widthPixels, metrics.heightPixels);
+        final int screenHeightPixels = Math.min(metrics.widthPixels, metrics.heightPixels);
+
+        final ViewGroup.LayoutParams layout = new ViewGroup.LayoutParams(screenWidthPixels, screenHeightPixels);
+        mFullScreenView = new View(mActivity);
+        mFullScreenView.setLayoutParams(layout);
+        mRenderableViewGroup.addView(mFullScreenView);
+
+        return mFullScreenView;
+    }
+
+    /**
+     * Gets the {@linkplain GVRMain} linked to the activity.
+     * @return the {@link GVRMain}.
+     */
+    public final GVRMain getMain() {
+        return mGVRMain;
+    }
+
+    final long getNative() {
+        return null != mActivityNative ? mActivityNative.getNative() : 0;
+    }
+
+    final IActivityNative getActivityNative() {
+        return mActivityNative;
+    }
+
+    final void setCameraRig(GVRCameraRig cameraRig) {
+        if (null != mActivityNative) {
+            mActivityNative.setCameraRig(cameraRig);
+        }
+    }
+
+    private long mBackKeyDownTime;
+
+    /**
+     *
+     * @param event
+     * @return
+     */
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        final int keyAction = event.getAction();
+        if (KeyEvent.KEYCODE_BACK == event.getKeyCode()) {
+            if (KeyEvent.ACTION_DOWN == keyAction) {
+                if (0 == mBackKeyDownTime) {
+                    mBackKeyDownTime = event.getDownTime();
+                }
+            } else if (KeyEvent.ACTION_UP == keyAction) {
+                final long duration = event.getEventTime() - mBackKeyDownTime;
+                mBackKeyDownTime = 0;
+                if (!isPaused()) {
+                    if (duration < 250) {
+                        if (!mGVRMain.onBackPress()) {
+                            if (!mDelegate.onBackPress()) {
+                                mActivity.finish();
+                            }
+                        }
+                    }
+                }
+            }
+            return true;
+        } else {
+            switch (event.getKeyCode()) {
+                case KeyEvent.KEYCODE_VOLUME_UP:
+                    if (keyAction == KeyEvent.ACTION_DOWN) {
+                        final AudioManager audioManager = (AudioManager) mActivity.getSystemService(Activity.AUDIO_SERVICE);
+                        audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                                AudioManager.ADJUST_RAISE, 0);
+                        return true;
+                    }
+                case KeyEvent.KEYCODE_VOLUME_DOWN:
+                    if (keyAction == KeyEvent.ACTION_DOWN) {
+                        final AudioManager audioManager = (AudioManager) mActivity.getSystemService(Activity.AUDIO_SERVICE);
+                        audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                                AudioManager.ADJUST_LOWER, 0);
+                        return true;
+                    }
+            }
+        }
+
+        mViewManager.getEventManager().sendEventWithMask(
+                SEND_EVENT_MASK,
+                this,
+                IActivityEvents.class,
+                "dispatchKeyEvent", event);
+
+        if (mViewManager.dispatchKeyEvent(event)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * @param keyCode
+     * @param event
+     * @return
+     */
+    public boolean keyLongPress(int keyCode, KeyEvent event) {
+        if (mDelegate.onKeyLongPress(keyCode, event)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * @param keyCode
+     * @param event
+     * @return
+     */
+    public boolean keyUp(int keyCode, KeyEvent event) {
+        if (mDelegate.onKeyUp(keyCode, event)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * @param keyCode
+     * @param event
+     * @return
+     */
+    public boolean keyDown(int keyCode, KeyEvent event) {
+        if (mDelegate.onKeyDown(keyCode, event)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * @param event
+     * @return
+     */
+    public boolean dispatchGenericMotionEvent(MotionEvent event) {
+        return mViewManager.dispatchMotionEvent(event);
+    }
+
+    /**
+     *
+     * @param event
+     * @return
+     */
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        boolean handled = mViewManager.dispatchMotionEvent(event);
+
+        mViewManager.getEventManager().sendEventWithMask(
+                SEND_EVENT_MASK,
+                this,
+                IActivityEvents.class,
+                "dispatchTouchEvent", event);
+
+        return handled;
+    }
+
+    /**
+     *
+     * @param newConfig
+     */
+    public void configurationChanged(Configuration newConfig) {
+        mDelegate.onConfigurationChanged(newConfig);
+
+        if (mViewManager != null) {
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onConfigurationChanged", newConfig);
+        }
+    }
+
+    /**
+     *
+     * @param event
+     * @return
+     */
+    public boolean touchEvent(MotionEvent event) {
+        if (mViewManager != null) {
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onTouchEvent", event);
+        }
+
+        return false;
+    }
+
+    /**
+     *
+     * @param hasFocus
+     */
+    public void windowFocusChanged(boolean hasFocus) {
+        if (mViewManager != null) {
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onWindowFocusChanged", hasFocus);
+        }
+
+        if (hasFocus) {
+            setImmersiveSticky();
+        }
+    }
+
+    // Set Immersive Sticky as described here:
+    // https://developer.android.com/training/system-ui/immersive.html
+    private void setImmersiveSticky() {
+        mActivity.getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+    }
+
+    /**
+     * Called from C++
+     */
+    final boolean updateSensoredScene() {
+        return mViewManager.updateSensoredScene();
+    }
+
+    /**
+     * It is a convenient function to add a {@link GVRView} to Android hierarchy
+     * view. UI thread will refresh the view when necessary.
+     *
+     * @param view Is a {@link GVRView} that draw itself into some
+     *            {@link GVRViewSceneObject}.
+     */
+    public final void registerView(final View view) {
+        mActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (null != mRenderableViewGroup) {
+                    /* The full screen should be updated otherwise just the children's bounds may be refreshed. */
+                    mRenderableViewGroup.setClipChildren(false);
+                    mRenderableViewGroup.addView(view);
+                }
+            }
+        });
+    }
+
+    /**
+     * Remove a child view of Android hierarchy view .
+     *
+     * @param view View to be removed.
+     */
+    public final void unregisterView(final View view) {
+        mActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (null != mRenderableViewGroup) {
+                    mRenderableViewGroup.removeView(view);
+                }
+            }
+        });
+    }
+
+    public final GVRContext getGVRContext() {
+        return mViewManager;
+    }
+
+    @Override
+    public final GVREventReceiver getEventReceiver() {
+        return mEventReceiver;
+    }
+
+    private boolean mIsDocked = false;
+
+    protected final void handleOnDock() {
+        Log.i(TAG, "handleOnDock");
+        final Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                if (!mIsDocked) {
+                    mIsDocked = true;
+
+                    if (null != mActivityNative) {
+                        mActivityNative.onDock();
+                    }
+
+                    for (final DockListener dl : mDockListeners) {
+                        dl.onDock();
+                    }
+                }
+            }
+        };
+        mActivity.runOnUiThread(r);
+    }
+
+    protected final void handleOnUndock() {
+        Log.i(TAG, "handleOnUndock");
+        final Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                if (mIsDocked) {
+                    mIsDocked = false;
+
+                    if (null != mActivityNative) {
+                        mActivityNative.onUndock();
+                    }
+
+                    for (final DockListener dl : mDockListeners) {
+                        dl.onUndock();
+                    }
+                }
+            }
+        };
+        mActivity.runOnUiThread(r);
+    }
+
+    public GVRConfigurationManager getConfigurationManager() {
+        return mConfigurationManager;
+    }
+
+    public Activity getActivity() {
+        return mActivity;
+    }
+
+    public void setMain(GVRMain gvrMain, String dataFileName) {
+        this.mGVRMain = gvrMain;
+        if (mActivity.getRequestedOrientation() == ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE) {
+            onConfigure(dataFileName);
+            if (!mDelegate.setMain(gvrMain, dataFileName)) {
+                Log.w(TAG, "delegate's setMain failed");
+                return;
+            }
+
+            mViewManager = mDelegate.makeViewManager();
+            mDelegate.setViewManager(mViewManager);
+
+            if (mConfigurationManager.isDockListenerRequired()) {
+                startDockEventReceiver();
+            } else {
+                handleOnDock();
+            }
+
+            mViewManager.getEventManager().sendEventWithMask(
+                    SEND_EVENT_MASK,
+                    this,
+                    IActivityEvents.class,
+                    "onSetMain", gvrMain);
+
+            final GVRConfigurationManager localConfigurationManager = mConfigurationManager;
+            if (null != mDockEventReceiver && localConfigurationManager.isDockListenerRequired()) {
+                getGVRContext().registerDrawFrameListener(new GVRDrawFrameListener() {
+                    @Override
+                    public void onDrawFrame(float frameTime) {
+                        if (localConfigurationManager.isHmtConnected()) {
+                            handleOnDock();
+                            getGVRContext().unregisterDrawFrameListener(this);
+                        }
+                    }
+                });
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "You can not set orientation to portrait for GVRF apps.");
+        }
+    }
+
+    interface DockListener {
+        void onDock();
+        void onUndock();
+    }
+
+    private final List<DockListener> mDockListeners = new CopyOnWriteArrayList<DockListener>();
+
+    final void addDockListener(final DockListener dl) {
+        mDockListeners.add(dl);
+    }
+
+    private DockEventReceiver mDockEventReceiver;
+
+    private void startDockEventReceiver() {
+        mDockEventReceiver = mConfigurationManager.makeDockEventReceiver(this.getActivity(),
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        handleOnDock();
+                    }
+                }, new Runnable() {
+                    @Override
+                    public void run() {
+                        handleOnUndock();
+                    }
+                });
+        if (null != mDockEventReceiver) {
+            mDockEventReceiver.start();
+        } else {
+            Log.w(TAG, "dock listener not started");
+        }
+    }
+
+    /**
+     * Enables the Android GestureDetector which in turn fires the appropriate {@link GVRMain} callbacks.
+     * By default it is not.
+     * @see GVRMain#onSwipe(GVRTouchPadGestureListener.Action, float)
+     * @see GVRMain#onSingleTapUp(MotionEvent)
+     * @see GVRTouchPadGestureListener
+     */
+    public synchronized void enableGestureDetector() {
+        final GVRTouchPadGestureListener gestureListener = new GVRTouchPadGestureListener() {
+            @Override
+            public boolean onSwipe(MotionEvent e, Action action, float vx, float vy) {
+                if (null != mGVRMain) {
+                    mGVRMain.onSwipe(action, vx);
+                }
+                return true;
+            }
+
+            @Override
+            public boolean onSingleTapUp(MotionEvent e) {
+                if (null != mGVRMain) {
+                    mGVRMain.onSingleTapUp(e);
+                }
+                return true;
+            }
+        };
+        mGestureDetector = new GestureDetector(mActivity.getApplicationContext(), gestureListener);
+        getEventReceiver().addListener(new GVREventListeners.ActivityEvents() {
+            @Override
+            public void dispatchTouchEvent(MotionEvent event) {
+                mGestureDetector.onTouchEvent(event);
+            }
+        });
+    }
+
+    private GestureDetector mGestureDetector;
+
+    private GVRActivityDelegate mDelegate;
+
+    GVRActivityDelegate getDelegate() {
+        return mDelegate;
+    }
+
+    interface GVRActivityDelegate {
+        void onCreate(GVRApplication activity);
+        void onPause();
+        void onResume();
+        void onDestroy();
+        void onConfigurationChanged(final Configuration newConfig);
+
+        boolean onKeyDown(int keyCode, KeyEvent event);
+        boolean onKeyUp(int keyCode, KeyEvent event);
+        boolean onKeyLongPress(int keyCode, KeyEvent event);
+
+        boolean setMain(GVRMain gvrMain, String dataFileName);
+        void setViewManager(GVRViewManager viewManager);
+        void onInitAppSettings(VrAppSettings appSettings);
+
+        VrAppSettings makeVrAppSettings();
+        IActivityNative getActivityNative();
+        GVRViewManager makeViewManager();
+        GVRCameraRig makeCameraRig(GVRContext context);
+        GVRConfigurationManager makeConfigurationManager();
+        void parseXmlSettings(AssetManager assetManager, String dataFilename);
+
+        boolean onBackPress();
+    }
+
+    static class ActivityDelegateStubs implements GVRActivityDelegate {
+
+        @Override
+        public void onCreate(GVRApplication application) {
+
+        }
+
+        @Override
+        public void onPause() {
+
+        }
+
+        @Override
+        public void onResume() {
+
+        }
+
+        @Override
+        public void onDestroy() {
+
+        }
+
+        @Override
+        public void onConfigurationChanged(Configuration newConfig) {
+
+        }
+
+        @Override
+        public boolean onKeyDown(int keyCode, KeyEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean onKeyUp(int keyCode, KeyEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean onKeyLongPress(int keyCode, KeyEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean setMain(GVRMain gvrMain, String dataFileName) {
+            return false;
+        }
+
+        @Override
+        public void setViewManager(GVRViewManager viewManager) {
+
+        }
+
+        @Override
+        public void onInitAppSettings(VrAppSettings appSettings) {
+
+        }
+
+        @Override
+        public VrAppSettings makeVrAppSettings() {
+            return null;
+        }
+
+        @Override
+        public IActivityNative getActivityNative() {
+            return null;
+        }
+
+        @Override
+        public GVRViewManager makeViewManager() {
+            return null;
+        }
+
+        @Override
+        public GVRCameraRig makeCameraRig(GVRContext context) {
+            return null;
+        }
+
+        @Override
+        public GVRConfigurationManager makeConfigurationManager() {
+            return null;
+        }
+
+        @Override
+        public void parseXmlSettings(AssetManager assetManager, String dataFilename) {
+
+        }
+
+        @Override
+        public boolean onBackPress() {
+            return false;
+        }
+    }
+
+    private final static String DEBUG_GEARVRF_BACKEND = "debug.gearvrf.backend";
+    private final static int MAX_BACKEND_ID = 9;
+}

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCameraRig.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRCameraRig.java
@@ -15,9 +15,10 @@
 
 package org.gearvrf;
 
-import static org.gearvrf.utility.Assert.*;
-
 import org.gearvrf.utility.Log;
+
+import static org.gearvrf.utility.Assert.checkFloatNotNaNOrInfinity;
+import static org.gearvrf.utility.Assert.checkStringNotNullOrEmpty;
 
 /** Holds the GVRCameras. */
 public class GVRCameraRig extends GVRComponent implements PrettyPrint {
@@ -73,7 +74,7 @@ public class GVRCameraRig extends GVRComponent implements PrettyPrint {
      * lead to native crashes.
      */
     public static GVRCameraRig makeInstance(GVRContext gvrContext) {
-        final GVRCameraRig result = gvrContext.getActivity().getDelegate().makeCameraRig(gvrContext);
+        final GVRCameraRig result = gvrContext.getApplication().getDelegate().makeCameraRig(gvrContext);
         result.init(gvrContext);
         return result;
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContextProxy.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRContextProxy.java
@@ -1,20 +1,15 @@
 package org.gearvrf;
 
+import android.app.Activity;
 import android.content.Context;
-import android.graphics.Bitmap;
 
 import org.gearvrf.animation.GVRAnimationEngine;
 import org.gearvrf.debug.DebugServer;
 import org.gearvrf.io.GVRInputManager;
 import org.gearvrf.periodic.GVRPeriodicEngine;
-import org.gearvrf.scene_objects.GVRModelSceneObject;
 import org.gearvrf.script.GVRScriptManager;
 
-import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.concurrent.Future;
 
 /**
  * Class that supports the scripting feature. Not meant for anything
@@ -35,7 +30,7 @@ public final class GVRContextProxy extends GVRContext {
         return mContext.get().getContext();
     }
 
-    public GVRActivity getActivity() {
+    public Activity getActivity() {
         return mContext.get().getActivity();
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderBundle.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderBundle.java
@@ -14,8 +14,6 @@
  */
 package org.gearvrf;
 
-import android.transition.Scene;
-
 import org.gearvrf.utility.Log;
 import org.gearvrf.utility.VrAppSettings;
 
@@ -41,7 +39,7 @@ class GVRRenderBundle {
         mGVRContext = gvrContext;
         mShaderManager = new GVRShaderManager(gvrContext);
 
-        final VrAppSettings appSettings = mGVRContext.getActivity().getAppSettings();
+        final VrAppSettings appSettings = mGVRContext.getApplication().getAppSettings();
         mSampleCount = appSettings.getEyeBufferParams().getMultiSamples() < 0 ? 0
                 : appSettings.getEyeBufferParams().getMultiSamples();
         if (mSampleCount > 1) {
@@ -50,8 +48,8 @@ class GVRRenderBundle {
                 mSampleCount = maxSampleCount;
             }
         }
-        mWidth = mGVRContext.getActivity().getAppSettings().getEyeBufferParams().getResolutionWidth();
-        mHeight = mGVRContext.getActivity().getAppSettings().getEyeBufferParams().getResolutionHeight();
+        mWidth = mGVRContext.getApplication().getAppSettings().getEyeBufferParams().getResolutionWidth();
+        mHeight = mGVRContext.getApplication().getAppSettings().getEyeBufferParams().getResolutionHeight();
     }
     public void createRenderTarget(int index, GVRViewManager.EYE eye, GVRRenderTexture renderTexture){
 
@@ -139,13 +137,13 @@ class GVRRenderBundle {
 
     public GVRRenderTexture getPostEffectRenderTextureA() {
         if(mPostEffectRenderTextureA == null)
-            mPostEffectRenderTextureA = new GVRRenderTexture(mGVRContext, mWidth , mHeight, mSampleCount, mGVRContext.getActivity().getAppSettings().isMultiviewSet() ? 2 : 1);
+            mPostEffectRenderTextureA = new GVRRenderTexture(mGVRContext, mWidth , mHeight, mSampleCount, mGVRContext.getApplication().getAppSettings().isMultiviewSet() ? 2 : 1);
         return mPostEffectRenderTextureA;
     }
 
     public GVRRenderTexture getPostEffectRenderTextureB() {
         if(mPostEffectRenderTextureB == null)
-            mPostEffectRenderTextureB = new GVRRenderTexture(mGVRContext, mWidth , mHeight, mSampleCount, mGVRContext.getActivity().getAppSettings().isMultiviewSet() ? 2 : 1);
+            mPostEffectRenderTextureB = new GVRRenderTexture(mGVRContext, mWidth , mHeight, mSampleCount, mGVRContext.getApplication().getAppSettings().isMultiviewSet() ? 2 : 1);
 
         return mPostEffectRenderTextureB;
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderData.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderData.java
@@ -299,7 +299,7 @@ public final class GVRRenderData extends GVRComponent implements IRenderable, Pr
         GVRRenderPass pass = mRenderPassList.get(0);
         GVRShaderId shader = pass.getMaterial().getShaderType();
         GVRShader template = shader.getTemplate(getGVRContext());
-        boolean isMultiview = getGVRContext().getActivity().getAppSettings().isMultiviewSet();
+        boolean isMultiview = getGVRContext().getApplication().getAppSettings().isMultiviewSet();
         if (template != null)
         {
             template.bindShader(getGVRContext(), this, scene, isMultiview);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderTarget.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRRenderTarget.java
@@ -15,8 +15,6 @@
 
 package org.gearvrf;
 
-import org.gearvrf.utility.Log;
-
 /**
  * A render target is a component which allows the scene to be rendered
  * into a texture from the viewpoint of a particular scene object.
@@ -140,7 +138,7 @@ public class GVRRenderTarget extends GVRBehavior
 
     public void onDrawFrame(float frameTime)
     {
-        getGVRContext().getActivity().getViewManager().cullAndRender(this, mScene);
+        getGVRContext().getApplication().getViewManager().cullAndRender(this, mScene);
     }
 }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -73,7 +73,7 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
         NativeScene.setJava(getNative(), this);
 
         if(MAX_LIGHTS == 0) {
-            MAX_LIGHTS = gvrContext.getActivity().getConfigurationManager().getMaxLights();
+            MAX_LIGHTS = gvrContext.getApplication().getConfigurationManager().getMaxLights();
         }
 
         mSceneRoot = new GVRSceneObject(gvrContext);
@@ -252,7 +252,7 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
 
         final GVRContext gvrContext = getGVRContext();
         if (this == gvrContext.getMainScene()) {
-            gvrContext.getActivity().setCameraRig(getMainCameraRig());
+            gvrContext.getApplication().setCameraRig(getMainCameraRig());
         }
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderTemplate.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRShaderTemplate.java
@@ -14,15 +14,15 @@
  */
 package org.gearvrf;
 
+import org.gearvrf.shaders.GVRPhongShader;
+import org.gearvrf.utility.Log;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.gearvrf.shaders.GVRPhongShader;
-import org.gearvrf.utility.Log;
 
 /**
  * Generates a set of native vertex and fragment shaders from source code segments.
@@ -544,7 +544,7 @@ public class GVRShaderTemplate extends GVRShader
         int castShadow = 0;
         GVRLight[] lights = (scene != null) ? scene.getLightList() : null;
 
-        if (renderable.getGVRContext().getActivity().getAppSettings().isMultiviewSet())
+        if (renderable.getGVRContext().getApplication().getAppSettings().isMultiviewSet())
         {
             defines.put("MULTIVIEW", 1);
         }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -48,10 +48,10 @@ abstract class GVRViewManager extends GVRContext {
     enum EYE {
         LEFT, RIGHT, MULTIVIEW, CENTER;
     }
-    GVRViewManager(GVRActivity activity, GVRMain main) {
+    GVRViewManager(GVRApplication activity, GVRMain main) {
         super(activity);
 
-        mActivity = activity;
+        mApplication = activity;
         mMain = main;
 
         VrAppSettings vrAppSettings = activity.getAppSettings();
@@ -142,7 +142,7 @@ abstract class GVRViewManager extends GVRContext {
     private void setMainSceneImpl(GVRScene scene) {
         mMainScene = scene;
         NativeScene.setMainScene(scene.getNative());
-        getActivity().setCameraRig(scene.getMainCameraRig());
+        mApplication.setCameraRig(scene.getMainCameraRig());
         mInputManager.setScene(scene);
     }
 
@@ -218,12 +218,12 @@ abstract class GVRViewManager extends GVRContext {
         setMainSceneImpl(scene);
         mRenderBundle = makeRenderBundle();
 
-        final DepthFormat depthFormat = getActivity().getAppSettings().getEyeBufferParams().getDepthFormat();
-        getActivity().getConfigurationManager().configureRendering(DepthFormat.DEPTH_24_STENCIL_8 == depthFormat);
+        final DepthFormat depthFormat = mApplication.getAppSettings().getEyeBufferParams().getDepthFormat();
+        mApplication.getConfigurationManager().configureRendering(DepthFormat.DEPTH_24_STENCIL_8 == depthFormat);
     }
 
     private void createMainScene() {
-        if (getActivity().getAppSettings().showLoadingIcon) {
+        if (mApplication.getAppSettings().showLoadingIcon) {
             mSplashScreen = mMain.createSplashScreen();
             if (mSplashScreen != null) {
                 mMainSceneLock.lock();
@@ -594,7 +594,7 @@ abstract class GVRViewManager extends GVRContext {
 
     protected void readRenderResult(GVRRenderTarget renderTarget, GVRViewManager.EYE eye, boolean useMultiview) {
         if (mReadbackBuffer == null) {
-            final VrAppSettings settings = mActivity.getAppSettings();
+            final VrAppSettings settings = mApplication.getAppSettings();
             final VrAppSettings.EyeBufferParams eyeBufferParams = settings.getEyeBufferParams();
             mReadbackBufferWidth = eyeBufferParams.getResolutionWidth();
             mReadbackBufferHeight = eyeBufferParams.getResolutionHeight();
@@ -812,7 +812,7 @@ abstract class GVRViewManager extends GVRContext {
     }
     GVRGearCursorController.ControllerReader mControllerReader;
     private final GVRScriptManager mScriptManager;
-    protected final GVRActivity mActivity;
+    protected final GVRApplication mApplication;
     protected float mFrameTime;
     protected long mPreviousTimeNanos;
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRAndroidWearTouchpad.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRAndroidWearTouchpad.java
@@ -16,6 +16,7 @@
 
 package org.gearvrf.io;
 
+import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -28,7 +29,6 @@ import android.os.RemoteException;
 import android.util.Log;
 import android.view.MotionEvent;
 
-import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVREventListeners.ActivityEvents;
 import org.gearvrf.GVREventManager;
@@ -46,7 +46,7 @@ class GVRAndroidWearTouchpad {
     private Messenger sendMessenger = null;
     private Messenger receiveMessenger = null;
     private GVRContext gvrContext;
-    private GVRActivity activity;
+    private Activity activity;
     private GVREventManager eventManager;
     private boolean boundToService;
     private boolean connectedToWatch;
@@ -55,7 +55,7 @@ class GVRAndroidWearTouchpad {
         gvrContext = context;
         activity = gvrContext.getActivity();
         eventManager = gvrContext.getEventManager();
-        gvrContext.getActivity().getEventReceiver().addListener(new ActivityPauseEvent());
+        gvrContext.getApplication().getEventReceiver().addListener(new ActivityPauseEvent());
         connectToWatch();
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRCursorController.java
@@ -18,7 +18,6 @@ package org.gearvrf.io;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
-import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRCamera;
 import org.gearvrf.GVRCollider;
 import org.gearvrf.GVRContext;

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/io/IWearTouchpadEvents.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/io/IWearTouchpadEvents.java
@@ -2,7 +2,6 @@ package org.gearvrf.io;
 
 import android.view.MotionEvent;
 
-import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRContext;
 import org.gearvrf.IEvents;
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRCameraSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRCameraSceneObject.java
@@ -139,7 +139,7 @@ public class GVRCameraSceneObject extends GVRSceneObject {
         }
 
         cameraActivityEvents = new CameraActivityEvents();
-        gvrContext.getActivity().getEventReceiver().addListener(cameraActivityEvents);
+        gvrContext.getApplication().getEventReceiver().addListener(cameraActivityEvents);
     }
 
     /**
@@ -266,7 +266,7 @@ public class GVRCameraSceneObject extends GVRSceneObject {
     public void close() {
         closeCamera();
         if(cameraActivityEvents != null){
-            gvrContext.getActivity().getEventReceiver().removeListener(cameraActivityEvents);
+            gvrContext.getApplication().getEventReceiver().removeListener(cameraActivityEvents);
         }
     }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRKeyboardSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRKeyboardSceneObject.java
@@ -37,7 +37,7 @@ import android.view.ViewConfiguration;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 
-import org.gearvrf.GVRActivity;
+import org.gearvrf.GVRApplication;
 import org.gearvrf.GVRCollider;
 import org.gearvrf.GVRComponent;
 import org.gearvrf.GVRContext;
@@ -68,7 +68,7 @@ import java.util.Map;
  * See: {@link Keyboard}
  */
 public class GVRKeyboardSceneObject extends GVRSceneObject {
-    private final GVRActivity mActivity;
+    private final GVRApplication mApplication;
 
     private GVRMesh mKeyboardMesh;
     private GVRMesh mKeyMesh;
@@ -103,7 +103,7 @@ public class GVRKeyboardSceneObject extends GVRSceneObject {
                                   GVRMesh keyMesh, GVRTexture keyboardTexture,
                                    Drawable keyBackground, int textColor, boolean enableHoverAnim) {
         super(gvrContext);
-        mActivity = gvrContext.getActivity();
+        mApplication = gvrContext.getApplication();
         mKeyboardMesh = keyboardMesh;
         mKeyMesh = keyMesh;
         mKeyboardTexture = keyboardTexture;
@@ -119,7 +119,7 @@ public class GVRKeyboardSceneObject extends GVRSceneObject {
         MeshUtils.resize(mKeyMesh, 1.0f);
 
         mKeyMeshDepthSize = MeshUtils.getBoundingSize(mKeyMesh)[2];
-        mKeyEventsHandler = new KeyEventsHandler(mActivity.getMainLooper(), this, mActivity);
+        mKeyEventsHandler = new KeyEventsHandler(gvrContext.getActivity().getMainLooper(), this, mApplication);
         mGVRKeyboardCache = new HashMap<Integer, GVRKeyboard>();
         mEditableSceneObject = null;
         mMiniKeyboard = null;
@@ -168,7 +168,7 @@ public class GVRKeyboardSceneObject extends GVRSceneObject {
         if (gvrKeyboard != null) {
             setKeyboard(gvrKeyboard.mKeyboard, keyboardResId);
         } else {
-            setKeyboard(new Keyboard(mActivity, keyboardResId), keyboardResId);
+            setKeyboard(new Keyboard(mApplication.getActivity(), keyboardResId), keyboardResId);
         }
     }
 
@@ -817,7 +817,7 @@ public class GVRKeyboardSceneObject extends GVRSceneObject {
 
         private boolean mIsProcessing = false;
         GVRKeyboardSceneObject mGvrKeyboard;
-        GVRActivity mActivity;
+        GVRApplication mApplication;
         GVRKey mSelectedKey;
         GVRKey mPressedKey;
 
@@ -869,10 +869,10 @@ public class GVRKeyboardSceneObject extends GVRSceneObject {
             }
         };
 
-        public KeyEventsHandler(Looper loop, GVRKeyboardSceneObject gvrKeyboard, GVRActivity activity) {
+        public KeyEventsHandler(Looper loop, GVRKeyboardSceneObject gvrKeyboard, GVRApplication activity) {
             super(loop);
             mGvrKeyboard = gvrKeyboard;
-            mActivity = activity;
+            mApplication = activity;
         }
 
         public void start() {
@@ -913,20 +913,20 @@ public class GVRKeyboardSceneObject extends GVRSceneObject {
 
         public void onEnter(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo) {
             mOnEnterKey.HitKey = (GVRKey) pickInfo.hitObject;
-            mActivity.runOnUiThread(mOnEnterKey);
+            mApplication.getActivity().runOnUiThread(mOnEnterKey);
         }
 
         public void onExit(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo) {
             mOnExitKey.HitKey = (GVRKey) pickInfo.hitObject;
-            mActivity.runOnUiThread(mOnExitKey);
+            mApplication.getActivity().runOnUiThread(mOnExitKey);
        }
 
         public void onTouchStart(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo) {
-            mActivity.runOnUiThread(mOnTouchStartKey);
+            mApplication.getActivity().runOnUiThread(mOnTouchStartKey);
         }
 
         public void onTouchEnd(GVRSceneObject sceneObject, GVRPicker.GVRPickedObject pickInfo) {
-            mActivity.runOnUiThread(mOnTouchEndKey);
+            mApplication.getActivity().runOnUiThread(mOnTouchEndKey);
         }
 
         @Override
@@ -1140,7 +1140,7 @@ public class GVRKeyboardSceneObject extends GVRSceneObject {
 
     private static class InputMethodHandler implements IKeyboardEvents
     {
-        final GVRActivity mActivity;
+        final GVRApplication mApplication;
         final GVRViewSceneObject.RootViewGroup mRootGroup;
         GVRKeyboardSceneObject mGvrKeybaord;
         final String mWordSeparators;
@@ -1153,10 +1153,10 @@ public class GVRKeyboardSceneObject extends GVRSceneObject {
 
         public InputMethodHandler(GVRViewSceneObject view)
         {
-            mActivity = view.getGVRContext().getActivity();
+            mApplication = view.getGVRContext().getApplication();
             mRootGroup = view.getRootView();
             mGvrKeybaord = null;
-            mWordSeparators = mActivity.getResources().getString(R.string.word_separators);
+            mWordSeparators = mApplication.getActivity().getResources().getString(R.string.word_separators);
 
             mCapsLock = false;
             mLastShiftTime = 0;

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRTextViewSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRTextViewSceneObject.java
@@ -15,21 +15,7 @@
 
 package org.gearvrf.scene_objects;
 
-import org.gearvrf.GVRActivity;
-import org.gearvrf.GVRContext;
-import org.gearvrf.GVRDrawFrameListener;
-import org.gearvrf.GVRExternalTexture;
-import org.gearvrf.GVRMaterial;
-import org.gearvrf.GVRMaterial.GVRShaderType;
-
-import java.lang.ref.WeakReference;
-import java.util.Locale;
-
-import org.gearvrf.GVRMesh;
-import org.gearvrf.GVRRenderData;
-import org.gearvrf.GVRSceneObject;
-import org.gearvrf.GVRTexture;
-
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -37,15 +23,25 @@ import android.graphics.PorterDuff.Mode;
 import android.graphics.SurfaceTexture;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
-import android.text.Layout;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
-
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRDrawFrameListener;
+import org.gearvrf.GVRExternalTexture;
+import org.gearvrf.GVRMaterial;
+import org.gearvrf.GVRMaterial.GVRShaderType;
+import org.gearvrf.GVRMesh;
+import org.gearvrf.GVRRenderData;
+import org.gearvrf.GVRSceneObject;
+import org.gearvrf.GVRTexture;
+
+import java.lang.ref.WeakReference;
 
 public class GVRTextViewSceneObject extends GVRSceneObject {
     private static final String TAG = GVRTextViewSceneObject.class.getSimpleName();
@@ -148,7 +144,7 @@ public class GVRTextViewSceneObject extends GVRSceneObject {
             canvasHeight = MAX_IMAGE_SIZE;
         }
 
-        final GVRActivity activity = gvrContext.getActivity();
+        final Activity activity = gvrContext.getActivity();
         mTextView = new TextView(activity);
         mTextView.setBackgroundColor(Color.TRANSPARENT);
         mTextView.setTextColor(Color.WHITE);
@@ -234,7 +230,7 @@ public class GVRTextViewSceneObject extends GVRSceneObject {
         super(gvrContext);
 
         setName(name);
-        final GVRActivity activity = gvrContext.getActivity();
+        final Activity activity = gvrContext.getActivity();
         mTextView = new TextView(activity);
         mTextView.setBackgroundColor(Color.TRANSPARENT);
         mTextView.setTextColor(Color.WHITE);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRVideoSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRVideoSceneObject.java
@@ -172,7 +172,7 @@ public class GVRVideoSceneObject extends GVRSceneObject {
         GVRShaderId materialType;
 
         gvrVideoSceneObjectPlayer = mediaPlayer;
-        gvrContext.getActivity().getEventReceiver().addListener(mActivityEventsListener);
+        gvrContext.getApplication().getEventReceiver().addListener(mActivityEventsListener);
 
 
         switch (videoType) {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
@@ -44,7 +44,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
-import org.gearvrf.GVRActivity;
+import org.gearvrf.GVRApplication;
 import org.gearvrf.GVRCollider;
 import org.gearvrf.GVRContext;
 import org.gearvrf.GVRExternalTexture;
@@ -192,32 +192,32 @@ public class GVRViewSceneObject extends GVRSceneObject {
     private GVRViewSceneObject(GVRContext gvrContext, final View view, final int viewId,
                                IViewEvents eventsListener, GVRMesh mesh) {
         super(gvrContext, mesh);
-        final GVRActivity activity = gvrContext.getActivity();
+        final GVRApplication application = gvrContext.getApplication();
 
         mEventsListener = eventsListener;
         mLock = new Object();
 
-        mRootViewGroup = new RootViewGroup(activity, this);
+        mRootViewGroup = new RootViewGroup(application, this);
 
-        activity.runOnUiThread(new Runnable() {
+        application.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 if (viewId != View.NO_ID) {
-                    addView(activity, viewId);
+                    addView(application, viewId);
                 } else {
-                    addView(activity, view);
+                    addView(application, view);
                 }
             }
         });
     }
 
     // UI thread
-    private void addView(GVRActivity gvrActivity, int viewId) {
-        addView(gvrActivity, View.inflate(gvrActivity, viewId, null));
+    private void addView(GVRApplication application, int viewId) {
+        addView(application, View.inflate(application.getActivity(), viewId, null));
     }
 
     // UI thread
-    private void addView(GVRActivity gvrActivity, View view) {
+    private void addView(GVRApplication application, View view) {
         if (view == null) {
             throw new IllegalArgumentException("Android view cannot be null.");
         } else if (view.getParent() != null) {
@@ -232,7 +232,7 @@ public class GVRViewSceneObject extends GVRSceneObject {
         getEventReceiver().addListener(mRootViewGroup);
 
         // To fix invalidate issue at S6/Note5
-        gvrActivity.getFullScreenView().invalidate();
+        application.getFullScreenView().invalidate();
     }
 
     public RootViewGroup getRootView() { return mRootViewGroup; }
@@ -247,7 +247,7 @@ public class GVRViewSceneObject extends GVRSceneObject {
     @Override
     protected void onNewParentObject(GVRSceneObject parent) {
         super.onNewParentObject(parent);
-        final GVRActivity activity = getGVRContext().getActivity();
+        final Activity activity = getGVRContext().getActivity();
 
         synchronized (mLock) {
             if (getRenderData() != null) {
@@ -265,7 +265,7 @@ public class GVRViewSceneObject extends GVRSceneObject {
     @Override
     protected void onRemoveParentObject(GVRSceneObject parent) {
         super.onRemoveParentObject(parent);
-        final GVRActivity activity = getGVRContext().getActivity();
+        final Activity activity = getGVRContext().getActivity();
 
         synchronized (mLock) {
             if (getRenderData() != null) {
@@ -506,19 +506,19 @@ public class GVRViewSceneObject extends GVRSceneObject {
         GVRSceneObject mSelected = null;
         SoftInputController mSoftInputController;
 
-        public RootViewGroup(GVRActivity gvrActivity, GVRViewSceneObject sceneObject) {
-            super(gvrActivity);
+        public RootViewGroup(GVRApplication application, GVRViewSceneObject sceneObject) {
+            super(application.getActivity());
 
             setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                     LayoutParams.WRAP_CONTENT));
 
-            mGVRContext = gvrActivity.getGVRContext();
+            mGVRContext = application.getGVRContext();
             mSceneObject = sceneObject;
 
             // To optimization
             setWillNotDraw(true);
 
-            mSoftInputController = new SoftInputController(gvrActivity, sceneObject);
+            mSoftInputController = new SoftInputController(application.getActivity(), sceneObject);
 
             // To block Android's popups
             // setDescendantFocusability(FOCUS_BLOCK_DESCENDANTS);
@@ -626,7 +626,7 @@ public class GVRViewSceneObject extends GVRSceneObject {
                         }
                     });
 
-            mGVRContext.getActivity().registerView(this);
+            mGVRContext.getApplication().registerView(this);
         }
 
         private void onLayoutReady() {

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/view/GVRFrameLayout.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/view/GVRFrameLayout.java
@@ -1,13 +1,11 @@
 package org.gearvrf.scene_objects.view;
 
-import org.gearvrf.GVRActivity;
-import org.gearvrf.scene_objects.GVRViewSceneObject;
-
-import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.PorterDuff;
 import android.view.View;
 import android.widget.FrameLayout;
+
+import org.gearvrf.GVRApplication;
+import org.gearvrf.scene_objects.GVRViewSceneObject;
 
 /**
  * This class represents a {@link FrameLayout} that is rendered
@@ -20,8 +18,9 @@ import android.widget.FrameLayout;
 public class GVRFrameLayout extends FrameLayout implements GVRView {
     private GVRViewSceneObject mSceneObject = null;
 
-    public GVRFrameLayout(GVRActivity  context) {
-        super(context);
+    @Deprecated
+    public GVRFrameLayout(GVRApplication application) {
+        super(application.getActivity());
 
         /* Setting background color to avoid complex logic,
          * otherwise android will call just drawChild
@@ -30,7 +29,7 @@ public class GVRFrameLayout extends FrameLayout implements GVRView {
          */
         setBackgroundColor(Color.TRANSPARENT);
 
-        context.registerView(this);
+        application.registerView(this);
     }
 
     @Override

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/view/GVRTextView.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/view/GVRTextView.java
@@ -1,15 +1,13 @@
 package org.gearvrf.scene_objects.view;
 
-import org.gearvrf.GVRActivity;
-import org.gearvrf.scene_objects.GVRViewSceneObject;
-
-import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.PorterDuff.Mode;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
+import org.gearvrf.GVRActivity;
+import org.gearvrf.GVRApplication;
+import org.gearvrf.scene_objects.GVRViewSceneObject;
 
 /**
  * This class represents a {@link TextView} that is rendered
@@ -22,16 +20,9 @@ public class GVRTextView extends TextView implements GVRView {
     private GVRViewSceneObject mSceneObject = null;
     private ViewGroup mTextViewContainer;
 
-    public GVRTextView(GVRActivity context) {
-        super(context);
-
-        mTextViewContainer = new LinearLayout(context);
-        mTextViewContainer.addView(this);
-
-        mTextViewContainer.setLayoutParams(new LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
-
-        context.registerView(mTextViewContainer);
+    @Deprecated
+    public GVRTextView(GVRActivity activity) {
+        this(activity.getGVRApplication());
     }
 
     /**
@@ -43,8 +34,33 @@ public class GVRTextView extends TextView implements GVRView {
      * @param viewHeight
      *            Height of the {@linkplain LinearLayout Layout container}
      */
-    public GVRTextView(GVRActivity context, int viewWidth, int viewHeight) {
-        this(context, viewWidth, viewHeight, null);
+    public GVRTextView(GVRActivity activity, int viewWidth, int viewHeight) {
+        this(activity.getGVRApplication(), viewWidth, viewHeight, null);
+    }
+
+    public GVRTextView(GVRApplication application) {
+        super(application.getActivity());
+
+        mTextViewContainer = new LinearLayout(application.getActivity());
+        mTextViewContainer.addView(this);
+
+        mTextViewContainer.setLayoutParams(new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+
+        application.registerView(mTextViewContainer);
+    }
+
+    /**
+     * Creates a new instance and sets its internal {@linkplain LinearLayout Layout container}
+     * with the specified width and height.
+     *
+     * @param viewWidth
+     *            Width of the {@linkplain LinearLayout Layout container}
+     * @param viewHeight
+     *            Height of the {@linkplain LinearLayout Layout container}
+     */
+    public GVRTextView(GVRApplication application, int viewWidth, int viewHeight) {
+        this(application, viewWidth, viewHeight, null);
     }
 
     /**
@@ -58,8 +74,8 @@ public class GVRTextView extends TextView implements GVRView {
      * @param text
      *            Text to set to the text view.
      */
-    public GVRTextView(GVRActivity context, int viewWidth, int viewHeight, String text) {
-        this(context);
+    public GVRTextView(GVRApplication application, int viewWidth, int viewHeight, String text) {
+        this(application);
 
         setLayoutParams(new LinearLayout.LayoutParams(viewWidth, viewHeight));
         mTextViewContainer.measure(viewWidth, viewHeight);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/view/GVRWebView.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/view/GVRWebView.java
@@ -15,13 +15,12 @@
 
 package org.gearvrf.scene_objects.view;
 
-import org.gearvrf.GVRActivity;
-import org.gearvrf.scene_objects.GVRViewSceneObject;
-
-import android.graphics.Canvas;
 import android.view.View;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+
+import org.gearvrf.GVRApplication;
+import org.gearvrf.scene_objects.GVRViewSceneObject;
 
 /**
  * This class represents a {@link WebView} that is rendered
@@ -32,11 +31,12 @@ import android.webkit.WebViewClient;
 public class GVRWebView extends WebView implements GVRView {
     private GVRViewSceneObject mSceneObject = null;
 
-    public GVRWebView(GVRActivity context) {
-        super(context);
+    @Deprecated
+    public GVRWebView(GVRApplication application) {
+        super(application.getActivity());
 
         setWebViewClient(new WebViewClient());
-        context.registerView(this);
+        application.registerView(this);
     }
 
     @Override

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptManager.java
@@ -57,7 +57,7 @@ public class GVRScriptManager {
     // For script bundles. All special targets start with @.
     public static final String TARGET_PREFIX = "@";
     public static final String TARGET_GVRMAIN = "@GVRMain";
-    public static final String TARGET_GVRACTIVITY = "@GVRActivity";
+    public static final String TARGET_GVRAPPLICATION = "@GVRApplication";
 
     interface TargetResolver {
         IScriptable getTarget(GVRContext gvrContext, String name);
@@ -74,16 +74,16 @@ public class GVRScriptManager {
             @Override
             public IScriptable getTarget(GVRContext gvrContext,
                                          String name) {
-                return gvrContext.getActivity().getMain();
+                return gvrContext.getApplication().getMain();
             }
         });
 
         // Target resolver for "@GVRActivity"
-        sBuiltinTargetMap.put(TARGET_GVRACTIVITY, new TargetResolver() {
+        sBuiltinTargetMap.put(TARGET_GVRAPPLICATION, new TargetResolver() {
             @Override
             public IScriptable getTarget(GVRContext gvrContext,
                                          String name) {
-                return gvrContext.getActivity();
+                return gvrContext.getApplication();
             }
         });
     }
@@ -359,7 +359,7 @@ public class GVRScriptManager {
                     toBind = true;
                 }
 
-                if ((bindMask & BIND_MASK_GVRACTIVITY) != 0 && targetName.equalsIgnoreCase(TARGET_GVRACTIVITY)) {
+                if ((bindMask & BIND_MASK_GVRACTIVITY) != 0 && targetName.equalsIgnoreCase(TARGET_GVRAPPLICATION)) {
                     toBind = true;
                 }
 


### PR DESCRIPTION
Demos PR: https://github.com/gearvrf/GearVRf-Demos/pull/626

Doesn't change the fact GVRf's backend adapters create full screen SurfaceViews/GLSurfaceViews. So it doesn't make GVRf more of a library than before. Just removes the requirement to derive from GVRActivity.

Provide GVRActivity implementation on top of GVRApplication that preserves API compatibility for older apps.

Small API changes since use of GVRActivity is no longer mandatory.

---

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>