### PR TITLE
gradle: include the support for vulkan validation layers only in the debug builds

### DIFF
--- a/GVRf/Framework/framework/build.gradle
+++ b/GVRf/Framework/framework/build.gradle
@@ -98,6 +98,11 @@ android {
         debug {
             debuggable = true
             jniDebuggable = true
+            sourceSets.debug {
+                jniLibs {
+                    srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
+                }
+            }
         }
         release {
             minifyEnabled false
@@ -108,10 +113,6 @@ android {
     sourceSets.main {
         java.srcDirs = ['src/main/java']
         resources.srcDir 'src/main/libs'
-
-        jniLibs {
-            srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
-        }
     }
 
     packagingOptions {


### PR DESCRIPTION
Removes a bunch of libVk shared libraries from release builds.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>