### PR TITLE
Ensure event emulation is off when the controller is connected

### DIFF
--- a/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrControllerReader.java
+++ b/GVRf/Framework/backend_oculus/src/main/java/org/gearvrf/OvrControllerReader.java
@@ -72,7 +72,7 @@ final class OvrControllerReader extends GVRGearCursorController.ControllerReader
 
         @Override
         public void dispatchKeyEvent(final KeyEvent event) {
-            if (KeyEvent.KEYCODE_BACK == event.getKeyCode() && KeyEvent.ACTION_DOWN == event.getAction()) {
+            if (KeyEvent.KEYCODE_BACK == event.getKeyCode()) {
                 mApplication.getActivity().dispatchKeyEvent(event);
             }
         }

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -380,6 +380,9 @@ void GVRActivity::onDrawFrame(jobject jViewManager) {
                 frameBuffer_[eye].destroy();
             }
 
+            if (nullptr != gearController) {
+                gearController->reset();
+            }
             vrapi_LeaveVrMode(oculusMobile_);
             oculusMobile_ = nullptr;
         } else {

--- a/GVRf/Framework/backend_oculus/src/main/jni/ovr_gear_controller.h
+++ b/GVRf/Framework/backend_oculus/src/main/jni/ovr_gear_controller.h
@@ -18,41 +18,37 @@
 #define FRAMEWORK_OVR_GEAR_CONTROLLER_H
 
 #include "VrApi_Input.h"
-#include "glm/glm.hpp"
-#include "glm/gtx/quaternion.hpp"
-#include "util/gvr_log.h"
 
 namespace gvr {
     class GearController {
 
     private:
-        ovrDeviceID RemoteDeviceID;
-        ovrMobile *ovrMobile_;
-        float *orientationTrackingReadbackBuffer;
+        ovrDeviceID mRemoteDeviceId = ovrDeviceIdType_Invalid;
+        ovrMobile *mOvrMobile;
+        float *mOrientationTrackingReadbackBuffer;
         static const int CONNECTED = 1;
         static const int DISCONNECTED = 0;
 
     public :
 
         GearController(float *orientationTrackingReadbackBuffer) {
-            this->orientationTrackingReadbackBuffer = orientationTrackingReadbackBuffer;
+            this->mOrientationTrackingReadbackBuffer = orientationTrackingReadbackBuffer;
         }
 
 
         void setOvrMobile(ovrMobile *ovrMobile) {
-            this->ovrMobile_ = ovrMobile;
+            this->mOvrMobile = ovrMobile;
         }
 
         bool findConnectedGearController();
 
         void onControllerConnected(ovrDeviceID const deviceID);
 
-        void onControllerDisconnected(ovrDeviceID const disconnectedDeviceID);
-
         void onFrame(double predictedDisplayTime);
 
         int handedness;
 
+        void reset();
     };
 }
 #endif //FRAMEWORK_OVR_GEAR_CONTROLLER_H


### PR DESCRIPTION
Remap the Oculus GO controller trigger key to Button_Enter

Backported from: https://github.com/sxrsdk/sxrsdk/pull/91
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>