### PR TITLE
Clean up log messages in bitmap images

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/gl/gl_bitmap_image.cpp
@@ -92,13 +92,11 @@ void GLBitmapImage::update(int texid)
     {
         updateFromBitmap(texid);
         clearData(getCurrentEnv(mJava));
-        LOGV("Texture: GLBitmapImage::update(%d, bitmap)", texid);
     }
     else if (mData != NULL)
     {
         updateFromMemory(texid);
         clearData(getCurrentEnv(mJava));
-        LOGV("Texture: GLBitmapImage::update(%d, byteArray)", texid);
     }
 }
 

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/bitmap_image.cpp
@@ -47,7 +47,6 @@ void BitmapImage::update(JNIEnv* env, int width, int height, jbyteArray data)
     {
         mData = static_cast<jbyteArray>(env->NewGlobalRef(data));
         signalUpdate();
-        LOGV("Texture: BitmapImage::update(byteArray)");
     }
 }
 
@@ -61,12 +60,11 @@ void BitmapImage::update(JNIEnv* env, jobject bitmap, bool hasAlpha, int format)
         mBitmap = static_cast<jbyteArray>(env->NewGlobalRef(bitmap));
         mFormat = format;
         mIsBuffer = false;
-        LOGV("Texture: BitmapImage::update(bitmap)");
         if( hasAlpha ) {
             if(bitmap_has_transparency(env, bitmap)) {
                 set_transparency(true);
             } else {
-                // TODO: warning: bitmap has an alpha channel with no translucent/transparent pixels.
+                LOGW("BitmapImage: bitmap has an alpha channel with no translucent/transparent pixels.");
             }
         }
         signalUpdate();
@@ -88,7 +86,6 @@ void BitmapImage::update(JNIEnv* env, int xoffset, int yoffset, int width, int h
         mType = type;
         mBitmap = env->NewGlobalRef(buffer);
         mIsBuffer = true;
-        LOGV("Texture: BitmapImage::update(buffer)");
         signalUpdate();
     }
 }
@@ -109,7 +106,6 @@ void BitmapImage::update(JNIEnv *env, int width, int height, int imageSize,
     {
         mData = static_cast<jbyteArray>(env->NewGlobalRef(data));
         mPixels = env->GetByteArrayElements(mData, 0);
-        LOGV("Texture: BitmapImage::update(byteArray, offsets)");
         set_transparency(hasAlpha(mFormat));
         env->ReleaseByteArrayElements(mData, mPixels, 0);
         mPixels = NULL;

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/cubemap_image.cpp
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/cubemap_image.cpp
@@ -35,7 +35,6 @@ namespace gvr {
         clearData(env);
         mBitmaps = env->NewGlobalRef(bitmapArray);
         signalUpdate();
-        LOGV("Texture: CubemapImage::update(bitmapArray)");
     }
 
     void CubemapImage::update(JNIEnv* env, int width, int height, int imageSize,
@@ -51,7 +50,6 @@ namespace gvr {
         clearData(env);
         mTextures = env->NewGlobalRef(textureArray);
         signalUpdate();
-        LOGV("Texture: CubemapImage::update(textureArray)");
     }
 
     CubemapImage::~CubemapImage()

--- a/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
+++ b/GVRf/Framework/framework/src/main/jni/objects/textures/image.h
@@ -132,14 +132,12 @@ protected:
     void signalUpdate()
     {
         mState = UPDATE_PENDING;
-        LOGD("Texture: UPDATE_PENDING %s", getFileName());
     }
 
     bool updatePending() const { return mState == UPDATE_PENDING; }
     void updateComplete()
     {
         mState = HAS_DATA;
-        LOGD("Texture: UPDATE_COMPLETE %s", getFileName());
     }
     virtual void update(int texid) { }
 


### PR DESCRIPTION
Remove LOGD and LOGV that could fire up on every frame during normal operations.
Fix a TODO: add a genuine LOGW

bitmap has an alpha channel with no translucent/transparent pixels.