### PR TITLE
X3D: Fixed errors with mesh having normals; new cursor setting.

### DIFF
--- a/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/X3Dobject.java
+++ b/GVRf/Extensions/x3d/src/main/java/org/gearvrf/x3d/X3Dobject.java
@@ -555,7 +555,7 @@ public class X3Dobject {
             {
                 descriptor += " float2 a_texcoord";
             }
-            if (mUseNormals && hasNormals)
+            if (mUseNormals)
             {
                 descriptor += " float3 a_normal";
             }
@@ -4369,6 +4369,7 @@ public class X3Dobject {
                         if(controller.getControllerType() == GVRControllerType.GAZE);
                         {
                             gazeController = controller;
+                            gazeController.setCursorControl(GVRCursorController.CursorControl.PROJECT_CURSOR_ON_SURFACE);
                             break;
                         }
                     }


### PR DESCRIPTION
Corrected two issues: Mesh with no normals (see demo below); and set the gaze cursor from default to be on surface.

[NoNormalsDemo.zip](https://github.com/Samsung/GearVRf/files/2177992/NoNormalsDemo.zip)

GearVRf-DCO-1.0-Signed-off-by: 
Mitch Williams <m1.williams@partner.samsung.com>