### PR TITLE
Fix animation finish callback being called every iteration

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/GVRAnimation.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/animation/GVRAnimation.java
@@ -340,9 +340,6 @@ public abstract class GVRAnimation {
         if (cycled && mRepeatMode != GVRRepeatMode.ONCE) {
             // End of a cycle - see if we should continue
             mIterations += 1;
-            if (mOnFinish != null && mOnRepeat == null) {
-                mOnFinish.finished(this);
-            }
             if (mRepeatCount == 0) {
                 stillRunning = false; // last pass
             } else if (mRepeatCount > 0) {


### PR DESCRIPTION
Small fix on animation callback. The method finished of GVROnFinish is called only after the last iteration of an animation.

GearVRf-DCO-1.0-Signed-off-by: Diego Azulay <diego.a@samsung.com>