### PR TITLE
Cleans up controllers in onPause()

### DIFF
--- a/GVRf/Extensions/widgetLib/src/org/gearvrf/widgetlib/main/WidgetLib.java
+++ b/GVRf/Extensions/widgetLib/src/org/gearvrf/widgetlib/main/WidgetLib.java
@@ -55,11 +55,17 @@ public class WidgetLib {
         return mInstance.get();
     }
 
+
+    public static void pause() {
+        if (mInstance != null) {
+            getTouchManager().onPause();
+        }
+    }
+
     public static void destroy() {
         if (mInstance != null) {
             getFocusManager().clear();
             getMainThread().quit();
-            getTouchManager().clear();
         }
         mInstance = null;
     }

--- a/GVRf/Extensions/widgetLib/src/org/gearvrf/widgetlib/widget/TouchManager.java
+++ b/GVRf/Extensions/widgetLib/src/org/gearvrf/widgetlib/widget/TouchManager.java
@@ -57,7 +57,8 @@ public class TouchManager {
         gvrContext.getInputManager().selectController(mPickHandler);
     }
 
-    public void clear() {
+    public void onPause() {
+        Log.d(Log.SUBSYSTEM.INPUT, TAG, "onPause(): clearing controllers");
         mGVRContext.getInputManager().clear();
     }
 


### PR DESCRIPTION
Instead of cleaning up the controllers in response to onDestroy(),
clean them up in response to onPause().  If onDestroy() doesn't get
called for some reason, skipping the clean up seems to cause
intermittent issues for subsequent apps; onPause() is, in some
circumstances, a more reliable place to do this.