### PR TITLE
Fix for compressed textures not being shown if loaded again and again

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.cpp
@@ -129,7 +129,6 @@ void BitmapImage::clearData(JNIEnv* env)
         env->DeleteGlobalRef(mBitmap);
         mBitmap = NULL;
     }
-    mIsCompressed = false;
 }
 
 bool BitmapImage::hasAlpha(int format) {


### PR DESCRIPTION
Addresses the compressed texture issue from https://github.com/Samsung/GearVRf/issues/1944.

clearData used to reset the mIsCompressed flag but that prevents GLBitmapImage::updateTexParams from adjusting the min filter.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>