### PR TITLE
Bug fix in GVRScene.removeAllSceneObjects

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -160,16 +160,16 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
         final GVRCameraRig rig = getMainCameraRig();
         final GVRSceneObject head = rig.getOwnerObject();
         rig.removeAllChildren();
-        final GVRSceneObject oldRoot = mSceneRoot;
 
         NativeScene.removeAllSceneObjects(getNative());
+        for (final GVRSceneObject child : mSceneRoot.getChildren()) {
+            child.detachAllComponents();
+            child.getParent().removeChildObject(child);
+        }
 
-        mSceneRoot = new GVRSceneObject(getGVRContext());
         if (null != head) {
-            head.getParent().removeChildObject(head);
             mSceneRoot.addChildObject(head);
         }
-        NativeScene.addSceneObject(getNative(), mSceneRoot.getNative());
 
         final int numControllers = getGVRContext().getInputManager().clear();
         if (numControllers > 0)
@@ -180,12 +180,6 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
         getGVRContext().runOnGlThread(new Runnable() {
             @Override
             public void run() {
-                //to prevent components from being deleted concurrently
-                for (final GVRSceneObject child : oldRoot.getChildren()) {
-                    child.detachAllComponents();
-                    child.getParent().removeChildObject(child);
-                }
-
                 NativeScene.deleteLightsAndDepthTextureOnRenderThread(getNative());
             }
         });
@@ -636,8 +630,6 @@ class NativeScene {
 
     static native void setJava(long scene, GVRScene javaScene);
 
-    static native void addSceneObject(long scene, long sceneObject);
-   
     static native void removeAllSceneObjects(long scene);
 
     static native void deleteLightsAndDepthTextureOnRenderThread(long scene);
@@ -655,10 +647,6 @@ class NativeScene {
     public static native int getNumberTriangles(long scene);
 
     public static native void exportToFile(long scene, String file_path);
-
-    static native boolean addLight(long scene, long light);
-
-    static native void clearLights(long scene);
 
     static native GVRLight[] getLightList(long scene);
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -156,14 +156,16 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
     /**
      * Remove all scene objects.
      */
-    public void removeAllSceneObjects() {
+    public synchronized void removeAllSceneObjects() {
         final GVRCameraRig rig = getMainCameraRig();
         final GVRSceneObject head = rig.getOwnerObject();
         rig.removeAllChildren();
 
         NativeScene.removeAllSceneObjects(getNative());
         for (final GVRSceneObject child : mSceneRoot.getChildren()) {
-            child.detachAllComponents();
+            if (child != head) {
+                child.detachAllComponents();
+            }
             child.getParent().removeChildObject(child);
         }
 
@@ -223,7 +225,7 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
      * @return The {@link GVRCameraRig camera rig} used for rendering the scene
      *         on the screen.
      */
-    public GVRCameraRig getMainCameraRig() {
+    public synchronized GVRCameraRig getMainCameraRig() {
         return mMainCameraRig;
     }
 
@@ -234,7 +236,7 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
      * @param cameraRig
      *            The {@link GVRCameraRig camera rig} to render with.
      */
-    public void setMainCameraRig(GVRCameraRig cameraRig) {
+    public synchronized void setMainCameraRig(GVRCameraRig cameraRig) {
         mMainCameraRig = cameraRig;
         NativeScene.setMainCameraRig(getNative(), cameraRig.getNative());
 
@@ -523,7 +525,7 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
      * know you don't want the corresponding glClear call then you can use these
      * special values to skip it.
      */
-    public final void setBackgroundColor(float r, float g, float b, float a) {
+    public synchronized final void setBackgroundColor(float r, float g, float b, float a) {
         mMainCameraRig.getLeftCamera().setBackgroundColor(r, g, b, a);
         mMainCameraRig.getRightCamera().setBackgroundColor(r, g, b, a);
         mMainCameraRig.getCenterCamera().setBackgroundColor(r, g, b, a);

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -163,9 +163,6 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
 
         NativeScene.removeAllSceneObjects(getNative());
         for (final GVRSceneObject child : mSceneRoot.getChildren()) {
-            if (child != head) {
-                child.detachAllComponents();
-            }
             child.getParent().removeChildObject(child);
         }
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRSceneObject.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRSceneObject.java
@@ -59,7 +59,7 @@ import org.joml.Vector3f;
  * </pre>
  */
 public class GVRSceneObject extends GVRHybridObject implements PrettyPrint, IScriptable, IEventReceiver {
-    private Map<Long, GVRComponent> mComponents = new HashMap<Long, GVRComponent>();
+    private final Map<Long, GVRComponent> mComponents = new HashMap<Long, GVRComponent>();
     private GVRSceneObject mParent;
     private Object mTag;
     private final List<GVRSceneObject> mChildren = new CopyOnWriteArrayList<GVRSceneObject>();

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRViewManager.java
@@ -464,6 +464,11 @@ abstract class GVRViewManager extends GVRContext {
                     }
                 }
             });
+
+            if (null != mControllerReader) {
+                mControllerReader.updatePosData();
+            }
+            getInputManager().updateGearControllers();
         }
 
         @Override
@@ -510,10 +515,6 @@ abstract class GVRViewManager extends GVRContext {
     protected void beforeDrawEyes() {
         GVRNotifications.notifyBeforeStep();
         mFrameHandler.beforeDrawEyes();
-        if (null != mControllerReader) {
-            mControllerReader.updatePosData();
-        }
-        getInputManager().updateGearControllers();
         makeShadowMaps(mMainScene.getNative(), getMainScene(), mRenderBundle.getShaderManager().getNative(),
                        mRenderBundle.getPostEffectRenderTextureA().getWidth(), mRenderBundle.getPostEffectRenderTextureA().getHeight());
     }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRGearCursorController.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/io/GVRGearCursorController.java
@@ -171,7 +171,7 @@ public final class GVRGearCursorController extends GVRCursorController
 
     private GVRSceneObject mControllerModel;
     private GVRSceneObject mRayModel;
-    private GVRSceneObject mPivotRoot;
+    private final GVRSceneObject mPivotRoot;
     private GVRSceneObject mControllerGroup;
     private ControllerReader mControllerReader;
     private boolean mShowControllerModel = false;
@@ -375,8 +375,7 @@ public final class GVRGearCursorController extends GVRCursorController
         }
         catch (IOException ex)
         {
-            Log.e("GearCursorController",
-                  "ERROR: cannot load controller model gear_vr_controller.obj");
+            Log.e(TAG, "cannot load controller model gear_vr_controller.obj");
             return;
         }
         mControllerGroup.addChildObject(mControllerModel);
@@ -386,17 +385,17 @@ public final class GVRGearCursorController extends GVRCursorController
     @Override
     public void setScene(GVRScene scene)
     {
-        GVRSceneObject parent = mPivotRoot.getParent();
+        synchronized (mPivotRoot) {
+            GVRSceneObject parent = mPivotRoot.getParent();
 
-        mPicker.setScene(scene);
-        this.scene = scene;
-        if (parent != null)
-        {
-            parent.removeChildObject(mPivotRoot);
-        }
-        if (scene != null)
-        {
-            scene.addSceneObject(mPivotRoot);
+            mPicker.setScene(scene);
+            this.scene = scene;
+            if (parent != null) {
+                parent.removeChildObject(mPivotRoot);
+            }
+            if (scene != null) {
+                scene.addSceneObject(mPivotRoot);
+            }
         }
         showControllerModel(mShowControllerModel);
     }
@@ -541,7 +540,9 @@ public final class GVRGearCursorController extends GVRCursorController
         mTempRotation.mul(q);
         mTempPivotMtx.rotation(mTempRotation);  // translate pivot by combined event and camera translation
         mTempPivotMtx.setTranslation(x, y, z);
-        mPivotRoot.getTransform().setModelMatrix(mTempPivotMtx);
+        synchronized (mPivotRoot) {
+            mPivotRoot.getTransform().setModelMatrix(mTempPivotMtx);
+        }
         setOrigin(x, y, z);
 
         int handleResult = handleEnterButton(key, event.pointF, event.touched);
@@ -663,7 +664,7 @@ public final class GVRGearCursorController extends GVRCursorController
                                                          0, MotionEvent.BUTTON_SECONDARY, 1f, 1f, 0,
                                                          0, InputDevice.SOURCE_TOUCHPAD, 0);
             setMotionEvent(motionEvent);
-            Log.d("EVENT:", "handleAButton action=%d button=%d x=%f y=%f",
+            Log.d(TAG, "handleAButton action=%d button=%d x=%f y=%f",
                   motionEvent.getAction(), motionEvent.getButtonState(), motionEvent.getX(),
                   motionEvent.getY());
         }
@@ -682,7 +683,7 @@ public final class GVRGearCursorController extends GVRCursorController
             {
                 setActive(true);
             }
-            Log.d("EVENT:", "handleAButton action=%d button=%d x=%f y=%f",
+            Log.d(TAG, "handleAButton action=%d button=%d x=%f y=%f",
                   motionEvent.getAction(), motionEvent.getButtonState(), motionEvent.getX(),
                   motionEvent.getY());
         }
@@ -693,7 +694,7 @@ public final class GVRGearCursorController extends GVRCursorController
     {
         if ((key & button.getNumVal()) != 0)
         {
-            Log.d("EVENT:", "keyPress button=%d code=%d", button.getNumVal(), keyCode);
+            Log.d(TAG, "keyPress button=%d code=%d", button.getNumVal(), keyCode);
             if (prevButton != KeyEvent.ACTION_DOWN)
             {
                 KeyEvent keyEvent = new KeyEvent(KeyEvent.ACTION_DOWN, keyCode);
@@ -814,4 +815,6 @@ public final class GVRGearCursorController extends GVRCursorController
             }
         }
     }
+
+    private static final String TAG = "GearCursorController";
 }

--- a/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
@@ -153,9 +153,7 @@ void Scene::removeCollider(Collider* collider) {
  * Called when the main scene is first presented for render.
  */
 void Scene::set_main_scene(Scene* scene) {
-    LOGI("scene.cpp: scene %p", scene);
     main_scene_ = scene;
-    LOGI("scene.cpp: root %p", scene->getRoot());
     scene->getRoot()->onAddedToScene(scene);
 }
 
@@ -186,7 +184,6 @@ void Scene::clearLights()
 }
 
 void Scene::setSceneRoot(SceneObject* sceneRoot) {
-    LOGI("scene.cpp: scene %p sceneRoot %p", this, sceneRoot);
     scene_root_ = sceneRoot;
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene.cpp
@@ -153,7 +153,9 @@ void Scene::removeCollider(Collider* collider) {
  * Called when the main scene is first presented for render.
  */
 void Scene::set_main_scene(Scene* scene) {
+    LOGI("scene.cpp: scene %p", scene);
     main_scene_ = scene;
+    LOGI("scene.cpp: root %p", scene->getRoot());
     scene->getRoot()->onAddedToScene(scene);
 }
 
@@ -184,6 +186,7 @@ void Scene::clearLights()
 }
 
 void Scene::setSceneRoot(SceneObject* sceneRoot) {
+    LOGI("scene.cpp: scene %p sceneRoot %p", this, sceneRoot);
     scene_root_ = sceneRoot;
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/scene_jni.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/scene_jni.cpp
@@ -30,10 +30,6 @@ extern "C" {
     Java_org_gearvrf_NativeScene_setJava(JNIEnv *env, jclass, jlong nativeScene, jobject javaScene);
 
     JNIEXPORT void JNICALL
-    Java_org_gearvrf_NativeScene_addSceneObject(JNIEnv * env,
-            jobject obj, jlong jscene, jlong jscene_object);
-
-    JNIEXPORT void JNICALL
     Java_org_gearvrf_NativeScene_removeSceneObject(JNIEnv * env,
             jobject obj, jlong jscene, jlong jscene_object);
 
@@ -69,14 +65,6 @@ extern "C" {
     JNIEXPORT int JNICALL
     Java_org_gearvrf_NativeScene_getNumberTriangles(JNIEnv * env,
             jobject obj, jlong jscene);
-
-    JNIEXPORT jboolean JNICALL
-    Java_org_gearvrf_NativeScene_addLight(
-            JNIEnv * env, jobject obj, jlong jscene, jlong light);
-
-    JNIEXPORT void JNICALL
-    Java_org_gearvrf_NativeScene_clearLights(
-            JNIEnv * env, jobject obj, jlong jscene);
 
     JNIEXPORT jobjectArray JNICALL
     Java_org_gearvrf_NativeScene_getLightList(JNIEnv* env, jobject obj, jlong scene);
@@ -115,14 +103,6 @@ Java_org_gearvrf_NativeScene_setJava(JNIEnv *env, jclass, jlong nativeScene, job
     env->GetJavaVM(&jvm);
     Scene* scene = reinterpret_cast<Scene*>(nativeScene);
     scene->set_java(jvm, javaScene);
-}
-
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeScene_addSceneObject(JNIEnv * env,
-        jobject obj, jlong jscene, jlong jscene_object) {
-    Scene* scene = reinterpret_cast<Scene*>(jscene);
-    SceneObject* scene_object = reinterpret_cast<SceneObject*>(jscene_object);
-    scene->addSceneObject(scene_object);
 }
 
 JNIEXPORT void JNICALL
@@ -201,25 +181,6 @@ Java_org_gearvrf_NativeScene_exportToFile(JNIEnv * env,
     scene->exportToFile(std::string(native_filepath));
 
     env->ReleaseStringUTFChars(filepath, native_filepath);
-}
-
-
-JNIEXPORT jboolean JNICALL
-Java_org_gearvrf_NativeScene_addLight(JNIEnv * env,
-        jobject obj, jlong jscene, jlong jlight) {
-    Scene* scene = reinterpret_cast<Scene*>(jscene);
-    if (jlight != 0) {
-        Light* light = reinterpret_cast<Light*>(jlight);
-        return scene->addLight(light);
-    }
-    return false;
-}
-
-JNIEXPORT void JNICALL
-Java_org_gearvrf_NativeScene_clearLights(JNIEnv * env,
-        jobject obj, jlong jscene) {
-    Scene* scene = reinterpret_cast<Scene*>(jscene);
-    scene->clearLights();
 }
 
 JNIEXPORT jobjectArray JNICALL


### PR DESCRIPTION
Fixes issue #1962 

- Improve thread-safety when accessing the main camera rig in GVRScene
- Remove the detachAllComponents for all children when removeAllSceneObjects is called; it is a problem if you intend to add some of the removed children again - the scene objects would be broken due to the missing components
- Some thread-safety improvements in GVRGearCursorController whenever the scene changes

Ultimately the major problem was the detachAllComponents in removeAllSceneObjects. Has been verified as fixing #1962.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>