### PR TITLE
framework: silence unnecessary exception that occurs for every app not using the scripting extension

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -820,7 +820,6 @@ abstract class GVRViewManager extends GVRContext {
             mScriptManager = (IScriptManager)cls.getConstructor(GVRContext.class).newInstance(this);
         }
         catch (Exception e) {
-            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION


GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>