### PR TITLE
Dirty flag of lights not cleared at all

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/lightlist.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/lightlist.cpp
@@ -228,6 +228,7 @@ ShadowMap* LightList::updateLightBlock(Renderer* renderer)
             LOGD("LIGHT: clearing light uniform block");
 #endif
         }
+        mDirty = 0;
         return NULL;
     }
     for (auto it1 = mClassMap.begin();


### PR DESCRIPTION
LIGHT_REMOVED flag when set is never cleared. Causes render data to be dirty every time. 
Issue found by gvr-cubemap demo which clears the scene which sets  LIGHT_REMOVED flag and never cleared.

GearVRf DCO signed off by: Abhijit Jagdale a.jagdale@samsung.com