### PR TITLE
Fix for view's anti-aliasing issue

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/scene_objects/GVRViewSceneObject.java
@@ -281,49 +281,54 @@ public class GVRViewSceneObject extends GVRSceneObject {
         }
     }
 
+    /**
+     * @return The instance of inflated view
+     */
     public View getView() {
         return mView;
     }
 
+    /**
+     * @see {@link View#postInvalidate()}
+     */
     public void invalidate() {
-        if (mRootViewGroup != null)
-            mRootViewGroup.postInvalidate();
+        mRootViewGroup.postInvalidate();
     }
 
+    /**
+     * @see {@link View#findFocus()}
+     */
     public View findFocus() {
-        if (mRootViewGroup != null) {
-            return mRootViewGroup.findFocus();
-        }
-
-        return null;
+        return mRootViewGroup.findFocus();
     }
 
+    /**
+     * Set the focused child view by its id
+     * @param id id of child view
+     */
     public void setFocusedView(int id) {
-        if (mRootViewGroup != null) {
-            mRootViewGroup.setCurrentFocusedView( mRootViewGroup.findViewById(id));
-        }
+        mRootViewGroup.setCurrentFocusedView(mRootViewGroup.findViewById(id));
     }
 
+    /**
+     * @see {@link View#requestFocus()}
+     */
     public void setFocusedView(View view) {
-        if (mRootViewGroup != null) {
-            mRootViewGroup.setCurrentFocusedView(view);
-        }
+        mRootViewGroup.setCurrentFocusedView(view);
     }
 
+    /**
+     * @see {@link View#findViewById(int)}
+     */
     public View findViewById(int id) {
-        if (mRootViewGroup != null) {
-            return mRootViewGroup.findViewById(id);
-        }
-
-        return null;
+        return mRootViewGroup.findViewById(id);
     }
 
+    /**
+     * @see {@link View#findViewWithTag(Object)}
+     */
     public View findViewWithTag(Object tag) {
-        if (mRootViewGroup != null) {
-            return mRootViewGroup.findViewWithTag(tag);
-        }
-
-        return null;
+        return mRootViewGroup.findViewWithTag(tag);
     }
 
     /**

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/shaders/GVROESConvolutionShader.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/shaders/GVROESConvolutionShader.java
@@ -1,0 +1,60 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gearvrf.shaders;
+
+import android.content.Context;
+
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRShaderData;
+import org.gearvrf.GVRShaderTemplate;
+import org.gearvrf.R;
+import org.gearvrf.utility.TextFile;
+
+/**
+ * Shader which samples from an external texture.
+ * This shader does not use light sources.
+ * Fix anti-aliasing for eos texture
+ * @<code>
+ *    a_position    position vertex attribute
+ *    a_texcoord    texture coordinate vertex attribute
+ *    u_color       color to modulate texture
+ *    u_opacity     opacity
+ *    u_texture     external texture
+ *    texelWidth    1.0f / image with
+ *    texelHeight   1.0f / image height
+ * </code>
+ */
+public class GVROESConvolutionShader extends GVRShaderTemplate
+{
+    public GVROESConvolutionShader(GVRContext gvrContext)
+    {
+        super("float3 u_color float u_opacity"
+                + " float texelWidth float texelHeight",
+              "samplerExternalOES u_texture",
+              "float3 a_position float2 a_texcoord", GLSLESVersion.VULKAN);
+        Context context = gvrContext.getContext();
+        setSegment("FragmentTemplate", TextFile.readTextFile(context, R.raw.oes_convolution_frag));
+        setSegment("VertexTemplate", TextFile.readTextFile(context, R.raw.oes_convolution_vert));
+    }
+
+    protected void setMaterialDefaults(GVRShaderData material)
+    {
+        material.setVec3("u_color", 1.0f, 1.0f, 1.0f);
+        material.setFloat("u_opacity", 1.0f);
+
+        material.setFloat("texelWidth", 1.0f / 1024.0f);
+        material.setFloat("texelHeight", 1.0f / 1024.0f);
+    }
+}

--- a/GVRf/Framework/framework/src/main/res/raw/oes_convolution_frag.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/oes_convolution_frag.fsh
@@ -1,0 +1,48 @@
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+#extension GL_OES_EGL_image_external : enable
+#extension GL_OES_EGL_image_external_essl3 : enable
+precision highp float;
+uniform samplerExternalOES u_texture;
+
+@MATERIAL_UNIFORMS
+
+out vec4 outColor;
+
+layout ( location = 0 ) in vec2 textureCoordinate;
+layout ( location = 1 ) in vec2 leftTextureCoordinate;
+layout ( location = 2 ) in vec2 rightTextureCoordinate;
+
+layout ( location = 3 ) in vec2 topTextureCoordinate;
+layout ( location = 4 ) in vec2 topLeftTextureCoordinate;
+layout ( location = 5 ) in vec2 topRightTextureCoordinate;
+
+layout ( location = 6 ) in vec2 bottomTextureCoordinate;
+layout ( location = 7 ) in vec2 bottomLeftTextureCoordinate;
+layout ( location = 8 ) in vec2 bottomRightTextureCoordinate;
+
+mediump mat3 matrix = mat3(
+            0.25, 0.5, 0.25,
+            0.5,  1.0, 0.5,
+            0.25, 0.5, 0.25
+        );
+
+void main()
+{
+    mediump vec4 bottomColor = texture(u_texture, bottomTextureCoordinate);
+    mediump vec4 bottomLeftColor = texture(u_texture, bottomLeftTextureCoordinate);
+    mediump vec4 bottomRightColor = texture(u_texture, bottomRightTextureCoordinate);
+    mediump vec4 centerColor = texture(u_texture, textureCoordinate);
+    mediump vec4 leftColor = texture(u_texture, leftTextureCoordinate);
+    mediump vec4 rightColor = texture(u_texture, rightTextureCoordinate);
+    mediump vec4 topColor = texture(u_texture, topTextureCoordinate);
+    mediump vec4 topRightColor = texture(u_texture, topRightTextureCoordinate);
+    mediump vec4 topLeftColor = texture(u_texture, topLeftTextureCoordinate);
+
+    mediump vec4 color = topLeftColor * matrix[0][0] + topColor * matrix[0][1] + topRightColor * matrix[0][2];
+    color += leftColor * matrix[1][0] + centerColor * matrix[1][1] + rightColor * matrix[1][2];
+    color += bottomLeftColor * matrix[2][0] + bottomColor * matrix[2][1] + bottomRightColor * matrix[2][2];
+    color /= 4.0; // 4.0 is the sum of matrix values
+
+    outColor = vec4(color.r * u_color.r * u_opacity, color.g * u_color.g * u_opacity, color.b * u_color.b * u_opacity, color.a * u_opacity);
+}

--- a/GVRf/Framework/framework/src/main/res/raw/oes_convolution_vert.vsh
+++ b/GVRf/Framework/framework/src/main/res/raw/oes_convolution_vert.vsh
@@ -1,0 +1,57 @@
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+
+#ifdef HAS_MULTIVIEW
+#extension GL_OVR_multiview2 : enable
+layout(num_views = 2) in;
+#endif
+
+layout ( location = 0 )in vec3 a_position;
+layout ( location = 1 )in vec2 a_texcoord;
+
+@MATRIX_UNIFORMS
+
+uniform highp float texelWidth;
+uniform highp float texelHeight;
+
+layout ( location = 0 ) out vec2 textureCoordinate;
+layout ( location = 1 ) out vec2 leftTextureCoordinate;
+layout ( location = 2 ) out vec2 rightTextureCoordinate;
+
+layout ( location = 3 ) out vec2 topTextureCoordinate;
+layout ( location = 4 ) out vec2 topLeftTextureCoordinate;
+layout ( location = 5 ) out vec2 topRightTextureCoordinate;
+
+layout ( location = 6 ) out vec2 bottomTextureCoordinate;
+layout ( location = 7 ) out vec2 bottomLeftTextureCoordinate;
+layout ( location = 8 ) out vec2 bottomRightTextureCoordinate;
+
+void main()
+{
+ #ifdef HAS_MULTIVIEW
+     bool render_mask = (u_render_mask & (gl_ViewID_OVR + uint(1))) > uint(0) ? true : false;
+     mat4 mvp = u_mvp_[gl_ViewID_OVR];
+     if(!render_mask)
+         mvp = mat4(0.0);  //  if render_mask is not set for particular eye, dont render that object
+     gl_Position = mvp  * vec4(a_position, 1);
+ #else
+ 	gl_Position = u_mvp * vec4(a_position, 1);
+ #endif
+
+     vec2 widthStep = vec2(texelWidth, 0.0);
+     vec2 heightStep = vec2(0.0, texelHeight);
+     vec2 widthHeightStep = vec2(texelWidth, texelHeight);
+     vec2 widthNegativeHeightStep = vec2(texelWidth, -texelHeight);
+
+     textureCoordinate = a_texcoord.xy;
+     leftTextureCoordinate = a_texcoord.xy - widthStep;
+     rightTextureCoordinate = a_texcoord.xy + widthStep;
+
+     topTextureCoordinate = a_texcoord.xy - heightStep;
+     topLeftTextureCoordinate = a_texcoord.xy - widthHeightStep;
+     topRightTextureCoordinate = a_texcoord.xy + widthNegativeHeightStep;
+
+     bottomTextureCoordinate = a_texcoord.xy + heightStep;
+     bottomLeftTextureCoordinate = a_texcoord.xy - widthNegativeHeightStep;
+     bottomRightTextureCoordinate = a_texcoord.xy + widthHeightStep;
+}


### PR DESCRIPTION
Anti-aliasing issue at form of gvr-keyboardview demo should be fixed.

GVRKeyboardS.O. will be fixed by other PR.

Use GVRViewSceneObject#setTextureBufferSize(int size) to ajust according to your application
layout to fix the anti-aliasing issue. The default buffer size should cover almost all issues.

`GearVRf-DCO-1.0-Signed-off-by: Ragner Magalhaes <ragner.n@samsung.com>`